### PR TITLE
Check query parameters but not against the config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   require_ci_to_pass: yes
+  allow_coverage_offsets: true
 
 ignore:
 

--- a/modules/src/ics02_client/query.rs
+++ b/modules/src/ics02_client/query.rs
@@ -88,19 +88,12 @@ where
         query: QueryClientFullState<CLS>,
         response: AbciQuery,
     ) -> Result<Self, error::Error> {
-        match (response.value, &response.proof) {
-            (Some(value), _) => {
-                let client_state = amino_unmarshal_binary_length_prefixed(&value)?;
-
-                Ok(ClientFullStateResponse::new(
-                    query.client_id,
-                    client_state,
-                    response.proof,
-                    response.height.into(),
-                ))
-            }
-            (None, _) => Err(error::Kind::Rpc.context("Bad response").into()),
-        }
+        Ok(ClientFullStateResponse::new(
+            query.client_id,
+            amino_unmarshal_binary_length_prefixed(&response.value)?,
+            response.proof,
+            response.height.into(),
+        ))
     }
 }
 
@@ -192,18 +185,11 @@ where
         query: QueryClientConsensusState<CS>,
         response: AbciQuery,
     ) -> Result<Self, error::Error> {
-        match (response.value, &response.proof) {
-            (Some(value), _) => {
-                let consensus_state = amino_unmarshal_binary_length_prefixed(&value)?;
-
-                Ok(ConsensusStateResponse::new(
-                    query.client_id,
-                    consensus_state,
-                    response.proof,
-                    response.height.into(),
-                ))
-            }
-            (None, _) => Err(error::Kind::Rpc.context("Bad response").into()),
-        }
+        Ok(ConsensusStateResponse::new(
+            query.client_id,
+            amino_unmarshal_binary_length_prefixed(&response.value)?,
+            response.proof,
+            response.height.into(),
+        ))
     }
 }

--- a/modules/src/ics04_channel/msgs.rs
+++ b/modules/src/ics04_channel/msgs.rs
@@ -146,7 +146,7 @@ mod tests {
             Test {
                 name: "Bad channel, name too short".to_string(),
                 params: OpenInitParams {
-                    channel_id: "connone".to_string(),
+                    channel_id: "chshort".to_string(),
                     ..default_params.clone()
                 },
                 want_pass: false,

--- a/modules/src/ics04_channel/query.rs
+++ b/modules/src/ics04_channel/query.rs
@@ -79,20 +79,13 @@ impl ChannelResponse {
 
 impl IbcResponse<QueryChannel> for ChannelResponse {
     fn from_abci_response(query: QueryChannel, response: AbciQuery) -> Result<Self, error::Error> {
-        match (response.value, &response.proof) {
-            (Some(value), _) => {
-                let channel = amino_unmarshal_binary_length_prefixed(&value)?;
-
-                Ok(ChannelResponse::new(
-                    query.port_id,
-                    query.channel_id,
-                    channel,
-                    response.proof,
-                    response.height.into(),
-                ))
-            }
-            (None, _) => Err(error::Kind::Rpc.context("Bad response").into()),
-        }
+        Ok(ChannelResponse::new(
+            query.port_id,
+            query.channel_id,
+            amino_unmarshal_binary_length_prefixed(&response.value)?,
+            response.proof,
+            response.height.into(),
+        ))
     }
 }
 

--- a/relayer/cli/Cargo.toml
+++ b/relayer/cli/Cargo.toml
@@ -30,4 +30,3 @@ version = "0.5.2"
 [dev-dependencies]
 abscissa_core = { version = "0.5.2", features = ["testing"] }
 once_cell = "1.2"
-itertools = "0.9.0"

--- a/relayer/cli/Cargo.toml
+++ b/relayer/cli/Cargo.toml
@@ -30,3 +30,4 @@ version = "0.5.2"
 [dev-dependencies]
 abscissa_core = { version = "0.5.2", features = ["testing"] }
 once_cell = "1.2"
+itertools = "0.9.0"

--- a/relayer/cli/src/commands/query/channel.rs
+++ b/relayer/cli/src/commands/query/channel.rs
@@ -44,7 +44,7 @@ impl QueryChannelEndsCmd {
     ) -> Result<(ChainConfig, QueryChannelOptions), String> {
         let chain_id = self
             .chain_id
-            .ok_or_else(|| "missing chain configuration".to_string())?;
+            .ok_or_else(|| "missing chain identifier".to_string())?;
         let chain_config = config
             .chains
             .iter()

--- a/relayer/cli/src/commands/query/channel.rs
+++ b/relayer/cli/src/commands/query/channel.rs
@@ -11,7 +11,7 @@ use relayer::chain::tendermint::TendermintChain;
 use relayer_modules::ics24_host::error::ValidationError;
 use tendermint::chain::Id as ChainId;
 
-#[derive(Command, Debug, Options)]
+#[derive(Clone, Command, Debug, Options)]
 pub struct QueryChannelEndsCmd {
     #[options(free, help = "identifier of the chain to query")]
     chain_id: Option<ChainId>,
@@ -113,6 +113,115 @@ impl Runnable for QueryChannelEndsCmd {
         match res {
             Ok(cs) => status_info!("channel query result: ", "{:?}", cs.channel),
             Err(e) => status_info!("channel query error: ", "{:?}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::query::channel::QueryChannelEndsCmd;
+    use relayer::config::parse;
+
+    #[test]
+    fn parse_query_ends_parameters() {
+        let default_params = QueryChannelEndsCmd {
+            chain_id: Some("ibc0".to_string().parse().unwrap()),
+            port_id: Some("transfer".to_string().parse().unwrap()),
+            channel_id: Some("testchannel".to_string().parse().unwrap()),
+            height: None,
+            proof: None,
+        };
+
+        struct Test {
+            name: String,
+            params: QueryChannelEndsCmd,
+            want_pass: bool,
+        }
+
+        let tests: Vec<Test> = vec![
+            Test {
+                name: "Good parameters".to_string(),
+                params: default_params.clone(),
+                want_pass: true,
+            },
+            Test {
+                name: "No chain specified".to_string(),
+                params: QueryChannelEndsCmd {
+                    chain_id: None,
+                    ..default_params.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Chain not configured".to_string(),
+                params: QueryChannelEndsCmd {
+                    chain_id: Some("notibc0oribc1".to_string().parse().unwrap()),
+                    ..default_params.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "No port id specified".to_string(),
+                params: QueryChannelEndsCmd {
+                    port_id: None,
+                    ..default_params.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Bad port, non-alpha".to_string(),
+                params: QueryChannelEndsCmd {
+                    port_id: Some("p34".to_string()),
+                    ..default_params.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "No channel id specified".to_string(),
+                params: QueryChannelEndsCmd {
+                    channel_id: None,
+                    ..default_params.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Bad channel, name too short".to_string(),
+                params: QueryChannelEndsCmd {
+                    channel_id: Some("chshort".to_string()),
+                    ..default_params.clone()
+                },
+                want_pass: false,
+            },
+        ]
+        .into_iter()
+        .collect();
+
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/two_chains.toml"
+        );
+
+        let config = parse(path).unwrap();
+
+        for test in tests {
+            let res = test.params.validate_options(&config);
+
+            match res {
+                Ok(_res) => {
+                    assert!(
+                        test.want_pass,
+                        "validate_options should have failed for test {}",
+                        test.name
+                    );
+                }
+                Err(err) => {
+                    assert!(
+                        !test.want_pass,
+                        "validate_options failed for test {}, \nerr {}",
+                        test.name, err
+                    );
+                }
+            }
         }
     }
 }

--- a/relayer/cli/src/commands/query/client.rs
+++ b/relayer/cli/src/commands/query/client.rs
@@ -191,12 +191,12 @@ fn validate_common_options(
     client_id: &Option<String>,
     config: &Config,
 ) -> Result<(ChainConfig, ClientId), String> {
-    let chain_id = chain_id.ok_or_else(|| "missing chain configuration".to_string())?;
+    let chain_id = chain_id.ok_or_else(|| "missing chain parameter".to_string())?;
     let chain_config = config
         .chains
         .iter()
         .find(|c| c.id == chain_id)
-        .ok_or_else(|| "missing chain configuration".to_string())?;
+        .ok_or_else(|| "missing chain in configuration".to_string())?;
     let client_id = client_id
         .as_ref()
         .ok_or_else(|| "missing client identifier".to_string())?

--- a/relayer/cli/tests/fixtures/two_chains.toml
+++ b/relayer/cli/tests/fixtures/two_chains.toml
@@ -1,0 +1,29 @@
+title = "IBC Relayer Config Example"
+
+[global]
+timeout = "10s"
+strategy = "naive"
+
+[[chains]]
+  id = "ibc0"
+  rpc_addr = "localhost:26657"
+  account_prefix = "cosmos"
+  key_name = "testkey"
+  store_prefix = "ibc"
+  client_ids = ["cla1", "cla2"]
+  gas = 200000
+  gas_adjustement = 1.3
+  gas_price = "0.025stake"
+  trusting_period = "336h"
+
+[[chains]]
+  id = "ibc0"
+  rpc_addr = "localhost:26557"
+  account_prefix = "cosmos"
+  key_name = "testkey"
+  store_prefix = "ibc"
+  client_ids = ["clb1"]
+  gas = 200000
+  gas_adjustement = 1.3
+  gas_price = "0.025stake"
+  trusting_period = "336h"


### PR DESCRIPTION
Queries should be allowed for clients and channels that are not configured.
Also, fix parameter verification order to be consistent and simplify the code.
Fix regressions.

Closes: #74 

For contributor use:

- [X] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
