### PR TITLE
Add type-safe wrapper around `sled` databases

### DIFF
--- a/relayer/cli/src/commands/light/init.rs
+++ b/relayer/cli/src/commands/light/init.rs
@@ -94,7 +94,7 @@ impl Runnable for InitCmd {
             .unwrap();
 
             let mut store: SledStore<TendermintChain> =
-                relayer::store::persistent(format!("store_{}.db", chain_config.id));
+                relayer::store::persistent(format!("store_{}.db", chain_config.id)).unwrap(); // FIXME: unwrap
 
             store.set_trust_options(trust_options).unwrap(); // FIXME: unwrap
 

--- a/relayer/cli/src/commands/start.rs
+++ b/relayer/cli/src/commands/start.rs
@@ -89,7 +89,7 @@ async fn create_client(
 ) -> Client<TendermintChain, impl Store<TendermintChain>> {
     let chain = TendermintChain::from_config(chain_config).unwrap();
 
-    let store = relayer::store::persistent(format!("store_{}.db", chain.id()));
+    let store = relayer::store::persistent(format!("store_{}.db", chain.id())).unwrap(); //FIXME: unwrap
     let trust_options = store.get_trust_options().unwrap(); // FIXME: unwrap
 
     Client::new(chain, store, trust_options).await.unwrap()

--- a/relayer/relay/src/lib.rs
+++ b/relayer/relay/src/lib.rs
@@ -17,3 +17,4 @@ pub mod config;
 pub mod error;
 pub mod query;
 pub mod store;
+pub mod util;

--- a/relayer/relay/src/store.rs
+++ b/relayer/relay/src/store.rs
@@ -1,8 +1,5 @@
 use std::path::Path;
 
-use serde::{de::DeserializeOwned, Serialize};
-
-use tendermint::lite::types as tmlite;
 use tendermint::lite::{Height, TrustedState};
 
 use crate::chain::Chain;
@@ -16,6 +13,7 @@ pub mod mem;
 pub mod sled;
 
 /// Either the last stored height or a given one
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum StoreHeight {
     /// The last stored height
     Last,
@@ -56,13 +54,7 @@ where
 
 /// Returns a persistent trusted store backed by an on-disk `sled` database
 /// stored in sthe folder specified in the `path` argument.
-///
-/// TODO: Remove this hideous `where` clause, once we enforce in
-/// tendermint-rs that validator sets must be serializable.
-pub fn persistent<C: Chain>(db_path: impl AsRef<Path>) -> sled::SledStore<C>
-where
-    <<C as Chain>::Commit as tmlite::Commit>::ValidatorSet: Serialize + DeserializeOwned,
-{
+pub fn persistent<C: Chain>(db_path: impl AsRef<Path>) -> sled::SledStore<C> {
     sled::SledStore::new(db_path)
 }
 

--- a/relayer/relay/src/store.rs
+++ b/relayer/relay/src/store.rs
@@ -54,7 +54,7 @@ where
 
 /// Returns a persistent trusted store backed by an on-disk `sled` database
 /// stored in sthe folder specified in the `path` argument.
-pub fn persistent<C: Chain>(db_path: impl AsRef<Path>) -> sled::SledStore<C> {
+pub fn persistent<C: Chain>(db_path: impl AsRef<Path>) -> Result<sled::SledStore<C>, error::Error> {
     sled::SledStore::new(db_path)
 }
 

--- a/relayer/relay/src/store/sled.rs
+++ b/relayer/relay/src/store/sled.rs
@@ -25,13 +25,15 @@ pub struct SledStore<C: Chain> {
 }
 
 impl<C: Chain> SledStore<C> {
-    pub fn new(path: impl AsRef<Path>) -> Self {
-        Self {
-            db: sled::open(path).unwrap(), // FIXME: Unwrap
+    pub fn new(path: impl AsRef<Path>) -> Result<Self, error::Error> {
+        let db = sled::open(path).map_err(|e| error::Kind::Store.context(e))?;
+
+        Ok(Self {
+            db,
             last_height_db: sled_util::single("last_height/"),
             trust_options_db: sled_util::single("trust_options/"),
             trusted_state_db: sled_util::key_value("trusted_state/"),
-        }
+        })
     }
 }
 

--- a/relayer/relay/src/util.rs
+++ b/relayer/relay/src/util.rs
@@ -1,0 +1,1 @@
+pub mod sled;

--- a/relayer/relay/src/util/sled.rs
+++ b/relayer/relay/src/util/sled.rs
@@ -1,0 +1,97 @@
+use serde::{de::DeserializeOwned, Serialize};
+use std::marker::PhantomData;
+
+use crate::error;
+
+pub fn single<V>(prefix: impl Into<Vec<u8>>) -> SingleDb<V> {
+    SingleDb::new(prefix)
+}
+
+pub fn key_value<K, V>(prefix: impl Into<Vec<u8>>) -> KeyValueDb<K, V> {
+    KeyValueDb::new(prefix)
+}
+
+pub type SingleDb<V> = KeyValueDb<(), V>;
+
+impl<V> SingleDb<V>
+where
+    V: Serialize + DeserializeOwned,
+{
+    pub fn get(&self, db: &sled::Db) -> Result<Option<V>, error::Error> {
+        self.fetch(&db, &())
+    }
+
+    pub fn set(&self, db: &sled::Db, value: &V) -> Result<(), error::Error> {
+        self.insert(&db, &(), &value)
+    }
+}
+
+pub struct KeyValueDb<K, V> {
+    prefix: Vec<u8>,
+    marker: PhantomData<(K, V)>,
+}
+
+impl<K, V> KeyValueDb<K, V> {
+    pub fn new(prefix: impl Into<Vec<u8>>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<K, V> KeyValueDb<K, V>
+where
+    K: Serialize,
+    V: Serialize + DeserializeOwned,
+{
+    fn prefixed_key(&self, mut key_bytes: Vec<u8>) -> Vec<u8> {
+        let mut prefix_bytes = self.prefix.clone();
+        prefix_bytes.append(&mut key_bytes);
+        prefix_bytes
+    }
+
+    pub fn fetch(&self, db: &sled::Db, key: &K) -> Result<Option<V>, error::Error> {
+        let key_bytes = serde_cbor::to_vec(&key).map_err(|e| error::Kind::Store.context(e))?;
+
+        let prefixed_key_bytes = self.prefixed_key(key_bytes);
+
+        let value_bytes = db
+            .get(prefixed_key_bytes)
+            .map_err(|e| error::Kind::Store.context(e))?;
+
+        match value_bytes {
+            Some(bytes) => {
+                let value =
+                    serde_cbor::from_slice(&bytes).map_err(|e| error::Kind::Store.context(e))?;
+                Ok(value)
+            }
+            None => Ok(None),
+        }
+    }
+
+    // pub fn has(&self, key: &K) -> Result<Option<V>, error::Error> {
+    //     let key_bytes = serde_cbor::to_vec(&key).map_err(|e| error::Kind::Store.context(e))?;
+
+    //     let exists = self
+    //         .db
+    //         .exists(key_bytes)
+    //         .map_err(|e| error::Kind::Store.context(e))?;
+
+    //     Ok(exists)
+    // }
+
+    pub fn insert(&self, db: &sled::Db, key: &K, value: &V) -> Result<(), error::Error> {
+        let key_bytes = serde_cbor::to_vec(&key).map_err(|e| error::Kind::Store.context(e))?;
+
+        let prefixed_key_bytes = self.prefixed_key(key_bytes);
+
+        let value_bytes = serde_cbor::to_vec(&value).map_err(|e| error::Kind::Store.context(e))?;
+
+        db.insert(prefixed_key_bytes, value_bytes)
+            .map(|_| ())
+            .map_err(|e| error::Kind::Store.context(e))?;
+
+        Ok(())
+    }
+}

--- a/relayer/relay/src/util/sled.rs
+++ b/relayer/relay/src/util/sled.rs
@@ -26,6 +26,7 @@ where
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct KeyValueDb<K, V> {
     prefix: Vec<u8>,
     marker: PhantomData<(K, V)>,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #43

## Description

Add type-safe wrapper around `sled::Db` to ease its use, and prevent serialization bugs.

## Details

Add a `KeyValueDb` struct which takes care of (de)serialization via `serde_cbor`, with the following interface:

```rust
impl<K, V> KeyValueDb<K, V>
where
    K: Serialize,
    V: Serialize + DeserializeOwned,
{
    pub fn fetch(&self, db: &sled::Db, key: &K) -> Result<Option<V>, error::Error>;

    pub fn insert(&self, db: &sled::Db, key: &K, value: &V) -> Result<(), error::Error>;
}
```

The given key is concatenated with a prefix given when creating a `KeyValueDb` value.

Additionally, add a type alias and convenience methods for the case where there is only one key (eg. for storing the latest height at some prefix).

```rust
pub type SingleDb<V> = KeyValueDb<(), V>;

impl<V> SingleDb<V>
where
    V: Serialize + DeserializeOwned,
{
    pub fn get(&self, db: &sled::Db) -> Result<Option<V>, error::Error> {
        self.fetch(&db, &())
    }

    pub fn set(&self, db: &sled::Db, value: &V) -> Result<(), error::Error> {
        self.insert(&db, &(), &value)
    }
}
```

______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
