### PR TITLE
Extract IBC queries paths into conditional modules

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -15,7 +15,7 @@ default = ["paths-cosmos"]
 paths-cosmos = []
 
 [dependencies]
-tendermint = { git = "https://github.com/romac/tendermint-rs.git", branch = "rpc-client-new-sync" }
+tendermint = { git = "https://github.com/interchainio/tendermint-rs.git" }
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -7,7 +7,12 @@ authors = [
   "Romain Ruetschi <romain@informal.systems>"
 ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+# Default features
+default = ["paths-cosmos"]
+
+# In IBC queries, use paths as defined in the Cosmos-SDK Go implementation, rather than in the ICS.
+paths-cosmos = []
 
 [dependencies]
 tendermint = { git = "https://github.com/romac/tendermint-rs.git", branch = "rpc-client-new-sync" }

--- a/modules/src/path.rs
+++ b/modules/src/path.rs
@@ -3,6 +3,14 @@ use std::fmt;
 use crate::ics24_host::client::ClientId;
 use crate::Height;
 
+mod cosmos;
+mod ics;
+
+#[cfg(feature = "paths-cosmos")]
+use cosmos as paths;
+#[cfg(not(feature = "paths-cosmos"))]
+use ics as paths;
+
 pub struct Key<'a, P>(&'a P);
 
 impl<'a, P> fmt::Display for Key<'a, P>
@@ -37,7 +45,7 @@ pub struct ConnectionPath {
 
 impl Path for ConnectionPath {
     fn to_string(&self) -> String {
-        format!("connection/{}", self.connection_id)
+        paths::connection_path(&self)
     }
 }
 
@@ -54,6 +62,6 @@ impl ConsensusStatePath {
 
 impl Path for ConsensusStatePath {
     fn to_string(&self) -> String {
-        format!("consensusState/{}/{}", self.client_id, self.height)
+        paths::consensus_state_path(&self)
     }
 }

--- a/modules/src/path/cosmos.rs
+++ b/modules/src/path/cosmos.rs
@@ -1,0 +1,9 @@
+use super::{ConnectionPath, ConsensusStatePath};
+
+pub fn connection_path(path: &ConnectionPath) -> String {
+    format!("connection/{}", path.connection_id)
+}
+
+pub fn consensus_state_path(path: &ConsensusStatePath) -> String {
+    format!("consensusState/{}/{}", path.client_id, path.height)
+}

--- a/modules/src/path/ics.rs
+++ b/modules/src/path/ics.rs
@@ -1,0 +1,9 @@
+use super::{ConnectionPath, ConsensusStatePath};
+
+pub fn connection_path(_path: &ConnectionPath) -> String {
+    todo!()
+}
+
+pub fn consensus_state_path(_path: &ConsensusStatePath) -> String {
+    todo!()
+}

--- a/relayer/relay/Cargo.toml
+++ b/relayer/relay/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 
 [dependencies]
 relayer-modules = { path = "../../modules" }
-tendermint = { git = "https://github.com/romac/tendermint-rs.git", branch = "rpc-client-new-sync" }
+tendermint = { git = "https://github.com/interchainio/tendermint-rs.git" }
 
 anomaly = "0.2.0"
 humantime-serde = "1.0.0"


### PR DESCRIPTION
Since these paths currently differ between the Go implementation
and the ICS, we need to be able to switch them up at compile-time
for when we will need to test against the Go implementation.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: N/A

## Description

Since these paths currently differ between the Go implementation
and the ICS, we need to be able to switch them up at compile-time
for when we will need to test against the Go implementation.

______

For contributor use:

- [ ] Wrote tests
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
