### PR TITLE
Replaced Vec<String> with Vec<ConnectionId>

### DIFF
--- a/modules/src/ics02_client/client.rs
+++ b/modules/src/ics02_client/client.rs
@@ -1,5 +1,7 @@
 use crate::ics03_connection::error::Kind;
+use crate::ics24_host::identifier::ConnectionId;
 use crate::try_from_raw::TryFromRaw;
+use std::str::FromStr;
 
 //TODO: This might need to be migrated to ibc-proto crate. But ClientConnections (as array of strings)
 // might not be part of an official proto file
@@ -9,12 +11,20 @@ pub struct RawClientConnections {
     pub connections: ::std::vec::Vec<String>,
 }
 
-impl TryFromRaw for Vec<String> {
+impl TryFromRaw for Vec<ConnectionId> {
     type RawType = RawClientConnections;
     type Error = anomaly::Error<Kind>;
     fn try_from(value: RawClientConnections) -> Result<Self, Self::Error> {
         if !value.connections.is_empty() {
-            Ok(value.connections)
+            let mut connections: Vec<ConnectionId> = vec![];
+            for value in value.connections {
+                let conn_id = ConnectionId::from_str(&value.replace("connections/", ""));
+                match conn_id {
+                    Ok(c) => connections.push(c),
+                    Err(_e) => return Err(Kind::IdentifierError.into()),
+                }
+            }
+            Ok(connections)
         } else {
             Err(Kind::ConnectionNotFound.into())
         }

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -4,7 +4,7 @@ use abscissa_core::{Command, Options, Runnable};
 use relayer::config::{ChainConfig, Config};
 
 use modules::ics24_host::error::ValidationError;
-use modules::ics24_host::identifier::ClientId;
+use modules::ics24_host::identifier::{ClientId, ConnectionId};
 use modules::ics24_host::Path::ClientConnections;
 use relayer::chain::Chain;
 use relayer::chain::CosmosSDKChain;
@@ -274,7 +274,7 @@ impl QueryClientConnectionsCmd {
 
 /// Command to handle query for client connections
 /// To run without proof:
-/// cargo run --bin relayer -- -c relayer/tests/config/fixtures/relayer_conf_example.toml query client connections chain_A clientidone -h 4 -p false
+/// relayer -c relayer/tests/config/fixtures/relayer_conf_example.toml query client connections chain_A clientidone -h 4 -p false
 impl Runnable for QueryClientConnectionsCmd {
     fn run(&self) {
         let config = app_config();
@@ -289,8 +289,11 @@ impl Runnable for QueryClientConnectionsCmd {
         status_info!("Options", "{:?}", opts);
 
         let chain = CosmosSDKChain::from_config(chain_config).unwrap();
-        let res =
-            chain.query::<Vec<String>>(ClientConnections(opts.client_id), opts.height, opts.proof);
+        let res = chain.query::<Vec<ConnectionId>>(
+            ClientConnections(opts.client_id),
+            opts.height,
+            opts.proof,
+        );
         match res {
             Ok(cs) => status_info!("client connections query result: ", "{:?}", cs),
             Err(e) => status_info!("client connections query error", "{}", e),

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -4,7 +4,7 @@ use abscissa_core::{Command, Options, Runnable};
 use relayer::config::{ChainConfig, Config};
 
 use ibc::ics24_host::error::ValidationError;
-use ibc::ics24_host::identifier::ClientId;
+use ibc::ics24_host::identifier::{ClientId, ConnectionId};
 use ibc::ics24_host::Path::ClientConnections;
 use relayer::chain::Chain;
 use relayer::chain::CosmosSDKChain;

--- a/relayer-cli/tests/integration.rs
+++ b/relayer-cli/tests/integration.rs
@@ -112,5 +112,8 @@ fn query_client_id() {
         )
         .unwrap();
 
-    assert_eq!(query[0], ConnectionId::from_str("connections/connectionidone").unwrap());
+    assert_eq!(
+        query[0],
+        ConnectionId::from_str("connections/connectionidone").unwrap()
+    );
 }

--- a/relayer-cli/tests/integration.rs
+++ b/relayer-cli/tests/integration.rs
@@ -105,12 +105,12 @@ fn query_channel_id() {
 fn query_client_id() {
     let chain = simd_chain();
     let query = chain
-        .query::<Vec<String>>(
+        .query::<Vec<ConnectionId>>(
             ClientConnections(ClientId::from_str("clientidone").unwrap()),
             0,
             false,
         )
         .unwrap();
 
-    assert_eq!(query[0], "connections/connectionidone");
+    assert_eq!(query[0], ConnectionId::from_str("connections/connectionidone").unwrap());
 }


### PR DESCRIPTION
Closes: #185

## Description

Refactored the response for the query client connections to return a collection of ConnectionId. Better than just a string collection.
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [X] Re-reviewed `Files changed` in the Github PR explorer
