### PR TITLE
Add stub CLI `config validate` command

### DIFF
--- a/relayer/cli/src/commands.rs
+++ b/relayer/cli/src/commands.rs
@@ -2,22 +2,17 @@
 //!
 //! This is where you specify the subcommands of your application.
 //!
-//! The default application comes with two subcommands:
-//!
-//! - `start`: launches the application
-//! - `version`: print application version
-//!
 //! See the `impl Configurable` below for how to specify the path to the
 //! application's configuration file.
 
+mod config;
 mod start;
 mod version;
 
-use self::{start::StartCmd, version::VersionCmd};
+use self::{config::ConfigCmd, start::StartCmd, version::VersionCmd};
+
 use crate::config::Config;
-use abscissa_core::{
-    config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
-};
+use abscissa_core::{Command, Configurable, FrameworkError, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// Cli Configuration Filename
@@ -31,8 +26,12 @@ pub enum CliCmd {
     Help(Help<Self>),
 
     /// The `start` subcommand
-    #[options(help = "start the application")]
+    #[options(help = "start the relayer")]
     Start(StartCmd),
+
+    /// The `config` subcommand
+    #[options(help = "manipulate the relayer configuration")]
+    Config(ConfigCmd),
 
     /// The `version` subcommand
     #[options(help = "display version information")]
@@ -62,7 +61,7 @@ impl Configurable<Config> for CliCmd {
     /// settings from command-line options.
     fn process_config(&self, config: Config) -> Result<Config, FrameworkError> {
         match self {
-            CliCmd::Start(cmd) => cmd.override_config(config),
+            // CliCmd::Start(cmd) => cmd.override_config(config),
             _ => Ok(config),
         }
     }

--- a/relayer/cli/src/commands/config.rs
+++ b/relayer/cli/src/commands/config.rs
@@ -1,0 +1,19 @@
+//! `config` subcommand
+
+use abscissa_core::{Command, Options, Runnable};
+
+mod validate;
+
+/// `config` subcommand
+///
+/// The `Options` proc macro generates an option parser based on the struct
+/// definition, and is defined in the `gumdrop` crate. See their documentation
+/// for a more comprehensive example:
+///
+/// <https://docs.rs/gumdrop/>
+#[derive(Command, Debug, Options, Runnable)]
+pub enum ConfigCmd {
+    /// The `config validate` subcommand
+    #[options(help = "validate the relayer configuration")]
+    Validate(validate::ValidateCmd),
+}

--- a/relayer/cli/src/commands/config/validate.rs
+++ b/relayer/cli/src/commands/config/validate.rs
@@ -1,0 +1,16 @@
+use crate::prelude::*;
+
+use abscissa_core::{Command, Options, Runnable};
+
+#[derive(Command, Debug, Options)]
+pub struct ValidateCmd {}
+
+impl Runnable for ValidateCmd {
+    /// Validate the loaded configuration.
+    fn run(&self) {
+        let config = app_config();
+        status_ok!("Loaded configuration:", "{:#?}", *config);
+
+        // TODO: Validate configuration
+    }
+}

--- a/relayer/cli/src/commands/start.rs
+++ b/relayer/cli/src/commands/start.rs
@@ -1,11 +1,10 @@
-//! `start` subcommand - example of how to write a subcommand
+//! `start` subcommand
 
 /// App-local prelude includes `app_reader()`/`app_writer()`/`app_config()`
 /// accessors along with logging macros. Customize as you see fit.
 use crate::prelude::*;
 
-use crate::config::Config;
-use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 
 /// `start` subcommand
 ///
@@ -15,26 +14,11 @@ use abscissa_core::{config, Command, FrameworkError, Options, Runnable};
 ///
 /// <https://docs.rs/gumdrop/>
 #[derive(Command, Debug, Options)]
-pub struct StartCmd {
-    /// To whom are we saying hello?
-    #[options(free)]
-    recipient: Vec<String>,
-}
+pub struct StartCmd {}
 
 impl Runnable for StartCmd {
     /// Start the application.
     fn run(&self) {
-        let config = app_config();
-        status_ok!("Loaded", "{:#?}", *config);
-    }
-}
-
-impl config::Override<Config> for StartCmd {
-    // Process the given command line options, overriding settings from
-    // a configuration file using explicit flags taken from command-line
-    // arguments.
-    #[allow(unused_mut)]
-    fn override_config(&self, mut config: Config) -> Result<Config, FrameworkError> {
-        Ok(config)
+        status_ok!("{}", "Quitting...");
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6
Depends-on: #20

## Description

Add stub CLI `config validate` command which just prints the loaded configuration.

## Usage

From the `relayer/cli` directory:

```bash
$ cargo run -- -c ../relay/tests/config/fixtures/relayer_conf_example.toml config validate
```

## TODO

- [ ] Add test stub for the command

## Notes

This PR depends on #20. Only the commits after `bda6902` are part of this PR.

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
