### PR TITLE
Adapt code to use new tendermint_rpc crate

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -18,6 +18,7 @@ paths-ics = []
 
 [dependencies]
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", path = "/rpc", features=["client"] }
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -8,7 +8,8 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use tendermint::block;
-use tendermint::rpc::event_listener::{ResultEvent, TMEventData};
+
+use tendermint_rpc::event_listener::{ResultEvent, TMEventData};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum IBCEvent {

--- a/modules/src/ics02_client/query.rs
+++ b/modules/src/ics02_client/query.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use tendermint::abci;
 

--- a/modules/src/ics03_connection/query.rs
+++ b/modules/src/ics03_connection/query.rs
@@ -1,4 +1,4 @@
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use tendermint::abci;
 

--- a/modules/src/ics04_channel/query.rs
+++ b/modules/src/ics04_channel/query.rs
@@ -1,4 +1,4 @@
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use tendermint::abci;
 

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -64,7 +64,7 @@ impl crate::ics02_client::state::ClientState for ClientState {
 #[cfg(test)]
 mod tests {
     use crate::test::test_serialization_roundtrip;
-    use tendermint::rpc::endpoint::abci_query::AbciQuery;
+    use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
     #[test]
     fn serialization_roundtrip_no_proof() {

--- a/modules/src/ics07_tendermint/consensus_state.rs
+++ b/modules/src/ics07_tendermint/consensus_state.rs
@@ -50,7 +50,7 @@ impl crate::ics02_client::state::ConsensusState for ConsensusState {
 #[cfg(test)]
 mod tests {
     use crate::test::test_serialization_roundtrip;
-    use tendermint::rpc::endpoint::abci_query::AbciQuery;
+    use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
     #[test]
     fn serialization_roundtrip_no_proof() {

--- a/modules/src/query.rs
+++ b/modules/src/query.rs
@@ -1,5 +1,5 @@
 use tendermint::abci;
-use tendermint::rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 use crate::error;
 use crate::Height;

--- a/relayer/relay/Cargo.toml
+++ b/relayer/relay/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 [dependencies]
 relayer-modules = { path = "../../modules" }
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", path = "/rpc", features=["client"] }
 anomaly = "0.2.0"
 async-trait = "0.1.24"
 humantime-serde = "1.0.0"

--- a/relayer/relay/src/chain.rs
+++ b/relayer/relay/src/chain.rs
@@ -6,7 +6,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use ::tendermint::chain::Id as ChainId;
 use ::tendermint::lite::types as tmlite;
 use ::tendermint::lite::{self, Height, TrustThresholdFraction};
-use ::tendermint::rpc::Client as RpcClient;
+use ::tendermint_rpc::Client as RpcClient;
 
 use relayer_modules::ics02_client::state::{ClientState, ConsensusState};
 

--- a/relayer/relay/src/chain/tendermint.rs
+++ b/relayer/relay/src/chain/tendermint.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tendermint::block::signed_header::SignedHeader as TMCommit;
 use tendermint::block::Header as TMHeader;
 use tendermint::lite::TrustThresholdFraction;
-use tendermint::rpc::Client as RpcClient;
+use tendermint_rpc::Client as RpcClient;
 
 use relayer_modules::ics07_tendermint::client_state::ClientState;
 use relayer_modules::ics07_tendermint::consensus_state::ConsensusState;

--- a/relayer/relay/src/client/rpc_requester.rs
+++ b/relayer/relay/src/client/rpc_requester.rs
@@ -3,10 +3,10 @@ use async_trait::async_trait;
 use tendermint::block::signed_header::SignedHeader as TMCommit;
 use tendermint::block::Header as TMHeader;
 use tendermint::lite::{error, Height, SignedHeader};
-use tendermint_rpc as rpc;
 use tendermint::validator;
 use tendermint::validator::Set;
 use tendermint::{block, lite};
+use tendermint_rpc as rpc;
 
 /// RpcRequester wraps the Tendermint rpc::Client to provide
 /// a slightly higher-level API to fetch signed headers

--- a/relayer/relay/src/client/rpc_requester.rs
+++ b/relayer/relay/src/client/rpc_requester.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use tendermint::block::signed_header::SignedHeader as TMCommit;
 use tendermint::block::Header as TMHeader;
 use tendermint::lite::{error, Height, SignedHeader};
-use tendermint::rpc;
+use tendermint_rpc as rpc;
 use tendermint::validator;
 use tendermint::validator::Set;
 use tendermint::{block, lite};
@@ -56,7 +56,6 @@ mod tests {
     use tendermint::lite::types::Header as LiteHeader;
     use tendermint::lite::types::Requester as LiteRequester;
     use tendermint::lite::types::ValidatorSet as LiteValSet;
-    use tendermint::rpc;
 
     // TODO: integration test
     #[ignore]

--- a/relayer/relay/src/event_monitor.rs
+++ b/relayer/relay/src/event_monitor.rs
@@ -1,6 +1,6 @@
 use relayer_modules::events::IBCEvent;
-use tendermint::rpc::event_listener::EventSubscription;
-use tendermint::{net, rpc::event_listener, Error as TMError};
+use tendermint_rpc::{event_listener, event_listener::EventSubscription};
+use tendermint::{net, Error as TMError};
 use tokio::sync::mpsc::Sender;
 
 use ::tendermint::chain::Id as ChainId;

--- a/relayer/relay/src/event_monitor.rs
+++ b/relayer/relay/src/event_monitor.rs
@@ -1,6 +1,6 @@
 use relayer_modules::events::IBCEvent;
-use tendermint_rpc::{event_listener, event_listener::EventSubscription};
 use tendermint::{net, Error as TMError};
+use tendermint_rpc::{event_listener, event_listener::EventSubscription};
 use tokio::sync::mpsc::Sender;
 
 use ::tendermint::chain::Id as ChainId;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #113

## Description

see #115 
This fixes all remaining issues described there by not trying to access (the non-public) client module but the reexported and required parts only.

______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
