### PR TITLE
Fix client-ids in OpenInit and OpenTry for connection

### DIFF
--- a/modules/src/ics03_connection/events.rs
+++ b/modules/src/ics03_connection/events.rs
@@ -21,8 +21,8 @@ impl TryFrom<RawObject> for OpenInit {
         Ok(OpenInit {
             height: obj.height,
             connection_id: attribute!(obj, "connection_open_init.connection_id"),
-            client_id: attribute!(obj, "connection_open_init.counterparty_client_id"),
-            counterparty_client_id: attribute!(obj, "connection_open_init.client_id"),
+            client_id: attribute!(obj, "connection_open_init.client_id"),
+            counterparty_client_id: attribute!(obj, "connection_open_init.counterparty_client_id"),
         })
     }
 }
@@ -47,8 +47,8 @@ impl TryFrom<RawObject> for OpenTry {
         Ok(OpenTry {
             height: obj.height,
             connection_id: attribute!(obj, "connection_open_try.connection_id"),
-            client_id: attribute!(obj, "connection_open_try.counterparty_client_id"),
-            counterparty_client_id: attribute!(obj, "connection_open_try.client_id"),
+            client_id: attribute!(obj, "connection_open_try.client_id"),
+            counterparty_client_id: attribute!(obj, "connection_open_try.counterparty_client_id"),
         })
     }
 }


### PR DESCRIPTION
Closes: #103

## Description
Small bug in client_id attributes for `OpenInit` and `OpenTry` connection events.


______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
