### PR TITLE
ci: add github actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# Everything goes through Anca and Romain
+*       @ancazamfir @romac

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report 
+about: Create a report to help us squash bugs!
+
+---
+
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
+v                            ✰  Thanks for opening an issue! ✰    
+v    Before smashing the submit button please review the template.
+v    Please also ensure that this is not a duplicate issue :)  
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+
+<!--
+IMPORTANT: Prior to opening a bug report, check if it affects one of the core modules
+and if its elegible for a bug bounty on `SECURITY.md`. Bugs that are not submitted
+through the appropriate channels won't receive any bounty.
+ -->
+
+## Summary of Bug
+
+<!-- Concisely describe the issue -->
+
+## Version
+
+<!-- git commit hash or release version -->
+
+## Steps to Reproduce
+
+<!-- What commands in order should someone run to reproduce your problem? -->
+
+____
+
+## For Admin Use
+
+- [ ] Not duplicate issue
+- [ ] Appropriate labels applied
+- [ ] Appropriate contributors tagged
+- [ ] Contributor assigned/self-assigned

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Create a proposal to request a feature
+
+---
+
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
+v                            ✰  Thanks for opening an issue! ✰    
+v    Before smashing the submit button please review the template.
+v    Word of caution: poorly thought-out proposals may be rejected 
+v                     without deliberation 
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+
+## Summary
+
+<!-- Short, concise description of the proposed feature -->
+
+## Problem Definition
+
+<!-- Why do we need this feature? 
+What problems may be addressed by introducing this feature?
+What benefits does IBC-rs stand to gain by including this feature?
+Are there any disadvantages of including this feature? -->
+
+## Proposal
+
+<!-- Detailed description of requirements of implementation -->
+
+____
+
+#### For Admin Use
+
+- [ ] Not duplicate issue
+- [ ] Appropriate labels applied
+- [ ] Appropriate contributors tagged
+- [ ] Contributor assigned/self-assigned

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
+v                               ✰  Thanks for creating a PR! ✰    
+v    Before smashing the submit button please review the checkboxes.
+v    If a checkbox is n/a - please still include it but + a little note why
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+
+Closes: #XXX
+
+## Description
+
+<!-- Add a description of the changes that this PR introduces and the files that
+are the most critical to review.
+-->
+
+
+______
+
+For contributor use:
+
+- [ ] Wrote tests
+- [ ] Updated CHANGELOG_PENDING.md
+- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
+- [ ] Updated relevant documentation (`docs/`) and code comments
+- [ ] Re-reviewed `Files changed` in the Github PR explorer

--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,0 +1,6 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+output-type: lcov
+output-file: ./lcov.info
+prefix-dir: /home/user/build/

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,4 +1,4 @@
-name: Rust
+name: Audit Check
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,8 +1,5 @@
-on:
-  pull_request:
-    paths:
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
+name: Rust
+on: [pull_request]
 
 jobs:
   security_audit:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,13 @@
 name: Rust
 on: [pull_request]
 jobs:
+    cleanup-runs:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
   fmt:
     runs-on: ubuntu-latest
     steps:
@@ -13,7 +20,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-          
+
   clippy_check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,73 @@
+name: Rust
+on: [pull_request]
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+          
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  test-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all --all-targets
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast
+
+  test-nightly-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clean
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+      - uses: actions-rs/grcov@v0.1
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ${{ steps.coverage.outputs.report }}
+          yml: ./codecov.yml
+          fail_ci_if_error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,13 +8,14 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+    
   fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -27,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           components: clippy
           override: true
       - uses: actions-rs/clippy-check@v1
@@ -41,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,13 +1,13 @@
 name: Rust
 on: [pull_request]
 jobs:
-    cleanup-runs:
-      runs-on: ubuntu-latest
-      steps:
-      - uses: rokroskar/workflow-run-cleanup-action@master
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,8 +6,7 @@ ignore:
 coverage:
   precision: 1
   round: down
-  # we should increase this to 70% ?
-  range: "50...100"
+  range: "70...100"
 
   status:
     project: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  require_ci_to_pass: yes
+
+ignore:
+
+coverage:
+  precision: 1
+  round: down
+  # we should increase this to 70% ?
+  range: "50...100"
+
+  status:
+    project: true
+    patch: true
+    changes: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: yes
+      macro: no


### PR DESCRIPTION
- seperated audit check into its own file but testing, build and linting lives in one file.
#### - someone will need to add the token for codecov for ci to be successful
- added issue (bug & feature) templates along with a PR template

closes #10 
closes #9 


while speaking with zaki a few weeks ago he recommended stable in ci and local nightly, if you'd like nightly in ci let me know its a minor change
Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>