### PR TITLE
Switch to ICS paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
           args: --all-features --no-fail-fast
         env:
           CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"
       - uses: actions-rs/grcov@v0.1
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,7 +17,7 @@ paths-cosmos = []
 paths-ics = []
 
 [dependencies]
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "tendermint/v0.33" }
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 
 [features]
 # Default features
-default = ["paths-cosmos"]
+#default = ["paths-cosmos"]
+default = ["paths-ics"]
 
 # In IBC queries, use paths as defined in the Cosmos-SDK Go implementation, rather than in the ICS.
 paths-cosmos = []
+paths-ics = []
 
 [dependencies]
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "tendermint/v0.33" }

--- a/modules/src/path/ics.rs
+++ b/modules/src/path/ics.rs
@@ -1,7 +1,7 @@
 use super::{ClientStatePath, ConnectionPath, ConsensusStatePath};
 
 pub fn connection_path(path: &ConnectionPath) -> String {
-    format!("connection/{}", path.connection_id)
+    format!("connections/{}", path.connection_id)
 }
 
 pub fn consensus_state_path(path: &ConsensusStatePath) -> String {

--- a/modules/src/path/ics.rs
+++ b/modules/src/path/ics.rs
@@ -1,13 +1,13 @@
 use super::{ClientStatePath, ConnectionPath, ConsensusStatePath};
 
-pub fn connection_path(_path: &ConnectionPath) -> String {
-    todo!()
+pub fn connection_path(path: &ConnectionPath) -> String {
+    format!("connection/{}", path.connection_id)
 }
 
-pub fn consensus_state_path(_path: &ConsensusStatePath) -> String {
-    todo!()
+pub fn consensus_state_path(path: &ConsensusStatePath) -> String {
+    format!("clients/{}/consensusState/{}", path.client_id, path.height)
 }
 
-pub fn client_state_path(_path: &ClientStatePath) -> String {
-    todo!()
+pub fn client_state_path(path: &ClientStatePath) -> String {
+    format!("clients/{}/clientState", path.client_id)
 }

--- a/relayer/cli/Cargo.toml
+++ b/relayer/cli/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 [dependencies]
 relayer = { path = "../relay" }
 relayer-modules = { path = "../../modules" }
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "tendermint/v0.33" }
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
 
 abscissa_tokio = "0.5.1"
 anomaly = "0.2.0"

--- a/relayer/cli/src/commands.rs
+++ b/relayer/cli/src/commands.rs
@@ -73,9 +73,6 @@ impl Configurable<Config> for CliCmd {
     /// This can be safely deleted if you don't want to override config
     /// settings from command-line options.
     fn process_config(&self, config: Config) -> Result<Config, FrameworkError> {
-        match self {
-            // CliCmd::Start(cmd) => cmd.override_config(config),
-            _ => Ok(config),
-        }
+        Ok(config)
     }
 }

--- a/relayer/cli/src/commands/query/client.rs
+++ b/relayer/cli/src/commands/query/client.rs
@@ -50,7 +50,7 @@ impl QueryClientStateCmd {
                 None => true,
             },
         };
-        Ok((chain_config.clone(), opts))
+        Ok((chain_config, opts))
     }
 }
 
@@ -137,7 +137,7 @@ impl QueryClientConsensusCmd {
                         None => true,
                     },
                 };
-                Ok((chain_config.clone(), opts))
+                Ok((chain_config, opts))
             }
             None => Err("missing client consensus height".to_string()),
         }

--- a/relayer/relay/Cargo.toml
+++ b/relayer/relay/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 
 [dependencies]
 relayer-modules = { path = "../../modules" }
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "tendermint/v0.33" }
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
 anomaly = "0.2.0"
 async-trait = "0.1.24"
 humantime-serde = "1.0.0"


### PR DESCRIPTION
Closes: #XXX

## Description
SDK has switched to somewhat standard paths. Most likely ICS24 will be updated with these. 

______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
