### PR TITLE
Rename TendermintChain to CosmosSDKChain

### DIFF
--- a/relayer/cli/src/commands/light/init.rs
+++ b/relayer/cli/src/commands/light/init.rs
@@ -9,7 +9,7 @@ use tendermint::chain::Id as ChainId;
 use tendermint::hash::Hash;
 use tendermint::lite::Height;
 
-use relayer::chain::tendermint::TendermintChain;
+use relayer::chain::CosmosSDKChain;
 use relayer::client::trust_options::TrustOptions;
 use relayer::config::{ChainConfig, Config};
 use relayer::store::{sled::SledStore, Store};
@@ -93,7 +93,7 @@ impl Runnable for InitCmd {
             )
             .unwrap();
 
-            let mut store: SledStore<TendermintChain> =
+            let mut store: SledStore<CosmosSDKChain> =
                 relayer::store::persistent(format!("store_{}.db", chain_config.id)).unwrap(); // FIXME: unwrap
 
             store.set_trust_options(trust_options).unwrap(); // FIXME: unwrap

--- a/relayer/cli/src/commands/query/channel.rs
+++ b/relayer/cli/src/commands/query/channel.rs
@@ -7,8 +7,7 @@ use relayer_modules::ics04_channel::channel::ChannelEnd;
 use relayer_modules::ics24_host::identifier::{ChannelId, PortId};
 use relayer_modules::ics24_host::Path::ChannelEnds;
 
-use relayer::chain::tendermint::TendermintChain;
-use relayer::chain::Chain;
+use relayer::chain::{Chain, CosmosSDKChain};
 use relayer_modules::ics24_host::error::ValidationError;
 use tendermint::chain::Id as ChainId;
 
@@ -97,7 +96,7 @@ impl Runnable for QueryChannelEndCmd {
 
         // run without proof:
         // cargo run --bin relayer -- -c relayer/relay/tests/config/fixtures/simple_config.toml query channel end ibc-test firstport firstchannel --height 3 -p false
-        let chain = TendermintChain::from_config(chain_config).unwrap();
+        let chain = CosmosSDKChain::from_config(chain_config).unwrap();
         let res = chain.query::<ChannelEnd>(
             ChannelEnds(opts.port_id, opts.channel_id),
             opts.height,

--- a/relayer/cli/src/commands/query/client.rs
+++ b/relayer/cli/src/commands/query/client.rs
@@ -9,7 +9,7 @@ use relayer::config::{ChainConfig, Config};
 use relayer_modules::ics24_host::identifier::ClientId;
 
 //use crate::commands::utils::block_on;
-use relayer::chain::tendermint::TendermintChain;
+use relayer::chain::CosmosSDKChain;
 use relayer_modules::ics24_host::error::ValidationError;
 use tendermint::chain::Id as ChainId;
 
@@ -79,7 +79,7 @@ impl Runnable for QueryClientStateCmd {
         //
         // Note: currently both fail in amino_unmarshal_binary_length_prefixed().
         // To test this start a Gaia node and configure a client using the go relayer.
-        let _chain = TendermintChain::from_config(chain_config).unwrap();
+        let _chain = CosmosSDKChain::from_config(chain_config).unwrap();
         /* Todo: Implement client full state query
         let res = block_on(query_client_full_state(
             &chain,
@@ -171,7 +171,7 @@ impl Runnable for QueryClientConsensusCmd {
         //
         // Note: currently both fail in amino_unmarshal_binary_length_prefixed().
         // To test this start a Gaia node and configure a client using the go relayer.
-        let _chain = TendermintChain::from_config(chain_config).unwrap();
+        let _chain = CosmosSDKChain::from_config(chain_config).unwrap();
         /* Todo: Implement client consensus state query
         let res = block_on(query_client_consensus_state(
             &chain,

--- a/relayer/cli/src/commands/query/connection.rs
+++ b/relayer/cli/src/commands/query/connection.rs
@@ -3,8 +3,7 @@ use crate::prelude::*;
 use abscissa_core::{Command, Options, Runnable};
 use relayer::config::{ChainConfig, Config};
 
-use relayer::chain::tendermint::TendermintChain;
-use relayer::chain::Chain;
+use relayer::chain::{Chain, CosmosSDKChain};
 use relayer_modules::ics24_host::error::ValidationError;
 use relayer_modules::ics24_host::identifier::ConnectionId;
 use relayer_modules::ics24_host::Path::Connections;
@@ -83,7 +82,7 @@ impl Runnable for QueryConnectionEndCmd {
         };
         status_info!("Options", "{:?}", opts);
 
-        let chain = TendermintChain::from_config(chain_config).unwrap();
+        let chain = CosmosSDKChain::from_config(chain_config).unwrap();
         // run without proof:
         // cargo run --bin relayer -- -c relayer/relay/tests/config/fixtures/simple_config.toml query connection end ibc-test connectionidone --height 3 -p false
         let res =

--- a/relayer/cli/src/commands/start.rs
+++ b/relayer/cli/src/commands/start.rs
@@ -9,8 +9,7 @@ use abscissa_core::{Command, Options, Runnable};
 use tendermint::lite::types::Header;
 
 use crate::commands::utils::block_on;
-use relayer::chain::tendermint::TendermintChain;
-use relayer::chain::Chain;
+use relayer::chain::{Chain, CosmosSDKChain};
 use relayer::client::Client;
 use relayer::config::ChainConfig;
 
@@ -62,7 +61,7 @@ async fn spawn_client(chain_config: ChainConfig, reset: bool) {
         .expect("could not spawn client task")
 }
 
-async fn client_task(client: Client<TendermintChain, impl Store<TendermintChain>>) {
+async fn client_task(client: Client<CosmosSDKChain, impl Store<CosmosSDKChain>>) {
     let trusted_state = client.last_trusted_state().unwrap();
 
     status_ok!(
@@ -108,9 +107,9 @@ async fn update_client<C: Chain, S: Store<C>>(mut client: Client<C, S>) {
 async fn create_client(
     chain_config: ChainConfig,
     reset: bool,
-) -> Client<TendermintChain, impl Store<TendermintChain>> {
+) -> Client<CosmosSDKChain, impl Store<CosmosSDKChain>> {
     let id = chain_config.id;
-    let chain = TendermintChain::from_config(chain_config).unwrap();
+    let chain = CosmosSDKChain::from_config(chain_config).unwrap();
 
     let store = relayer::store::persistent(format!("store_{}.db", chain.id())).unwrap(); //FIXME: unwrap
     let trust_options = store.get_trust_options().unwrap(); // FIXME: unwrap

--- a/relayer/relay/src/chain.rs
+++ b/relayer/relay/src/chain.rs
@@ -16,7 +16,8 @@ use crate::config::ChainConfig;
 use crate::error;
 use std::error::Error;
 
-pub mod tendermint;
+mod cosmos;
+pub use cosmos::CosmosSDKChain;
 
 /// Handy type alias for the type of validator set associated with a chain
 pub type ValidatorSet<Chain> = <<Chain as self::Chain>::Commit as tmlite::Commit>::ValidatorSet;

--- a/relayer/relay/src/chain/cosmos.rs
+++ b/relayer/relay/src/chain/cosmos.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tendermint::abci::Path as TendermintPath;
+use tendermint::abci::Path as TendermintABCIPath;
 use tendermint::block::signed_header::SignedHeader as TMCommit;
 use tendermint::block::Header as TMHeader;
 use tendermint::block::Height;

--- a/relayer/relay/src/chain/cosmos.rs
+++ b/relayer/relay/src/chain/cosmos.rs
@@ -54,7 +54,7 @@ impl Chain for CosmosSDKChain {
     where
         T: TryFromRaw,
     {
-        let path = TendermintPath::from_str(IBC_QUERY_PATH).unwrap();
+        let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).unwrap();
         if !data.is_provable() & prove {
             return Err(Kind::Store
                 .context("requested proof for privateStore path")
@@ -97,7 +97,7 @@ impl Chain for CosmosSDKChain {
 /// Perform a generic `abci_query`, and return the corresponding deserialized response data.
 async fn abci_query(
     chain: &CosmosSDKChain,
-    path: TendermintPath,
+    path: TendermintABCIPath,
     data: String,
     height: u64,
     prove: bool,

--- a/relayer/relay/src/chain/cosmos.rs
+++ b/relayer/relay/src/chain/cosmos.rs
@@ -22,13 +22,13 @@ use bytes::Bytes;
 use prost::Message;
 use std::str::FromStr;
 
-pub struct TendermintChain {
+pub struct CosmosSDKChain {
     config: ChainConfig,
     rpc_client: RpcClient,
     requester: RpcRequester,
 }
 
-impl TendermintChain {
+impl CosmosSDKChain {
     pub fn from_config(config: ChainConfig) -> Result<Self, Error> {
         // TODO: Derive Clone on RpcClient in tendermint-rs
         let requester = RpcRequester::new(RpcClient::new(config.rpc_addr.clone()));
@@ -42,7 +42,7 @@ impl TendermintChain {
     }
 }
 
-impl Chain for TendermintChain {
+impl Chain for CosmosSDKChain {
     type Header = TMHeader;
     type Commit = TMCommit;
     type ConsensusState = ConsensusState;
@@ -96,7 +96,7 @@ impl Chain for TendermintChain {
 
 /// Perform a generic `abci_query`, and return the corresponding deserialized response data.
 async fn abci_query(
-    chain: &TendermintChain,
+    chain: &CosmosSDKChain,
     path: TendermintPath,
     data: String,
     height: u64,


### PR DESCRIPTION
Closes: #176 

## Description
* Rename the `TendermintChain` struct into `CosmosSDKChain`
* Rename the `tendermint.rs` file implementing the chain to `cosmos.rs`
* hide the non-useful new `cosmos.rs` file from the exports and export the Chain directly as a feature of the `chain.rs` lib (so, you can import it with `use relayer::chain::CosmosSDKChain` instead of the longer and not too informative `use relayer::chain::cosmos::CosmosSDKChain`.)

This last one is highlighted because I don't see it too much in the code and I don't want people to get confused about it.
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
