### PR TITLE
Perform bisection when verifying headers using the light client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ configure and spawn two light clients for this chain with the following commands
 4. Start the light clients and a dummy relayer thread:
 
     ```bash
-    ibc-rs $ cargo run --bin relayer -- -c ./relayer/relay/tests/config/fixtures/relayer_conf_example.toml run
+    ibc-rs $ cargo run --bin relayer -- -c ./relayer/relay/tests/config/fixtures/relayer_conf_example.toml start
     ```
 
 **Note:** Add a `-v` flag to the commands above to see detailed log output, eg. `cargo run --bin relayer -- -v -c ./relayer/relay/tests/config/fixtures/relayer_conf_example.toml run`

--- a/relayer/cli/Cargo.toml
+++ b/relayer/cli/Cargo.toml
@@ -12,14 +12,14 @@ relayer = { path = "../relay" }
 relayer-modules = { path = "../../modules" }
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "tendermint/v0.33" }
 
+abscissa_tokio = "0.5.1"
 anomaly = "0.2.0"
 gumdrop = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
-abscissa_tokio = "0.5.1"
-tokio = "0.2.13"
-tracing-subscriber = "0.2.3"
+tokio = { version = "0.2.13", features = ["rt-util"] }
 tracing = "0.1.13"
+tracing-subscriber = "0.2.3"
 
 [dependencies.abscissa_core]
 version = "0.5.2"

--- a/relayer/cli/src/commands/start.rs
+++ b/relayer/cli/src/commands/start.rs
@@ -85,6 +85,8 @@ async fn update_client<C: Chain, S: Store<C>>(mut client: Client<C, S>) {
     let mut interval = tokio::time::interval(Duration::from_secs(3));
 
     loop {
+        interval.tick().await;
+
         info!(chain.id = %client.chain().id(), "updating client");
 
         let result = client.update(SystemTime::now()).await;
@@ -104,8 +106,6 @@ async fn update_client<C: Chain, S: Store<C>>(mut client: Client<C, S>) {
                 error!(chain.id = %client.chain().id(), "error when updating headers: {}", err)
             }
         }
-
-        interval.tick().await;
     }
 }
 

--- a/relayer/cli/src/commands/start.rs
+++ b/relayer/cli/src/commands/start.rs
@@ -27,60 +27,81 @@ impl Runnable for StartCmd {
 
         debug!("launching 'start' command");
 
-        block_on(async {
+        // Spawn all tasks on the same thread that calls `block_on`, ie. the main thread.
+        // This allows us to spawn tasks which do not implement `Send`,
+        // like the light client task.
+        let local = tokio::task::LocalSet::new();
+
+        block_on(local.run_until(async move {
             for chain_config in config.chains {
                 info!(chain.id = %chain_config.id, "spawning light client");
-
-                let _handle = tokio::spawn(async move {
-                    let client = create_client(chain_config).await;
-                    let trusted_state = client.last_trusted_state().unwrap();
-
-                    info!(
-                        chain.id = %client.chain().id(),
-                        "Spawned new client now at trusted state: {} at height {}",
-                        trusted_state.last_header().header().hash(),
-                        trusted_state.last_header().header().height(),
-                    );
-
-                    update_headers(client).await;
-                });
+                tokio::task::spawn_local(spawn_client(chain_config));
             }
 
-            start_relayer().await
-        })
+            info!("starting relayer");
+            relayer_task().await
+        }));
     }
 }
 
-async fn start_relayer() {
+async fn spawn_client(chain_config: ChainConfig) {
+    status_info!(
+        "Relayer",
+        "spawning light client for chain {}",
+        chain_config.id
+    );
+
+    let client = create_client(chain_config).await;
+    tokio::task::spawn_local(client_task(client))
+        .await
+        .expect("could not spawn client task")
+}
+
+async fn client_task(client: Client<TendermintChain, impl Store<TendermintChain>>) {
+    let trusted_state = client.last_trusted_state().unwrap();
+
+    status_ok!(
+        client.chain().id(),
+        "spawned new client now at trusted state: {} at height {}",
+        trusted_state.last_header().header().hash(),
+        trusted_state.last_header().header().height(),
+    );
+
+    update_client(client).await;
+}
+
+async fn relayer_task() {
     let mut interval = tokio::time::interval(Duration::from_secs(3));
 
     loop {
-        info!(target: "relayer_cli::relayer", "Relayer is running");
+        info!(target: "relayer_cli::relayer", "relayer is running");
         interval.tick().await;
     }
 }
 
-async fn update_headers<C: Chain, S: Store<C>>(mut client: Client<C, S>) {
+async fn update_client<C: Chain, S: Store<C>>(mut client: Client<C, S>) {
     debug!(chain.id = %client.chain().id(), "updating headers");
 
     let mut interval = tokio::time::interval(Duration::from_secs(3));
 
     loop {
+        info!(chain.id = %client.chain().id(), "updating client");
+
         let result = client.update(SystemTime::now()).await;
 
         match result {
             Ok(Some(trusted_state)) => info!(
                 chain.id = %client.chain().id(),
-                "Updated to trusted state: {} at height {}",
+                "client updated to trusted state: {} at height {}",
                 trusted_state.header().hash(),
                 trusted_state.header().height()
             ),
 
             Ok(None) => {
-                warn!(chain.id = %client.chain().id(), "Ignoring update to a previous state")
+                warn!(chain.id = %client.chain().id(), "ignoring update to a previous state")
             }
             Err(err) => {
-                error!(chain.id = %client.chain().id(), "Error when updating headers: {}", err)
+                error!(chain.id = %client.chain().id(), "error when updating headers: {}", err)
             }
         }
 

--- a/relayer/relay/src/chain.rs
+++ b/relayer/relay/src/chain.rs
@@ -21,14 +21,15 @@ pub type ValidatorSet<Chain> = <<Chain as self::Chain>::Commit as tmlite::Commit
 /// Defines a blockchain as understood by the relayer
 pub trait Chain {
     /// Type of headers for this chain
-    type Header: tmlite::Header + Serialize + DeserializeOwned;
+    type Header: tmlite::Header + Send + Sync + Serialize + DeserializeOwned;
 
     /// Type of commits for this chain
-    type Commit: tmlite::Commit + Serialize + DeserializeOwned;
+    type Commit: tmlite::Commit + Send + Sync + Serialize + DeserializeOwned;
 
     /// Type of consensus state for this chain
-    type ConsensusState: ConsensusState + Serialize + DeserializeOwned;
-    type Type;
+    type ConsensusState: ConsensusState + Send + Sync + Serialize + DeserializeOwned;
+
+    /// Type of the client state for this chain
     type ClientState: ClientState;
 
     /// Type of RPC requester (wrapper around low-level RPC client) for this chain

--- a/relayer/relay/src/chain/tendermint.rs
+++ b/relayer/relay/src/chain/tendermint.rs
@@ -5,7 +5,6 @@ use tendermint::block::Header as TMHeader;
 use tendermint::lite::TrustThresholdFraction;
 use tendermint::rpc::Client as RpcClient;
 
-use relayer_modules::ics02_client::client_type::ClientType;
 use relayer_modules::ics07_tendermint::client_state::ClientState;
 use relayer_modules::ics07_tendermint::consensus_state::ConsensusState;
 
@@ -36,7 +35,6 @@ impl TendermintChain {
 }
 
 impl Chain for TendermintChain {
-    type Type = ClientType;
     type Header = TMHeader;
     type Commit = TMCommit;
     type ConsensusState = ConsensusState;

--- a/relayer/relay/src/client.rs
+++ b/relayer/relay/src/client.rs
@@ -93,10 +93,6 @@ where
             client.init_with_trust_options(trust_options).await?;
         }
 
-        // Perform an update already, to make sure the client is up-to-date.
-        // TODO: Should we leave this up to the responsibility of the caller?
-        let _ = client.update(SystemTime::now()).await?;
-
         Ok(client)
     }
 

--- a/relayer/relay/src/client.rs
+++ b/relayer/relay/src/client.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use tendermint::lite::types::{Commit, Header as _, Requester, ValidatorSet as _};
 use tendermint::lite::{SignedHeader, TrustThresholdFraction, TrustedState};
 
-use crate::chain::{self, ValidatorSet};
+use crate::chain;
 use crate::error;
 use crate::store::{self, StoreHeight};
 
@@ -135,16 +135,8 @@ where
                     .await
                     .map_err(|e| error::Kind::LightClient.context(e))?;
 
-                let latest_validator_set = self
-                    .chain
-                    .requester()
-                    .validator_set(latest_header.header().height())
-                    .await
-                    .map_err(|e| error::Kind::LightClient.context(e))?;
-
                 if latest_header.header().height() > last_trusted_height {
-                    self.verify_header(&latest_header, &latest_validator_set, now)
-                        .await?;
+                    self.verify_header(&latest_header, now).await?;
 
                     Ok(Some(latest_header))
                 } else {
@@ -162,15 +154,14 @@ where
     /// the stored hash, we fail with an error.
     ///
     /// Otherwise, and only if we already have a trusted state,
-    /// we then pull the next validator set (w.r.t to the given header)
-    /// and attempt to verify the new header against it.
-    /// If that succeeds we update the trusted store and our last trusted state.
+    /// we attempt bisection for the new header at the given height.
+    /// If this succeeds, we add the new trusted states to the store and
+    /// update our last trusted state.
     ///
-    /// If there is no current trusted state, we fail with an error.
+    /// In any other case, we fail with an error.
     async fn verify_header(
         &mut self,
         new_header: &SignedHeader<Chain::Commit, Chain::Header>,
-        new_validator_set: &ValidatorSet<Chain>,
         now: SystemTime,
     ) -> Result<(), error::Error> {
         let in_store = self
@@ -192,40 +183,26 @@ where
             }
         }
 
-        // If we already have a trusted state, we then pull the next validator set of
-        // the header we were given to verify, and attempt to verify the new
-        // header against it.
+        // If we already have a trusted state, we attempt bisection for the
+        // new header at the given height. If it succeeds, we add the new
+        // trusted states to the store and update our last trusted state.
         if let Some(ref last_trusted_state) = self.last_trusted_state {
-            let next_height = new_header
-                .header()
-                .height()
-                .checked_add(1)
-                .expect("height overflow");
+            let new_header_height = new_header.header().height();
 
-            let new_next_validator_set = self
-                .chain
-                .requester()
-                .validator_set(next_height)
-                .await
-                .map_err(|e| error::Kind::LightClient.context(e))?;
-
-            tendermint::lite::verifier::verify_single(
+            let new_trusted_states = tendermint::lite::verifier::verify_bisection(
                 last_trusted_state.clone(),
-                &new_header,
-                &new_validator_set,
-                &new_next_validator_set,
+                new_header_height,
                 self.trust_threshold,
                 self.trusting_period,
                 now,
+                self.chain.requester(),
             )
+            .await
             .map_err(|e| error::Kind::LightClient.context(e))?;
 
-            // TODO: Compare new header with witnesses (?)
-
-            let new_trusted_state =
-                TrustedState::new(new_header.clone(), new_validator_set.clone());
-
-            self.update_trusted_state(new_trusted_state)?;
+            for new_trusted_state in new_trusted_states {
+                self.update_trusted_state(new_trusted_state)?;
+            }
 
             Ok(())
         } else {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #49

## Description

This PR implements proposal B described in #49.

All tasks spawned in the `start` command are now spawned on a local task set which executes them all on the same thread, ie. the main thread.

This seems like an acceptable solution to me given that the overall architecture of the relayer and the light client will likely change quite a bit in the coming weeks.
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
