### PR TITLE
Fix nightly runs

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -18,7 +18,7 @@ paths-ics = []
 
 [dependencies]
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
-tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", features=["client"] }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master", features=["client"] }
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = "0.1.0"

--- a/relayer/relay/Cargo.toml
+++ b/relayer/relay/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 [dependencies]
 relayer-modules = { path = "../../modules" }
 tendermint = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master" }
-tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", features=["client"] }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs.git", branch = "master", features=["client"] }
 anomaly = "0.2.0"
 async-trait = "0.1.24"
 humantime-serde = "1.0.0"


### PR DESCRIPTION
Closes: #135

## Description
After taking out a lot of the code that were creating errors, the final issue boiled down to Cargo somehow not understanding that tendermint-rpc should come from the same master branch as tendermint is coming from. Explicit indication fixed nightly.
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
