### PR TITLE
Run cargo-audit daily or when dependencies have changed

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Cache cargo bin
         uses: actions/cache@v1
         with:

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,11 +1,25 @@
-name: Audit Check
-on: [pull_request]
+name: Security Audit
+on:
+  pull_request:
+    paths: Cargo.lock
+  push:
+    branches: develop
+    paths: Cargo.lock
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   security_audit:
+    name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
+      - name: Cache cargo bin
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-audit-v0.11.2
       - uses: actions-rs/audit-check@v1
         with:
+          args: --ignore RUSTSEC-2019-0031
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes: N/A

## Description

Change the Audit GitHub Action to run daily, and on pushes but only when dependencies have actually changed. This should speed up CI quite a bit as this action takes a considerable amount of time to complete.

The config comes from https://github.com/interchainio/tendermint-rs/pull/144#issuecomment-595322485

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
