### PR TITLE
Fixes for tendermint rpc refactored in its own crate (#113)

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -18,6 +18,7 @@ paths-ics = []
 
 [dependencies]
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", path = "/rpc", features=["client"] }
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -8,7 +8,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use tendermint::block;
-use tendermint::rpc::event_listener::{ResultEvent, TMEventData};
+use tendermint_rpc::client::event_listener::{ResultEvent, TMEventData};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum IBCEvent {

--- a/modules/src/ics02_client/query.rs
+++ b/modules/src/ics02_client/query.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use tendermint::abci;
 

--- a/modules/src/ics03_connection/query.rs
+++ b/modules/src/ics03_connection/query.rs
@@ -1,4 +1,4 @@
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use tendermint::abci;
 

--- a/modules/src/ics04_channel/query.rs
+++ b/modules/src/ics04_channel/query.rs
@@ -1,4 +1,4 @@
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use tendermint::abci;
 

--- a/modules/src/query.rs
+++ b/modules/src/query.rs
@@ -1,5 +1,5 @@
 use tendermint::abci;
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use crate::error;
 use crate::Height;


### PR DESCRIPTION
Closes: #113 

## Description

Added a new dependency for the 'tendermint-rpc' crate. Fixed the dependency path (from tendermint::rpc to tendermint_rpc).

Opening this as a draft PR since it's still not compiling because the 'client' module is not public in tendermint-rs so this build is failing. Need to make ['client' module in tendermint-rs public](https://github.com/informalsystems/tendermint-rs/blob/81f7eb3aac9aac24ac83a02ba7e91ac477bf57fc/rpc/src/lib.rs). 
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
