### PR TITLE
[WIP] Add main event handler and per chain monitor tasks

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,13 +17,15 @@ paths-cosmos = []
 paths-ics = []
 
 [dependencies]
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
+tendermint = { path = "/Users/ancaz/rust/tendermint-rs/tendermint"}
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"
 serde_derive = "1.0.104"
 serde = "1.0.104"
+serde_json = "1"
+tracing = "0.1.13"
 
 [dev-dependencies]
-serde_json = "1"
+tokio = { version = "0.2", features = ["macros"] }
 

--- a/modules/src/error.rs
+++ b/modules/src/error.rs
@@ -8,6 +8,10 @@ pub enum Kind {
     /// RPC error (typically raised by the RPC client or the RPC requester)
     #[error("RPC error")]
     Rpc,
+
+    /// Event error (raised by the event monitor)
+    #[error("Bad Notification")]
+    EventErr,
 }
 
 impl Kind {

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -1,0 +1,248 @@
+use crate::ics02_client::events as ClientEvents;
+use crate::ics02_client::events::NewBlock;
+use crate::ics03_connection::events as ConnectionEvents;
+use crate::ics04_channel::events as ChannelEvents;
+use crate::ics20_fungible_token_transfer::events as TransferEvents;
+use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::convert::{TryFrom, TryInto};
+use tendermint::block;
+use tendermint::rpc::event_listener::{ResultEvent, TMEventData};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum IBCEvent {
+    NewBlock(NewBlock),
+
+    CreateClient(ClientEvents::CreateClient),
+    UpdateClient(ClientEvents::UpdateClient),
+    ClientMisbehavior(ClientEvents::ClientMisbehavior),
+
+    OpenInitConnection(ConnectionEvents::OpenInit),
+    OpenTryConnection(ConnectionEvents::OpenTry),
+    OpenAckConnection(ConnectionEvents::OpenAck),
+    OpenConfirmConnection(ConnectionEvents::OpenConfirm),
+
+    OpenInitChannel(ChannelEvents::OpenInit),
+    OpenTryChannel(ChannelEvents::OpenTry),
+    OpenAckChannel(ChannelEvents::OpenAck),
+    OpenConfirmChannel(ChannelEvents::OpenConfirm),
+    CloseInitChannel(ChannelEvents::CloseInit),
+    CloseConfirmChannel(ChannelEvents::CloseConfirm),
+
+    SendPacketChannel(ChannelEvents::SendPacket),
+    ReceivePacketChannel(ChannelEvents::ReceivePacket),
+    AcknowledgePacketChannel(ChannelEvents::AcknowledgePacket),
+    CleanupPacketChannel(ChannelEvents::CleanupPacket),
+    TimeoutPacketChannel(ChannelEvents::TimeoutPacket),
+
+    TimeoutTransfer(TransferEvents::Timeout),
+    PacketTransfer(TransferEvents::Packet),
+    ChannelClosedTransfer(TransferEvents::ChannelClosed),
+}
+
+impl IBCEvent {
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TryObject {
+    pub height: block::Height,
+    pub action: String,
+    pub idx: usize,
+    pub events: HashMap<String, Vec<String>>,
+}
+
+impl TryObject {
+    pub fn new(
+        height: block::Height,
+        action: String,
+        idx: usize,
+        events: HashMap<String, Vec<String>>,
+    ) -> TryObject {
+        TryObject {
+            height,
+            action,
+            idx,
+            events,
+        }
+    }
+}
+
+pub fn extract_events<'a, S: ::std::hash::BuildHasher>(
+    events: &'a HashMap<String, Vec<String>, S>,
+    action_string: &'a str,
+) -> Result<&'a HashMap<String, Vec<String>, S>, Box<dyn std::error::Error>> {
+    if let Some(message_action) = events.get("message.action") {
+        if message_action.contains(&action_string.to_owned()) {
+            return Ok(events);
+        }
+        return Err("Missing action string".into());
+    }
+    Err("Incorrect Event Type".into())
+}
+
+//Takes events in the form
+//  "events":{
+//      "connection_open_init.client_id":["testclient","testclientsec"],
+//      "connection_open_init.connection_id":["ancaconnonetest","ancaconnonetestsec"],
+//      "connection_open_init.counterparty_client_id":["testclientsec","testclientsecsec"],
+//      "create_client.client_id":["testclientthird"],
+//      "create_client.client_type":["tendermint"],
+//      "message.action":["connection_open_init","create_client","connection_open_init"],
+//      "message.module":["ibc_connection","ibc_client",ibc_connection"],
+//      "message.sender":["cosmos187xxg4yfkypl05cqylucezpjvycj24nurvm8p9","cosmos187xxg4yfkypl05cqylucezpjvycj24nurvm8p9","cosmos187xxg4yfkypl05cqylucezpjvycj24nurvm8p9","cosmos187xxg4yfkypl05cqylucezpjvycj24nurvm8p9"],"tm.event":["Tx"],"transfer.amount":["5000stake"],"transfer.recipient":["cosmos17xpfvakm2amg962yls6f84z3kell8c5lserqta"],"tx.hash":["A9E18AE3909F22232F8DBDB1C48F2FECB260A308A2D157E8832E901D45950605"],
+//      "tx.height":["35"]
+// and returns:
+// [{"connection_open_init", 0}, {"create_client", 0}, {"connection_open_init", 1}]
+// where the number in each entry is the index in the matching events that should be used to build the event
+// e.g. for the last "connection_open_init" in the result
+//      "connection_open_init.client_id" -> "testclientsec"
+//      "connection_open_init.connection_id" -> "ancaconnonetestsec",
+//      "connection_open_init.counterparty_client_id" -> "testclientsec","testclientsecsec",
+fn extract_helper(events: &HashMap<String, Vec<String>>) -> Result<Vec<(String, u32)>, String> {
+    let message_action = events.get("message.action").ok_or("Incorrect Event Type")?;
+    let mut val_indeces = HashMap::new();
+    let mut result = Vec::new();
+
+    for action_string in message_action {
+        let idx = val_indeces
+            .entry(action_string.clone())
+            .or_insert_with(|| 0);
+        result.push((action_string.clone(), *idx));
+        *val_indeces.get_mut(action_string.as_str()).unwrap() += 1;
+    }
+    Ok(result)
+}
+
+pub fn get_all_events(result: ResultEvent) -> Result<Vec<IBCEvent>, String> {
+    let mut vals: Vec<IBCEvent> = vec![];
+
+    match &result.data {
+        TMEventData::EventDataNewBlock(nb) => {
+            let block = (&nb.block).as_ref().ok_or("missing block")?;
+            vals.push(NewBlock::new(block.header.height).into());
+        }
+
+        TMEventData::EventDataTx(_tx) => {
+            let events = &result.events.ok_or("missing events")?;
+            let height = events.get("tx.height").ok_or("tx.height")?[0]
+                .parse::<u64>()
+                .map_err(|e| e.to_string())?;
+            let actions_and_indices = extract_helper(&events)?;
+            for action in actions_and_indices {
+                let ev = build_event(TryObject::new(
+                    height.into(),
+                    action.0,
+                    action.1.try_into().unwrap(),
+                    events.clone(),
+                ))
+                .map_err(|e| e.to_string())?;
+                vals.push(ev);
+            }
+        }
+        _ => {}
+    }
+    Ok(vals)
+}
+
+pub fn build_event(object: TryObject) -> Result<IBCEvent, Box<dyn std::error::Error>> {
+    match object.action.as_str() {
+        "create_client" => Ok(IBCEvent::from(ClientEvents::CreateClient::try_from(
+            object,
+        )?)),
+        "update_client" => Ok(IBCEvent::from(ClientEvents::UpdateClient::try_from(
+            object,
+        )?)),
+
+        "connection_open_init" => Ok(IBCEvent::from(ConnectionEvents::OpenInit::try_from(
+            object,
+        )?)),
+        "connection_open_try" => Ok(IBCEvent::from(ConnectionEvents::OpenTry::try_from(object)?)),
+        "connection_open_ack" => Ok(IBCEvent::from(ConnectionEvents::OpenAck::try_from(object)?)),
+        "connection_open_confirm" => Ok(IBCEvent::from(ConnectionEvents::OpenConfirm::try_from(
+            object,
+        )?)),
+
+        "channel_open_init" => Ok(IBCEvent::from(ChannelEvents::OpenInit::try_from(object)?)),
+        "channel_open_try" => Ok(IBCEvent::from(ChannelEvents::OpenTry::try_from(object)?)),
+        "channel_open_ack" => Ok(IBCEvent::from(ChannelEvents::OpenAck::try_from(object)?)),
+        "channel_open_confirm" => Ok(IBCEvent::from(ChannelEvents::OpenConfirm::try_from(
+            object,
+        )?)),
+        "channel_close_init" => Ok(IBCEvent::from(ChannelEvents::CloseInit::try_from(object)?)),
+        "channel_close_confirm" => Ok(IBCEvent::from(ChannelEvents::CloseConfirm::try_from(
+            object,
+        )?)),
+
+        // send_packet
+        "transfer" => Ok(IBCEvent::from(ChannelEvents::SendPacket::try_from(object)?)),
+        // recv_packet
+        "ics04/opaque" => Ok(IBCEvent::from(ChannelEvents::ReceivePacket::try_from(
+            object,
+        )?)),
+        // acknowledge_packet
+        // needs these changes in cosmos-sdk
+        //        --- a/x/ibc/04-channel/types/msgs.go
+        //        +++ b/x/ibc/04-channel/types/msgs.go
+        //    @@ -511,5 +511,5 @@ func (msg MsgAcknowledgement) GetSigners() []sdk.AccAddress {
+        //
+        //        // Type implements sdk.Msg
+        //        func (msg MsgAcknowledgement) Type() string {
+        //            -       return "ics04/opaque"
+        //            +       return "ics04/acknowledge"
+        //        }
+        "ics04/acknowledge" => Ok(IBCEvent::from(ChannelEvents::AcknowledgePacket::try_from(
+            object,
+        )?)),
+        //timeout_packet
+        "ics04/timeout" => Ok(IBCEvent::from(ChannelEvents::TimeoutPacket::try_from(
+            object,
+        )?)),
+
+        // TODO not clear what the message.action for this is
+        "cleanup_packet" => Ok(IBCEvent::from(ChannelEvents::CleanupPacket::try_from(
+            object,
+        )?)),
+
+        _ => Err("Incorrect Event Type".into()),
+    }
+}
+
+pub fn extract_block_height(
+    result: &ResultEvent,
+) -> Result<block::Height, Box<dyn std::error::Error>> {
+    match &result.data {
+        TMEventData::EventDataNewBlock(nb) => match &nb.block {
+            Some(block) => Ok(block.header.height),
+            None => Err("Empty block".into()),
+        },
+        _ => Err("Incorrect Event Data".into()),
+    }
+}
+
+#[macro_export]
+macro_rules! make_event {
+    ($a:ident, $b:literal) => {
+        #[derive(Debug, Deserialize, Serialize, Clone)]
+        pub struct $a {
+            pub data: std::collections::HashMap<String, Vec<String>>,
+        }
+        impl TryFrom<TryObject> for $a {
+            type Error = Box<dyn std::error::Error>;
+            fn try_from(result: TryObject) -> Result<Self, Self::Error> {
+                Ok($a {
+                    data: crate::events::extract_events(&result.events, $b)?.clone(),
+                })
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! attribute {
+    ($a:ident, $b:literal) => {
+        $a.events.get($b).ok_or($b)?[$a.idx].parse()?
+    };
+}

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -1,8 +1,10 @@
 use super::error;
 use anomaly::fail;
+use serde_derive::{Deserialize, Serialize};
 
 /// Type of the consensus algorithm
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+
 pub enum ClientType {
     Tendermint = 1,
 }

--- a/modules/src/ics02_client/events.rs
+++ b/modules/src/ics02_client/events.rs
@@ -1,0 +1,108 @@
+use crate::attribute;
+use crate::events::{IBCEvent, TryObject};
+use crate::ics02_client::client_type::ClientType;
+use crate::ics24_host::identifier::ClientId;
+
+use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use tendermint::block;
+use tendermint::rpc::event_listener::ResultEvent;
+
+// TODO - find a better place for NewBlock
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct NewBlock {
+    pub height: block::Height,
+}
+
+impl NewBlock {
+    pub fn new(h: block::Height) -> NewBlock {
+        NewBlock { height: h }
+    }
+}
+
+impl TryFrom<&ResultEvent> for NewBlock {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(result: &ResultEvent) -> Result<Self, Self::Error> {
+        Ok(NewBlock {
+            height: crate::events::extract_block_height(result)?,
+        })
+    }
+}
+
+impl From<NewBlock> for IBCEvent {
+    fn from(v: NewBlock) -> Self {
+        IBCEvent::NewBlock(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CreateClient {
+    pub height: block::Height,
+    pub client_id: ClientId,
+    pub client_type: ClientType,
+}
+
+impl TryFrom<TryObject> for CreateClient {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(CreateClient {
+            height: obj.height,
+            client_id: attribute!(obj, "create_client.client_id"),
+            client_type: attribute!(obj, "create_client.client_type"),
+        })
+    }
+}
+
+impl From<CreateClient> for IBCEvent {
+    fn from(v: CreateClient) -> Self {
+        IBCEvent::CreateClient(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct UpdateClient {
+    pub height: block::Height,
+    pub client_id: ClientId,
+    pub client_type: ClientType,
+}
+
+impl TryFrom<TryObject> for UpdateClient {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(UpdateClient {
+            height: obj.height,
+            client_id: attribute!(obj, "update_client.client_id"),
+            client_type: attribute!(obj, "update_client.client_type"),
+        })
+    }
+}
+
+impl From<UpdateClient> for IBCEvent {
+    fn from(v: UpdateClient) -> Self {
+        IBCEvent::UpdateClient(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ClientMisbehavior {
+    pub height: block::Height,
+    pub client_id: ClientId,
+    pub client_type: ClientType,
+}
+
+impl TryFrom<TryObject> for ClientMisbehavior {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(ClientMisbehavior {
+            height: obj.height,
+            client_id: attribute!(obj, "client_misbehaviour.client_id"),
+            client_type: attribute!(obj, "client_misbehaviour.client_type"),
+        })
+    }
+}
+
+impl From<ClientMisbehavior> for IBCEvent {
+    fn from(v: ClientMisbehavior) -> Self {
+        IBCEvent::ClientMisbehavior(v)
+    }
+}

--- a/modules/src/ics02_client/mod.rs
+++ b/modules/src/ics02_client/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod client_type;
 pub mod error;
+pub mod events;
 pub mod header;
 pub mod msgs;
 pub mod query;

--- a/modules/src/ics03_connection/events.rs
+++ b/modules/src/ics03_connection/events.rs
@@ -1,0 +1,102 @@
+use crate::attribute;
+use crate::events::{IBCEvent, TryObject};
+use crate::ics24_host::identifier::{ClientId, ConnectionId};
+use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use tendermint::block;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenInit {
+    pub height: block::Height,
+    pub connection_id: ConnectionId,
+    pub client_id: ClientId,
+    pub counterparty_client_id: ClientId,
+}
+
+impl TryFrom<TryObject> for OpenInit {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenInit {
+            height: obj.height,
+            connection_id: attribute!(obj, "connection_open_init.connection_id"),
+            client_id: attribute!(obj, "connection_open_init.counterparty_client_id"),
+            counterparty_client_id: attribute!(obj, "connection_open_init.client_id"),
+        })
+    }
+}
+
+impl From<OpenInit> for IBCEvent {
+    fn from(v: OpenInit) -> Self {
+        IBCEvent::OpenInitConnection(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenTry {
+    pub height: block::Height,
+    pub connection_id: ConnectionId,
+    pub client_id: ClientId,
+    pub counterparty_client_id: ClientId,
+}
+
+impl TryFrom<TryObject> for OpenTry {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenTry {
+            height: obj.height,
+            connection_id: attribute!(obj, "connection_open_try.connection_id"),
+            client_id: attribute!(obj, "connection_open_try.counterparty_client_id"),
+            counterparty_client_id: attribute!(obj, "connection_open_try.client_id"),
+        })
+    }
+}
+
+impl From<OpenTry> for IBCEvent {
+    fn from(v: OpenTry) -> Self {
+        IBCEvent::OpenTryConnection(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenAck {
+    pub height: block::Height,
+    pub connection_id: ConnectionId,
+}
+
+impl TryFrom<TryObject> for OpenAck {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenAck {
+            height: obj.height,
+            connection_id: attribute!(obj, "connection_open_ack.connection_id"),
+        })
+    }
+}
+
+impl From<OpenAck> for IBCEvent {
+    fn from(v: OpenAck) -> Self {
+        IBCEvent::OpenAckConnection(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenConfirm {
+    pub height: block::Height,
+    pub connection_id: ConnectionId,
+}
+
+impl TryFrom<TryObject> for OpenConfirm {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenConfirm {
+            height: obj.height,
+            connection_id: attribute!(obj, "connection_open_confirm.connection_id"),
+        })
+    }
+}
+
+impl From<OpenConfirm> for IBCEvent {
+    fn from(v: OpenConfirm) -> Self {
+        IBCEvent::OpenConfirmConnection(v)
+    }
+}

--- a/modules/src/ics03_connection/mod.rs
+++ b/modules/src/ics03_connection/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod connection;
 pub mod error;
+pub mod events;
 pub mod exported;
 pub mod msgs;
 pub mod query;

--- a/modules/src/ics04_channel/events.rs
+++ b/modules/src/ics04_channel/events.rs
@@ -1,0 +1,336 @@
+//! Types for the IBC events emitted from Tendermint Websocket for the channels modules.
+
+use crate::attribute;
+use crate::events::{IBCEvent, TryObject};
+use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
+use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use tendermint::block;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenInit {
+    pub height: block::Height,
+    pub port_id: PortId,
+    pub connection_id: ConnectionId,
+    pub channel_id: ChannelId,
+    pub counterparty_port_id: PortId,
+    pub counterparty_channel_id: ChannelId,
+}
+
+impl TryFrom<TryObject> for OpenInit {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenInit {
+            height: obj.height,
+            port_id: attribute!(obj, "channel_open_init.port_id"),
+            connection_id: attribute!(obj, "channel_open_init.connection_id"),
+            channel_id: attribute!(obj, "channel_open_init.channel_id"),
+            counterparty_port_id: attribute!(obj, "channel_open_init.counterparty_port_id"),
+            counterparty_channel_id: attribute!(obj, "channel_open_init.counterparty_channel_id"),
+        })
+    }
+}
+
+impl From<OpenInit> for IBCEvent {
+    fn from(v: OpenInit) -> Self {
+        IBCEvent::OpenInitChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenTry {
+    pub height: block::Height,
+    pub port_id: PortId,
+    pub connection_id: ConnectionId,
+    pub channel_id: ChannelId,
+    pub counterparty_port_id: PortId,
+    pub counterparty_channel_id: ChannelId,
+}
+
+impl TryFrom<TryObject> for OpenTry {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenTry {
+            height: obj.height,
+            port_id: attribute!(obj, "channel_open_try.port_id"),
+            connection_id: attribute!(obj, "channel_open_try.connection_id"),
+            channel_id: attribute!(obj, "channel_open_try.channel_id"),
+            counterparty_port_id: attribute!(obj, "channel_open_try.counterparty_port_id"),
+            counterparty_channel_id: attribute!(obj, "channel_open_try.counterparty_channel_id"),
+        })
+    }
+}
+
+impl From<OpenTry> for IBCEvent {
+    fn from(v: OpenTry) -> Self {
+        IBCEvent::OpenTryChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenAck {
+    pub height: block::Height,
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
+}
+
+impl TryFrom<TryObject> for OpenAck {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenAck {
+            height: obj.height,
+            port_id: attribute!(obj, "channel_open_ack.port_id"),
+            channel_id: attribute!(obj, "channel_open_ack.channel_id"),
+        })
+    }
+}
+
+impl From<OpenAck> for IBCEvent {
+    fn from(v: OpenAck) -> Self {
+        IBCEvent::OpenAckChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct OpenConfirm {
+    pub height: block::Height,
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
+}
+
+impl TryFrom<TryObject> for OpenConfirm {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(OpenConfirm {
+            height: obj.height,
+            port_id: attribute!(obj, "channel_open_confirm.port_id"),
+            channel_id: attribute!(obj, "channel_open_confirm.channel_id"),
+        })
+    }
+}
+
+impl From<OpenConfirm> for IBCEvent {
+    fn from(v: OpenConfirm) -> Self {
+        IBCEvent::OpenConfirmChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CloseInit {
+    pub height: block::Height,
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
+}
+
+impl TryFrom<TryObject> for CloseInit {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(CloseInit {
+            height: obj.height,
+            port_id: attribute!(obj, "channel_close_init.port_id"),
+            channel_id: attribute!(obj, "channel_close_init.channel_id"),
+        })
+    }
+}
+
+impl From<CloseInit> for IBCEvent {
+    fn from(v: CloseInit) -> Self {
+        IBCEvent::CloseInitChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CloseConfirm {
+    pub height: block::Height,
+    pub port_id: PortId,
+    pub channel_id: ChannelId,
+}
+
+impl TryFrom<TryObject> for CloseConfirm {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(CloseConfirm {
+            height: obj.height,
+            port_id: attribute!(obj, "channel_close_confirm.port_id"),
+            channel_id: attribute!(obj, "channel_close_confirm.channel_id"),
+        })
+    }
+}
+
+impl From<CloseConfirm> for IBCEvent {
+    fn from(v: CloseConfirm) -> Self {
+        IBCEvent::CloseConfirmChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SendPacket {
+    pub height: block::Height,
+    pub packet_src_port: PortId,
+    pub packet_src_channel: ChannelId,
+    pub packet_dst_port: PortId,
+    pub packet_dst_channel: ChannelId,
+    pub packet_sequence: u64,
+    pub packet_timeout_height: u64,
+    pub packet_timeout_stamp: u64,
+}
+
+impl TryFrom<TryObject> for SendPacket {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(SendPacket {
+            height: obj.height,
+            packet_src_port: attribute!(obj, "send_packet.packet_src_port"),
+            packet_src_channel: attribute!(obj, "send_packet.packet_src_channel"),
+            packet_dst_port: attribute!(obj, "send_packet.packet_dst_port"),
+            packet_dst_channel: attribute!(obj, "send_packet.packet_dst_channel"),
+            packet_sequence: attribute!(obj, "send_packet.packet_sequence"),
+            packet_timeout_height: attribute!(obj, "send_packet.packet_timeout_height"),
+            packet_timeout_stamp: attribute!(obj, "send_packet.packet_timeout_timestamp"),
+        })
+    }
+}
+
+impl From<SendPacket> for IBCEvent {
+    fn from(v: SendPacket) -> Self {
+        IBCEvent::SendPacketChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ReceivePacket {
+    pub height: block::Height,
+    pub packet_src_port: PortId,
+    pub packet_src_channel: ChannelId,
+    pub packet_dst_port: PortId,
+    pub packet_dst_channel: ChannelId,
+    pub packet_sequence: u64,
+    pub packet_timeout_height: u64,
+    pub packet_timeout_stamp: u64,
+    pub packet_ack: String,
+}
+
+impl TryFrom<TryObject> for ReceivePacket {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(ReceivePacket {
+            height: obj.height,
+            packet_src_port: attribute!(obj, "recv_packet.packet_src_port"),
+            packet_src_channel: attribute!(obj, "recv_packet.packet_src_channel"),
+            packet_dst_port: attribute!(obj, "recv_packet.packet_dst_port"),
+            packet_dst_channel: attribute!(obj, "recv_packet.packet_dst_channel"),
+            packet_sequence: attribute!(obj, "recv_packet.packet_sequence"),
+            packet_timeout_height: attribute!(obj, "recv_packet.packet_timeout_height"),
+            packet_timeout_stamp: attribute!(obj, "recv_packet.packet_timeout_timestamp"),
+            packet_ack: attribute!(obj, "recv_packet.packet_ack"),
+        })
+    }
+}
+
+impl From<ReceivePacket> for IBCEvent {
+    fn from(v: ReceivePacket) -> Self {
+        IBCEvent::ReceivePacketChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AcknowledgePacket {
+    pub height: block::Height,
+    pub packet_src_port: PortId,
+    pub packet_src_channel: ChannelId,
+    pub packet_dst_port: PortId,
+    pub packet_dst_channel: ChannelId,
+    pub packet_sequence: u64,
+    pub packet_timeout_height: u64,
+    pub packet_timeout_stamp: u64,
+}
+
+impl TryFrom<TryObject> for AcknowledgePacket {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(AcknowledgePacket {
+            height: obj.height,
+            packet_src_port: attribute!(obj, "acknowledge_packet.packet_src_port"),
+            packet_src_channel: attribute!(obj, "acknowledge_packet.packet_src_channel"),
+            packet_dst_port: attribute!(obj, "acknowledge_packet.packet_dst_port"),
+            packet_dst_channel: attribute!(obj, "acknowledge_packet.packet_dst_channel"),
+            packet_sequence: attribute!(obj, "acknowledge_packet.packet_sequence"),
+            packet_timeout_height: attribute!(obj, "acknowledge_packet.packet_timeout_height"),
+            packet_timeout_stamp: attribute!(obj, "acknowledge_packet.packet_timeout_timestamp"),
+        })
+    }
+}
+
+impl From<AcknowledgePacket> for IBCEvent {
+    fn from(v: AcknowledgePacket) -> Self {
+        IBCEvent::AcknowledgePacketChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CleanupPacket {
+    pub height: block::Height,
+    pub packet_src_port: PortId,
+    pub packet_src_channel: ChannelId,
+    pub packet_dst_port: PortId,
+    pub packet_dst_channel: ChannelId,
+    pub packet_sequence: u64,
+    pub packet_timeout_height: u64,
+    pub packet_timeout_stamp: u64,
+}
+
+impl TryFrom<TryObject> for CleanupPacket {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(CleanupPacket {
+            height: obj.height,
+            packet_src_port: attribute!(obj, "cleanup_packet.packet_src_port"),
+            packet_src_channel: attribute!(obj, "cleanup_packet.packet_src_channel"),
+            packet_dst_port: attribute!(obj, "cleanup_packet.packet_dst_port"),
+            packet_dst_channel: attribute!(obj, "cleanup_packet.packet_dst_channel"),
+            packet_sequence: attribute!(obj, "cleanup_packet.packet_sequence"),
+            packet_timeout_height: attribute!(obj, "cleanup_packet.packet_timeout_height"),
+            packet_timeout_stamp: attribute!(obj, "cleanup_packet.packet_timeout_timestamp"),
+        })
+    }
+}
+
+impl From<CleanupPacket> for IBCEvent {
+    fn from(v: CleanupPacket) -> Self {
+        IBCEvent::CleanupPacketChannel(v)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TimeoutPacket {
+    pub height: block::Height,
+    pub packet_src_port: PortId,
+    pub packet_src_channel: ChannelId,
+    pub packet_dst_port: PortId,
+    pub packet_dst_channel: ChannelId,
+    pub packet_sequence: u64,
+    pub packet_timeout_height: u64,
+    pub packet_timeout_stamp: u64,
+}
+
+impl TryFrom<TryObject> for TimeoutPacket {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(obj: TryObject) -> Result<Self, Self::Error> {
+        Ok(TimeoutPacket {
+            height: obj.height,
+            packet_src_port: attribute!(obj, "timeout_packet.packet_src_port"),
+            packet_src_channel: attribute!(obj, "timeout_packet.packet_src_channel"),
+            packet_dst_port: attribute!(obj, "timeout_packet.packet_dst_port"),
+            packet_dst_channel: attribute!(obj, "timeout_packet.packet_dst_channel"),
+            packet_sequence: attribute!(obj, "timeout_packet.packet_sequence"),
+            packet_timeout_height: attribute!(obj, "timeout_packet.packet_timeout_height"),
+            packet_timeout_stamp: attribute!(obj, "timeout_packet.packet_timeout_timestamp"),
+        })
+    }
+}
+
+impl From<TimeoutPacket> for IBCEvent {
+    fn from(v: TimeoutPacket) -> Self {
+        IBCEvent::TimeoutPacketChannel(v)
+    }
+}

--- a/modules/src/ics04_channel/mod.rs
+++ b/modules/src/ics04_channel/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod channel;
 pub mod error;
+pub mod events;
 pub mod exported;
 pub mod msgs;
 pub mod query;

--- a/modules/src/ics20_fungible_token_transfer/events.rs
+++ b/modules/src/ics20_fungible_token_transfer/events.rs
@@ -1,0 +1,26 @@
+use crate::events::{IBCEvent, TryObject};
+use crate::make_event;
+use serde_derive::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+// TODO - extract attributes
+make_event!(Timeout, "timeout");
+make_event!(Packet, "transfer");
+make_event!(ChannelClosed, "channel_closed");
+
+impl From<ChannelClosed> for IBCEvent {
+    fn from(v: ChannelClosed) -> Self {
+        IBCEvent::ChannelClosedTransfer(v)
+    }
+}
+
+impl From<Packet> for IBCEvent {
+    fn from(v: Packet) -> Self {
+        IBCEvent::PacketTransfer(v)
+    }
+}
+impl From<Timeout> for IBCEvent {
+    fn from(v: Timeout) -> Self {
+        IBCEvent::TimeoutTransfer(v)
+    }
+}

--- a/modules/src/ics20_fungible_token_transfer/mod.rs
+++ b/modules/src/ics20_fungible_token_transfer/mod.rs
@@ -1,0 +1,2 @@
+//! ICS 20: IBC Transfer implementation
+pub mod events;

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -24,11 +24,14 @@ pub mod ics02_client;
 pub mod ics03_connection;
 pub mod ics04_channel;
 pub mod ics07_tendermint;
+pub mod ics20_fungible_token_transfer;
 pub mod ics23_commitment;
 pub mod ics24_host;
 pub mod keys;
 pub mod path;
 pub mod query;
+#[macro_use]
+pub mod events;
 
 /// Height of a block, same as in `tendermint` crate
 pub type Height = tendermint::lite::Height;

--- a/relayer/cli/Cargo.toml
+++ b/relayer/cli/Cargo.toml
@@ -10,16 +10,17 @@ authors = [
 [dependencies]
 relayer = { path = "../relay" }
 relayer-modules = { path = "../../modules" }
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
+tendermint = { path = "/Users/ancaz/rust/tendermint-rs/tendermint"}
 
 abscissa_tokio = "0.5.1"
 anomaly = "0.2.0"
 gumdrop = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
-tokio = { version = "0.2.13", features = ["rt-util"] }
+tokio = { version = "0.2.13", features = ["rt-util", "sync"] }
 tracing = "0.1.13"
 tracing-subscriber = "0.2.3"
+futures = "0.3.5"
 
 [dependencies.abscissa_core]
 version = "0.5.2"

--- a/relayer/cli/src/commands/start.rs
+++ b/relayer/cli/src/commands/start.rs
@@ -13,7 +13,16 @@ use relayer::chain::tendermint::TendermintChain;
 use relayer::chain::Chain;
 use relayer::client::Client;
 use relayer::config::ChainConfig;
+use relayer::event_handler::*;
+use relayer::event_monitor::*;
+
 use relayer::store::Store;
+use std::process;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+use ::tendermint::chain::Id as ChainId;
+use futures::future::join_all;
+use relayer_modules::events::IBCEvent;
 
 #[derive(Command, Debug, Options)]
 pub struct StartCmd {
@@ -36,15 +45,45 @@ impl Runnable for StartCmd {
         let local = tokio::task::LocalSet::new();
 
         block_on(local.run_until(async move {
-            for chain_config in config.chains {
+            for chain_config in &config.chains {
                 info!(chain.id = %chain_config.id, "spawning light client");
-                tokio::task::spawn_local(spawn_client(chain_config, self.reset));
+                tokio::task::spawn_local(spawn_client(chain_config.clone(), self.reset));
             }
 
-            info!("starting relayer");
-            relayer_task().await
-        }));
+            let (tx, rx) = channel(100);
+            let mut all_futures = Vec::new();
+            for chain_config in &config.chains {
+                info!(chain.id = % chain_config.id, "spawning event monitor for");
+                let mut event_monitor = init_monitor(chain_config.clone(), tx.clone()).await;
+                let m_handle = tokio::spawn(async move { event_monitor.run().await });
+                all_futures.push(m_handle);
+            }
+
+            info!("spawning main event handler");
+            let mut event_handler = init_event_handler(rx).await;
+            let r_handle = tokio::spawn(async move { event_handler.run().await });
+
+            all_futures.push(r_handle);
+            let _res = join_all(all_futures).await;
+        }))
     }
+}
+
+async fn init_monitor(
+    chain_config: ChainConfig,
+    tx: Sender<(ChainId, Vec<IBCEvent>)>,
+) -> EventMonitor {
+    EventMonitor::create(chain_config.id, chain_config.rpc_addr.clone(), tx)
+        .await
+        .unwrap_or_else(|e| {
+            status_err!("couldn't initialize event monitor: {}", e);
+            process::exit(1);
+        })
+}
+
+async fn init_event_handler(rx: Receiver<(ChainId, Vec<IBCEvent>)>) -> EventHandler {
+    let event_reporter = EventHandler::new(rx);
+    event_reporter
 }
 
 async fn spawn_client(chain_config: ChainConfig, reset: bool) {
@@ -73,14 +112,14 @@ async fn client_task(client: Client<TendermintChain, impl Store<TendermintChain>
     update_client(client).await;
 }
 
-async fn relayer_task() {
-    let mut interval = tokio::time::interval(Duration::from_secs(3));
-
-    loop {
-        info!(target: "relayer_cli::relayer", "relayer is running");
-        interval.tick().await;
-    }
-}
+//async fn relayer_task(config: Config) {
+//    let mut interval = tokio::time::interval(config.global.timeout);
+//
+//    loop {
+//        info!(target: "relayer_cli::relayer", "relayer is running");
+//        interval.tick().await;
+//    }
+//}
 
 async fn update_client<C: Chain, S: Store<C>>(mut client: Client<C, S>) {
     debug!(chain.id = %client.chain().id(), "updating headers");

--- a/relayer/relay/Cargo.toml
+++ b/relayer/relay/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 
 [dependencies]
 relayer-modules = { path = "../../modules" }
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
+tendermint = { path = "/Users/ancaz/rust/tendermint-rs/tendermint"}
 anomaly = "0.2.0"
 async-trait = "0.1.24"
 humantime-serde = "1.0.0"
@@ -20,6 +20,7 @@ sled = { version = "0.31.0", features = ["no_metrics", "no_logs"] }
 thiserror = "1.0.11"
 toml = "0.5"
 tracing = "0.1.13"
+tokio = "0.2"
+serde_json = { version = "1" }
 
 [dev-dependencies]
-tokio = { version = "0.2.13", features = ["macros"] }

--- a/relayer/relay/src/event_handler.rs
+++ b/relayer/relay/src/event_handler.rs
@@ -1,0 +1,37 @@
+use relayer_modules::events::IBCEvent;
+use tokio::sync::mpsc::Receiver;
+
+use ::tendermint::chain::Id as ChainId;
+use tracing::{debug, info};
+
+/// The Event Handler handles IBC events from the monitors.
+pub struct EventHandler {
+    channel_from_monitors: Receiver<(ChainId, Vec<IBCEvent>)>,
+}
+
+impl EventHandler {
+    /// Constructor for the Event Handler
+    pub fn new(channel_from_monitors: Receiver<(ChainId, Vec<IBCEvent>)>) -> Self {
+        Self { channel_from_monitors }
+    }
+
+    ///Event Handler loop
+    pub async fn run(&mut self) {
+        info!("running IBC Event Handler");
+
+        loop {
+            match self.channel_from_monitors.recv().await {
+                Some(events) => {
+                    for event in events.1 {
+                        self.handle(events.0, event);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn handle(&self, id: ChainId, event: IBCEvent) {
+        debug!("Relayer handle event from {}: {}", id, event.to_json());
+    }
+}

--- a/relayer/relay/src/event_monitor.rs
+++ b/relayer/relay/src/event_monitor.rs
@@ -1,0 +1,96 @@
+use relayer_modules::events::IBCEvent;
+use tendermint::rpc::event_listener::EventSubscription;
+use tendermint::{net, rpc::event_listener, Error as TMError};
+use tokio::sync::mpsc::Sender;
+
+use ::tendermint::chain::Id as ChainId;
+use tracing::{debug, info};
+
+/// Connect to a TM node, receive push events over a websocket and filter them for the
+/// event handler.
+pub struct EventMonitor {
+    chain_id: ChainId,
+    /// Websocket to collect events from
+    event_listener: event_listener::EventListener,
+    /// Channel to handler where the monitor for this chain sends the events
+    channel_to_handler: Sender<(ChainId, Vec<IBCEvent>)>,
+    /// Node Address
+    node_addr: net::Address,
+    /// Queries
+    event_queries: Vec<EventSubscription>,
+}
+
+impl EventMonitor {
+    /// Create an event monitor, connect to a node and subscribe to queries.
+    pub async fn create(
+        chain_id: ChainId,
+        rpc_addr: net::Address,
+        channel_to_handler: Sender<(ChainId, Vec<IBCEvent>)>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut event_listener = event_listener::EventListener::connect(rpc_addr.clone()).await?;
+        // TODO move them to config file(?)
+        let event_queries = vec![
+            EventSubscription::TransactionSubscription,
+            EventSubscription::BlockSubscription,
+        ];
+        for query in event_queries.clone() {
+            event_listener.subscribe(query.clone()).await?;
+        }
+        Ok(EventMonitor {
+            chain_id,
+            event_listener,
+            channel_to_handler,
+            node_addr: rpc_addr.clone(),
+            event_queries: event_queries,
+        })
+    }
+
+    /// Event monitor loop
+    pub async fn run(&mut self) {
+        info!(chain.id = % self.chain_id, "running listener for");
+
+        loop {
+            match self.collect_events().await {
+                Ok(..) => continue,
+                Err(err) => {
+                    debug!("Web socket error: {}", err);
+                    // Try to reconnect
+                    match event_listener::EventListener::connect(self.node_addr.clone()).await {
+                        Ok(event_listener) => {
+                            debug!("Reconnected");
+                            self.event_listener = event_listener;
+                            for query in &self.event_queries {
+                                match self.event_listener.subscribe((*query).clone()).await {
+                                    Ok(..) => continue,
+                                    Err(err) => {
+                                        debug!("Error on recreating subscriptions {}", err);
+                                        panic!("Abort during reconnection");
+                                    }
+                                };
+                            }
+                        }
+                        Err(err) => {
+                            debug!("Error on reconnection {}", err);
+                            panic!("Abort on failed reconnection")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// get a TM event and extract the IBC events
+    pub async fn collect_events(&mut self) -> Result<(), TMError> {
+        match self.event_listener.get_event().await? {
+            Some(tm_event) => match relayer_modules::events::get_all_events(tm_event) {
+                Ok(ibc_events) => {
+                    // TODO - send_timeout()?
+                    self.channel_to_handler.send((self.chain_id, ibc_events)).await?;
+                }
+                _ => {}
+            },
+            None => {}
+        }
+        Ok(())
+    }
+}

--- a/relayer/relay/src/lib.rs
+++ b/relayer/relay/src/lib.rs
@@ -15,6 +15,8 @@ pub mod chain;
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod event_handler;
+pub mod event_monitor;
 pub mod query;
 pub mod store;
 pub mod util;


### PR DESCRIPTION

Closes: #87

## Description
Starting with https://github.com/informalsystems/ibc-rs/pull/59 as base, extract attributes specific to IBC events.
Add monitor tasks, one per chain, that register for Tx and Block events with tendermint nodes. 
Push the IBC events to the main handler task.

There are a few things to clarify:
- can the IBC events be determined from "message.action" list? or a try for all possible events is needed (see https://github.com/cosmos/cosmos-sdk/issues/6358)
- need access to `TMEventData::EventDataNewBlock()` that is an Option; need to extract block height. I had to change tendermint for this. 
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
