### PR TITLE
Makes Msg trait global

### DIFF
--- a/modules/src/ics02_client/msgs.rs
+++ b/modules/src/ics02_client/msgs.rs
@@ -18,10 +18,8 @@ where
     Self: Msg,
 {
     type ConsensusState: ConsensusState;
-    type Header: Header;
 
     fn client_id(&self) -> &ClientId;
     fn client_type(&self) -> ClientType;
-    fn header(&self) -> &Self::Header;
     fn consensus_state(&self) -> Self::ConsensusState;
 }

--- a/modules/src/ics02_client/msgs.rs
+++ b/modules/src/ics02_client/msgs.rs
@@ -2,29 +2,13 @@ use super::client_type::ClientType;
 use super::header::Header;
 use super::state::ConsensusState;
 use crate::ics24_host::identifier::ClientId;
-
-// FIXME: Remove Header associated type and use Box<dyn tendermint::lite::Header> instead of
-// Self::Header?
-
-pub trait Msg {
-    type ValidationError: std::error::Error;
-    type Header: Header;
-
-    fn route(&self) -> String; // TODO: Make this &'static str or custom type?
-    fn get_type(&self) -> String;
-
-    fn validate_basic(&self) -> Result<(), Self::ValidationError>;
-
-    fn get_sign_bytes(&self) -> Vec<u8>;
-    fn get_signers(&self) -> Vec<ClientId>;
-    fn get_client_id(&self) -> &ClientId;
-    fn get_header(&self) -> &Self::Header;
-}
+use crate::tx_msg::Msg;
 
 pub trait MsgUpdateClient
 where
     Self: Msg,
 {
+    type Header: Header;
     fn client_id(&self) -> &ClientId;
     fn header(&self) -> &Self::Header;
 }
@@ -34,6 +18,7 @@ where
     Self: Msg,
 {
     type ConsensusState: ConsensusState;
+    type Header: Header;
 
     fn client_id(&self) -> &ClientId;
     fn client_type(&self) -> ClientType;

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -1,10 +1,10 @@
 use crate::ics03_connection::connection::Counterparty;
 use crate::ics03_connection::error::Kind;
 use crate::ics03_connection::exported::ConnectionCounterparty;
-use crate::ics04_channel::msgs::Msg;
 use crate::ics23_commitment::CommitmentPrefix;
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
 use crate::ics24_host::validate::{validate_client_identifier, validate_connection_identifier};
+use crate::tx_msg::Msg;
 use serde_derive::{Deserialize, Serialize};
 use tendermint::account::Id as AccountId;
 

--- a/modules/src/ics04_channel/msgs.rs
+++ b/modules/src/ics04_channel/msgs.rs
@@ -3,26 +3,12 @@ use super::channel::{ChannelEnd, Counterparty};
 use super::exported::*;
 use crate::ics04_channel::error::Kind;
 use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
+use crate::tx_msg::Msg;
 use serde_derive::{Deserialize, Serialize};
 use std::str::FromStr;
 use tendermint::account::Id as AccountId;
 
 pub const TYPE_MSG_CHANNEL_OPEN_INIT: &str = "channel_open_init";
-
-// FIXME - this should be common for all messages not just channel, client also defines it.
-pub trait Msg {
-    type ValidationError: std::error::Error;
-
-    fn route(&self) -> String;
-
-    fn get_type(&self) -> String;
-
-    fn validate_basic(&self) -> Result<(), Self::ValidationError>;
-
-    fn get_sign_bytes(&self) -> Vec<u8>;
-
-    fn get_signers(&self) -> Vec<AccountId>;
-}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MsgChannelOpenInit {

--- a/modules/src/ics07_tendermint/msgs/create_client.rs
+++ b/modules/src/ics07_tendermint/msgs/create_client.rs
@@ -1,9 +1,9 @@
 use crate::ics02_client::client_type::ClientType;
-use crate::ics02_client::msgs::Msg;
 use crate::ics07_tendermint::consensus_state::ConsensusState;
 use crate::ics07_tendermint::header::Header;
 use crate::ics23_commitment::CommitmentRoot;
 use crate::ics24_host::identifier::ClientId;
+use crate::tx_msg::Msg;
 
 use serde_derive::{Deserialize, Serialize};
 use tendermint::account::Id as AccountId;
@@ -35,11 +35,18 @@ impl MsgCreateClient {
             signer,
         }
     }
+
+    fn get_client_id(&self) -> &ClientId {
+        &self.client_id
+    }
+
+    fn get_header(&self) -> &Header {
+        &self.header
+    }
 }
 
 impl Msg for MsgCreateClient {
     type ValidationError = crate::ics24_host::error::ValidationError;
-    type Header = Header;
 
     fn route(&self) -> String {
         crate::keys::ROUTER_KEY.to_string()
@@ -58,24 +65,21 @@ impl Msg for MsgCreateClient {
         todo!()
     }
 
-    fn get_signers(&self) -> Vec<ClientId> {
-        vec![self.client_id.clone()]
-    }
-
-    fn get_client_id(&self) -> &ClientId {
-        &self.client_id
-    }
-
-    fn get_header(&self) -> &Self::Header {
-        &self.header
+    fn get_signers(&self) -> Vec<AccountId> {
+        vec![self.signer]
     }
 }
 
 impl crate::ics02_client::msgs::MsgCreateClient for MsgCreateClient {
     type ConsensusState = ConsensusState;
+    type Header = Header;
 
     fn client_id(&self) -> &ClientId {
         &self.client_id
+    }
+
+    fn client_type(&self) -> ClientType {
+        ClientType::Tendermint
     }
 
     fn header(&self) -> &Self::Header {
@@ -92,9 +96,5 @@ impl crate::ics02_client::msgs::MsgCreateClient for MsgCreateClient {
             header.time,
             self.header.validator_set.clone(),
         )
-    }
-
-    fn client_type(&self) -> ClientType {
-        ClientType::Tendermint
     }
 }

--- a/modules/src/ics07_tendermint/msgs/create_client.rs
+++ b/modules/src/ics07_tendermint/msgs/create_client.rs
@@ -72,7 +72,6 @@ impl Msg for MsgCreateClient {
 
 impl crate::ics02_client::msgs::MsgCreateClient for MsgCreateClient {
     type ConsensusState = ConsensusState;
-    type Header = Header;
 
     fn client_id(&self) -> &ClientId {
         &self.client_id
@@ -80,10 +79,6 @@ impl crate::ics02_client::msgs::MsgCreateClient for MsgCreateClient {
 
     fn client_type(&self) -> ClientType {
         ClientType::Tendermint
-    }
-
-    fn header(&self) -> &Self::Header {
-        &self.header
     }
 
     fn consensus_state(&self) -> Self::ConsensusState {

--- a/modules/src/ics07_tendermint/msgs/update_client.rs
+++ b/modules/src/ics07_tendermint/msgs/update_client.rs
@@ -1,6 +1,6 @@
-use crate::ics02_client::msgs::Msg;
 use crate::ics07_tendermint::header::Header;
 use crate::ics24_host::identifier::ClientId;
+use crate::tx_msg::Msg;
 
 use serde_derive::{Deserialize, Serialize};
 use tendermint::account::Id as AccountId;
@@ -22,11 +22,18 @@ impl MsgUpdateClient {
             signer,
         }
     }
+
+    fn get_client_id(&self) -> &ClientId {
+        &self.client_id
+    }
+
+    fn get_header(&self) -> &Header {
+        &self.header
+    }
 }
 
 impl Msg for MsgUpdateClient {
     type ValidationError = crate::ics24_host::error::ValidationError;
-    type Header = Header;
 
     fn route(&self) -> String {
         crate::keys::ROUTER_KEY.to_string()
@@ -45,20 +52,14 @@ impl Msg for MsgUpdateClient {
         todo!()
     }
 
-    fn get_signers(&self) -> Vec<ClientId> {
-        vec![self.client_id.clone()]
-    }
-
-    fn get_client_id(&self) -> &ClientId {
-        &self.client_id
-    }
-
-    fn get_header(&self) -> &Self::Header {
-        &self.header
+    fn get_signers(&self) -> Vec<AccountId> {
+        vec![self.signer]
     }
 }
 
 impl crate::ics02_client::msgs::MsgUpdateClient for MsgUpdateClient {
+    type Header = Header;
+
     fn client_id(&self) -> &ClientId {
         &self.client_id
     }

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -29,6 +29,7 @@ pub mod ics24_host;
 pub mod keys;
 pub mod path;
 pub mod query;
+pub mod tx_msg;
 
 /// Height of a block, same as in `tendermint` crate
 pub type Height = tendermint::lite::Height;

--- a/modules/src/tx_msg.rs
+++ b/modules/src/tx_msg.rs
@@ -1,0 +1,15 @@
+use tendermint::account::Id as AccountId;
+
+pub trait Msg {
+    type ValidationError: std::error::Error;
+
+    fn route(&self) -> String;
+
+    fn get_type(&self) -> String;
+
+    fn validate_basic(&self) -> Result<(), Self::ValidationError>;
+
+    fn get_sign_bytes(&self) -> Vec<u8>;
+
+    fn get_signers(&self) -> Vec<AccountId>;
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #75 

## Description

- Msg trait moved to modules/src/tx_msg.rs where it is accessible for other modules to use.
- Made some related changes to ics07_tendermint's Msg implementation code
- The older Msg trait from ics02_client had the `get_signers()` function return `Vec<ClientId>` whereas it should ideally return `Vec<AccountId>`. I'm not sure if there is a reason behind keeping it that way. Please let me know!

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
