### PR TITLE
Cleanup Any* wrappers related code

### DIFF
--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -189,8 +189,6 @@ impl ClientDef for AnyClient {
         client_state: AnyClientState,
         header: AnyHeader,
     ) -> Result<(AnyClientState, AnyConsensusState), Box<dyn std::error::Error>> {
-        // We have to split and nest the following match because patterns containing
-        // both by-move and by-ref bindings are still unstable (feature: move_ref_pattern).
         match self {
             Self::Tendermint(client) => {
                 let (client_state, header) = downcast!(

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -176,6 +176,7 @@ impl AnyClient {
     }
 }
 
+// /!\ Beware of the awful boilerplate below /!\
 impl ClientDef for AnyClient {
     type Header = AnyHeader;
     type ClientState = AnyClientState;
@@ -186,8 +187,8 @@ impl ClientDef for AnyClient {
         client_state: AnyClientState,
         header: AnyHeader,
     ) -> Result<(AnyClientState, AnyConsensusState), Box<dyn std::error::Error>> {
-        // We have to split and nest the following match because one cannot
-        // bind patterns both by-move and by-ref within the same pattern.
+        // We have to split and nest the following match because patterns containing
+        // both by-move and by-ref bindings are still unstable (feature: move_ref_pattern).
         match self {
             Self::Tendermint(client) => match (client_state, header) {
                 (AnyClientState::Tendermint(client_state), AnyHeader::Tendermint(header)) => {
@@ -262,8 +263,9 @@ impl ClientDef for AnyClient {
                 expected_consensus_state,
             ),
 
-            // The compiler is confused, and this pattern is actually reachable
-            #[allow(unreachable_patterns)]
+            // We need to tell the compiler that this pattern is currently reachable in test mode,
+            // and will be actually reachable when we add more client types.
+            #[cfg_attr(not(test), allow(unreachable_patterns))]
             _ => panic!("Type mismatch between client and arguments: {:?}", self),
         }
     }
@@ -299,8 +301,9 @@ impl ClientDef for AnyClient {
                     expected_connection_end,
                 ),
 
-            // The compiler is confused, and this pattern is actually reachable
-            #[allow(unreachable_patterns)]
+            // We need to tell the compiler that this pattern is currently reachable in test mode,
+            // and will be actually reachable when we add more client types.
+            #[cfg_attr(not(test), allow(unreachable_patterns))]
             _ => panic!("Type mismatch between client and arguments: {:?}", self),
         }
     }

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -3,13 +3,13 @@ use serde_derive::{Deserialize, Serialize};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::header::Header;
 use crate::ics02_client::state::{ClientState, ConsensusState};
-use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
-use crate::Height;
-
 use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics07_tendermint as tendermint;
 use crate::ics07_tendermint::client_def::TendermintClient;
+use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
+
+use ::tendermint::block::Height;
 
 #[cfg(test)]
 use crate::mock_client::client_def::MockClient;
@@ -22,6 +22,43 @@ pub trait ClientDef: Clone {
     type Header: Header;
     type ClientState: ClientState;
     type ConsensusState: ConsensusState;
+
+    /// TODO
+    fn check_header_and_update_state(
+        &self,
+        client_state: Self::ClientState,
+        header: Self::Header,
+    ) -> Result<(Self::ClientState, Self::ConsensusState), Box<dyn std::error::Error>>;
+
+    /// Verification functions as specified in:
+    /// https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics
+    ///
+    /// Verify a `proof` that the consensus state of a given client (at height `consensus_height`)
+    /// matches the input `consensus_state`. The parameter `counterparty_height` represent the
+    /// height of the counterparty chain that this proof assumes (i.e., the height at which this
+    /// proof was computed).
+    #[allow(clippy::too_many_arguments)]
+    fn verify_client_consensus_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        client_id: &ClientId,
+        consensus_height: Height,
+        expected_consensus_state: &Self::ConsensusState,
+    ) -> Result<(), Box<dyn std::error::Error>>;
+
+    /// Verify a `proof` that a connection state matches that of the input `connection_end`.
+    fn verify_connection_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        connection_id: &ConnectionId,
+        expected_connection_end: &ConnectionEnd,
+    ) -> Result<(), Box<dyn std::error::Error>>;
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)] // TODO: Add Eq
@@ -37,6 +74,7 @@ impl Header for AnyHeader {
     fn client_type(&self) -> ClientType {
         match self {
             Self::Tendermint(header) => header.client_type(),
+
             #[cfg(test)]
             Self::Mock(header) => header.client_type(),
         }
@@ -45,6 +83,7 @@ impl Header for AnyHeader {
     fn height(&self) -> Height {
         match self {
             Self::Tendermint(header) => header.height(),
+
             #[cfg(test)]
             Self::Mock(header) => header.height(),
         }
@@ -59,125 +98,35 @@ pub enum AnyClientState {
     Mock(MockClientState),
 }
 
-impl AnyClientState {
-    pub fn check_header_and_update_state(
-        &self,
-        header: AnyHeader,
-    ) -> Result<(AnyClientState, AnyConsensusState), Box<dyn std::error::Error>> {
-        match self {
-            AnyClientState::Tendermint(tm_state) => {
-                let (new_state, new_consensus) = tm_state.check_header_and_update_state(header)?;
-                Ok((
-                    AnyClientState::Tendermint(new_state),
-                    AnyConsensusState::Tendermint(new_consensus),
-                ))
-            }
-            #[cfg(test)]
-            AnyClientState::Mock(mock_state) => {
-                let (new_state, new_consensus) =
-                    mock_state.check_header_and_update_state(header)?;
-                Ok((
-                    AnyClientState::Mock(new_state),
-                    AnyConsensusState::Mock(new_consensus),
-                ))
-            }
-        }
-    }
-}
-
 impl ClientState for AnyClientState {
     fn chain_id(&self) -> String {
         todo!()
     }
 
     fn client_type(&self) -> ClientType {
-        todo!()
+        match self {
+            Self::Tendermint(state) => state.client_type(),
+
+            #[cfg(test)]
+            Self::Mock(state) => state.client_type(),
+        }
     }
 
     fn latest_height(&self) -> Height {
         match self {
-            AnyClientState::Tendermint(tm_state) => tm_state.latest_height(),
+            Self::Tendermint(tm_state) => tm_state.latest_height(),
 
             #[cfg(test)]
-            AnyClientState::Mock(mock_state) => mock_state.latest_height(),
+            Self::Mock(mock_state) => mock_state.latest_height(),
         }
     }
 
     fn is_frozen(&self) -> bool {
         match self {
-            AnyClientState::Tendermint(tm_state) => tm_state.is_frozen(),
+            Self::Tendermint(tm_state) => tm_state.is_frozen(),
 
             #[cfg(test)]
-            AnyClientState::Mock(mock_state) => mock_state.is_frozen(),
-        }
-    }
-
-    // fn check_header_and_update_state(
-    //     &self,
-    //     header: &dyn Header,
-    // ) -> Result<(Box<dyn ClientState>, Box<dyn ConsensusState>), Box<dyn std::error::Error>> {
-    //     match self {
-    //         AnyClientState::Tendermint(tm_state) => tm_state.check_header_and_update_state(header),
-    //         AnyClientState::Mock(mock_state) => mock_state.check_header_and_update_state(header),
-    //     }
-    // }
-
-    fn verify_client_consensus_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &dyn ConsensusState,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        match self {
-            AnyClientState::Tendermint(tm_state) => tm_state.verify_client_consensus_state(
-                height,
-                prefix,
-                proof,
-                client_id,
-                consensus_height,
-                expected_consensus_state,
-            ),
-
-            #[cfg(test)]
-            AnyClientState::Mock(mock_state) => mock_state.verify_client_consensus_state(
-                height,
-                prefix,
-                proof,
-                client_id,
-                consensus_height,
-                expected_consensus_state,
-            ),
-        }
-    }
-
-    fn verify_connection_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        match self {
-            AnyClientState::Tendermint(tm_state) => tm_state.verify_connection_state(
-                height,
-                prefix,
-                proof,
-                connection_id,
-                expected_connection_end,
-            ),
-
-            #[cfg(test)]
-            AnyClientState::Mock(mock_state) => mock_state.verify_connection_state(
-                height,
-                prefix,
-                proof,
-                connection_id,
-                expected_connection_end,
-            ),
+            Self::Mock(mock_state) => mock_state.is_frozen(),
         }
     }
 }
@@ -216,8 +165,143 @@ pub enum AnyClient {
     Mock(MockClient),
 }
 
+impl AnyClient {
+    pub fn from_client_type(client_type: ClientType) -> AnyClient {
+        match client_type {
+            ClientType::Tendermint => Self::Tendermint(TendermintClient),
+
+            #[cfg(test)]
+            ClientType::Mock => Self::Mock(MockClient),
+        }
+    }
+}
+
 impl ClientDef for AnyClient {
     type Header = AnyHeader;
     type ClientState = AnyClientState;
     type ConsensusState = AnyConsensusState;
+
+    fn check_header_and_update_state(
+        &self,
+        client_state: AnyClientState,
+        header: AnyHeader,
+    ) -> Result<(AnyClientState, AnyConsensusState), Box<dyn std::error::Error>> {
+        // We have to split and nest the following match because one cannot
+        // bind patterns both by-move and by-ref within the same pattern.
+        match self {
+            Self::Tendermint(client) => match (client_state, header) {
+                (AnyClientState::Tendermint(client_state), AnyHeader::Tendermint(header)) => {
+                    let (new_state, new_consensus) =
+                        client.check_header_and_update_state(client_state, header)?;
+
+                    Ok((
+                        AnyClientState::Tendermint(new_state),
+                        AnyConsensusState::Tendermint(new_consensus),
+                    ))
+                }
+
+                #[allow(unreachable_patterns)]
+                _ => panic!("Type mismatch between client and arguments: {:?}", self),
+            },
+
+            #[cfg(test)]
+            Self::Mock(client) => match (client_state, header) {
+                (AnyClientState::Mock(client_state), AnyHeader::Mock(header)) => {
+                    let (new_state, new_consensus) =
+                        client.check_header_and_update_state(client_state, header)?;
+
+                    Ok((
+                        AnyClientState::Mock(new_state),
+                        AnyConsensusState::Mock(new_consensus),
+                    ))
+                }
+
+                #[allow(unreachable_patterns)]
+                _ => panic!("Type mismatch between client and arguments: {:?}", self),
+            },
+        }
+    }
+
+    fn verify_client_consensus_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        client_id: &ClientId,
+        consensus_height: Height,
+        expected_consensus_state: &AnyConsensusState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match (self, client_state, expected_consensus_state) {
+            (
+                Self::Tendermint(client),
+                AnyClientState::Tendermint(client_state),
+                AnyConsensusState::Tendermint(expected_consensus_state),
+            ) => client.verify_client_consensus_state(
+                client_state,
+                height,
+                prefix,
+                proof,
+                client_id,
+                consensus_height,
+                expected_consensus_state,
+            ),
+
+            #[cfg(test)]
+            (
+                Self::Mock(client),
+                AnyClientState::Mock(client_state),
+                AnyConsensusState::Mock(expected_consensus_state),
+            ) => client.verify_client_consensus_state(
+                client_state,
+                height,
+                prefix,
+                proof,
+                client_id,
+                consensus_height,
+                expected_consensus_state,
+            ),
+
+            // The compiler is confused, and this pattern is actually reachable
+            #[allow(unreachable_patterns)]
+            _ => panic!("Type mismatch between client and arguments: {:?}", self),
+        }
+    }
+
+    fn verify_connection_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        connection_id: &ConnectionId,
+        expected_connection_end: &ConnectionEnd,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match (self, client_state) {
+            (Self::Tendermint(client), AnyClientState::Tendermint(client_state)) => client
+                .verify_connection_state(
+                    client_state,
+                    height,
+                    prefix,
+                    proof,
+                    connection_id,
+                    expected_connection_end,
+                ),
+
+            #[cfg(test)]
+            (Self::Mock(client), AnyClientState::Mock(client_state)) => client
+                .verify_connection_state(
+                    client_state,
+                    height,
+                    prefix,
+                    proof,
+                    connection_id,
+                    expected_connection_end,
+                ),
+
+            // The compiler is confused, and this pattern is actually reachable
+            #[allow(unreachable_patterns)]
+            _ => panic!("Type mismatch between client and arguments: {:?}", self),
+        }
+    }
 }

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -178,7 +178,7 @@ impl AnyClient {
     }
 }
 
-// /!\ Beware of the awful boilerplate below /!\
+// ⚠️  Beware of the awful boilerplate below ⚠️
 impl ClientDef for AnyClient {
     type Header = AnyHeader;
     type ClientState = AnyClientState;

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -1,5 +1,4 @@
 use super::error;
-use anomaly::fail;
 use serde_derive::{Deserialize, Serialize};
 
 /// Type of the client, depending on the specific consensus algorithm.

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -29,7 +29,11 @@ impl std::str::FromStr for ClientType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "tendermint" => Ok(Self::Tendermint),
-            _ => fail!(error::Kind::UnknownClientType, s),
+
+            #[cfg(test)]
+            "mock" => Ok(Self::Mock),
+
+            _ => Err(error::Kind::UnknownClientType(s.to_string()).into()),
         }
     }
 }
@@ -45,6 +49,16 @@ mod tests {
 
         match client_type {
             Ok(ClientType::Tendermint) => (),
+            _ => panic!("parse failed"),
+        }
+    }
+
+    #[test]
+    fn parse_mock_client_type() {
+        let client_type = ClientType::from_str("mock");
+
+        match client_type {
+            Ok(ClientType::Mock) => (),
             _ => panic!("parse failed"),
         }
     }

--- a/modules/src/ics02_client/context.rs
+++ b/modules/src/ics02_client/context.rs
@@ -2,7 +2,7 @@ use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::error::Error;
 use crate::ics24_host::identifier::ClientId;
-use crate::Height;
+use tendermint::block::Height;
 
 pub trait ClientReader {
     fn client_type(&self, client_id: &ClientId) -> Option<ClientType>;

--- a/modules/src/ics02_client/error.rs
+++ b/modules/src/ics02_client/error.rs
@@ -1,7 +1,9 @@
 use anomaly::{BoxError, Context};
 use thiserror::Error;
 
+use crate::ics02_client::client_type::ClientType;
 use crate::ics24_host::identifier::ClientId;
+
 use tendermint::block::Height;
 
 pub type Error = anomaly::Error<Kind>;
@@ -25,6 +27,9 @@ pub enum Kind {
 
     #[error("header verification failed")]
     HeaderVerificationFailure,
+
+    #[error("mismatch between client and arguments types, expected: {0:?}")]
+    ClientArgsTypeMismatch(ClientType),
 }
 
 impl Kind {

--- a/modules/src/ics02_client/error.rs
+++ b/modules/src/ics02_client/error.rs
@@ -2,14 +2,14 @@ use anomaly::{BoxError, Context};
 use thiserror::Error;
 
 use crate::ics24_host::identifier::ClientId;
-use crate::Height;
+use tendermint::block::Height;
 
 pub type Error = anomaly::Error<Kind>;
 
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum Kind {
-    #[error("unknown client type")]
-    UnknownClientType,
+    #[error("unknown client type: {0}")]
+    UnknownClientType(String),
 
     #[error("client already exists: {0}")]
     ClientAlreadyExists(ClientId),

--- a/modules/src/ics02_client/handler.rs
+++ b/modules/src/ics02_client/handler.rs
@@ -1,5 +1,4 @@
 use crate::handler::{Event, EventType, HandlerOutput};
-use crate::ics02_client::client_def::AnyClient;
 use crate::ics02_client::error::Error;
 use crate::ics02_client::msgs::ClientMsg;
 use crate::ics24_host::identifier::ClientId;

--- a/modules/src/ics02_client/handler.rs
+++ b/modules/src/ics02_client/handler.rs
@@ -30,7 +30,7 @@ impl From<ClientEvent> for Event {
     }
 }
 
-pub fn dispatch<Ctx>(ctx: &mut Ctx, msg: ClientMsg<AnyClient>) -> Result<HandlerOutput<()>, Error>
+pub fn dispatch<Ctx>(ctx: &mut Ctx, msg: ClientMsg) -> Result<HandlerOutput<()>, Error>
 where
     Ctx: ClientReader + ClientKeeper,
 {

--- a/modules/src/ics02_client/handler/create_client.rs
+++ b/modules/src/ics02_client/handler/create_client.rs
@@ -1,5 +1,5 @@
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::ics02_client::client_def::{AnyClient, ClientDef};
+use crate::ics02_client::client_def::{AnyClient, AnyClientState, AnyConsensusState, ClientDef};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::ics02_client::error::{Error, Kind};
@@ -8,17 +8,17 @@ use crate::ics02_client::msgs::MsgCreateAnyClient;
 use crate::ics24_host::identifier::ClientId;
 
 #[derive(Debug)]
-pub struct CreateClientResult<CD: ClientDef> {
+pub struct CreateClientResult {
     client_id: ClientId,
     client_type: ClientType,
-    client_state: CD::ClientState,
-    consensus_state: CD::ConsensusState,
+    client_state: AnyClientState,
+    consensus_state: AnyConsensusState,
 }
 
 pub fn process(
     ctx: &dyn ClientReader,
-    msg: MsgCreateAnyClient<AnyClient>,
-) -> HandlerResult<CreateClientResult<AnyClient>, Error> {
+    msg: MsgCreateAnyClient,
+) -> HandlerResult<CreateClientResult, Error> {
     let mut output = HandlerOutput::builder();
 
     let MsgCreateAnyClient {
@@ -50,10 +50,7 @@ pub fn process(
     }))
 }
 
-pub fn keep(
-    keeper: &mut dyn ClientKeeper,
-    result: CreateClientResult<AnyClient>,
-) -> Result<(), Error> {
+pub fn keep(keeper: &mut dyn ClientKeeper, result: CreateClientResult) -> Result<(), Error> {
     keeper.store_client_type(result.client_id.clone(), result.client_type)?;
     keeper.store_client_state(result.client_id.clone(), result.client_state)?;
     keeper.store_consensus_state(result.client_id, result.consensus_state)?;

--- a/modules/src/ics02_client/handler/create_client.rs
+++ b/modules/src/ics02_client/handler/create_client.rs
@@ -1,5 +1,5 @@
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::ics02_client::client_def::{AnyClient, AnyClientState, AnyConsensusState, ClientDef};
+use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::ics02_client::error::{Error, Kind};

--- a/modules/src/ics02_client/handler/update_client.rs
+++ b/modules/src/ics02_client/handler/update_client.rs
@@ -76,7 +76,7 @@ mod tests {
     fn test_update_client_ok() {
         let mock = MockClientContext {
             client_id: "mockclient".parse().unwrap(),
-            client_type: Some(ClientType::Tendermint),
+            client_type: Some(ClientType::Mock),
             client_state: MockClientState(MockHeader(Height(42))).into(),
             consensus_state: MockConsensusState(MockHeader(Height(42))).into(),
         };

--- a/modules/src/ics02_client/handler/update_client.rs
+++ b/modules/src/ics02_client/handler/update_client.rs
@@ -1,7 +1,7 @@
 #![allow(unreachable_code, unused_variables)]
 
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::ics02_client::client_def::{AnyClient, ClientDef};
+use crate::ics02_client::client_def::{AnyClient, AnyClientState, AnyConsensusState, ClientDef};
 use crate::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::ics02_client::error::{Error, Kind};
 use crate::ics02_client::handler::ClientEvent;
@@ -11,16 +11,16 @@ use crate::ics02_client::state::ClientState;
 use crate::ics24_host::identifier::ClientId;
 
 #[derive(Debug)]
-pub struct UpdateClientResult<CD: ClientDef> {
+pub struct UpdateClientResult {
     client_id: ClientId,
-    client_state: CD::ClientState,
-    consensus_state: CD::ConsensusState,
+    client_state: AnyClientState,
+    consensus_state: AnyConsensusState,
 }
 
 pub fn process(
     ctx: &dyn ClientReader,
-    msg: MsgUpdateAnyClient<AnyClient>,
-) -> HandlerResult<UpdateClientResult<AnyClient>, Error> {
+    msg: MsgUpdateAnyClient,
+) -> HandlerResult<UpdateClientResult, Error> {
     let mut output = HandlerOutput::builder();
 
     let MsgUpdateAnyClient { client_id, header } = msg;
@@ -28,6 +28,8 @@ pub fn process(
     let client_type = ctx
         .client_type(&client_id)
         .ok_or_else(|| Kind::ClientNotFound(client_id.clone()))?;
+
+    let client_def = AnyClient::from_client_type(client_type);
 
     let client_state = ctx
         .client_state(&client_id)
@@ -41,8 +43,8 @@ pub fn process(
     // Use client_state to validate the new header against the latest consensus_state.
     // This function will return the new client_state (its latest_height changed) and a
     // consensus_state obtained from header. These will be later persisted by the keeper.
-    let (new_client_state, new_consensus_state) = client_state
-        .check_header_and_update_state(header)
+    let (new_client_state, new_consensus_state) = client_def
+        .check_header_and_update_state(client_state, header)
         .map_err(|_| Kind::HeaderVerificationFailure)?;
 
     output.emit(ClientEvent::ClientUpdated(client_id.clone()));
@@ -54,10 +56,7 @@ pub fn process(
     }))
 }
 
-pub fn keep(
-    keeper: &mut dyn ClientKeeper,
-    result: UpdateClientResult<AnyClient>,
-) -> Result<(), Error> {
+pub fn keep(keeper: &mut dyn ClientKeeper, result: UpdateClientResult) -> Result<(), Error> {
     keeper.store_client_state(result.client_id.clone(), result.client_state)?;
     keeper.store_consensus_state(result.client_id, result.consensus_state)?;
 

--- a/modules/src/ics02_client/header.rs
+++ b/modules/src/ics02_client/header.rs
@@ -1,5 +1,5 @@
-use super::client_type::ClientType;
-use crate::Height;
+use crate::ics02_client::client_type::ClientType;
+use tendermint::block::Height;
 
 /// Abstract of consensus state update information
 #[dyn_clonable::clonable]

--- a/modules/src/ics02_client/msgs.rs
+++ b/modules/src/ics02_client/msgs.rs
@@ -4,7 +4,7 @@
 //! subsequently calls into the chain-specific (e.g., ICS 07) client handler. See:
 //! https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics#create.
 
-use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState, AnyHeader, ClientDef};
+use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState, AnyHeader};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics24_host::identifier::ClientId;
 

--- a/modules/src/ics02_client/msgs.rs
+++ b/modules/src/ics02_client/msgs.rs
@@ -4,27 +4,28 @@
 //! subsequently calls into the chain-specific (e.g., ICS 07) client handler. See:
 //! https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics#create.
 
-use crate::ics02_client::client_def::ClientDef;
+use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState, AnyHeader, ClientDef};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics24_host::identifier::ClientId;
 
-pub enum ClientMsg<CD: ClientDef> {
-    CreateClient(MsgCreateAnyClient<CD>),
-    UpdateClient(MsgUpdateAnyClient<CD>),
+#[allow(clippy::large_enum_variant)]
+pub enum ClientMsg {
+    CreateClient(MsgCreateAnyClient),
+    UpdateClient(MsgUpdateAnyClient),
 }
 
 /// A type of message that triggers the creation of a new on-chain (IBC) client.
 #[derive(Clone, Debug)]
-pub struct MsgCreateAnyClient<CD: ClientDef> {
+pub struct MsgCreateAnyClient {
     pub client_id: ClientId,
     pub client_type: ClientType,
-    pub client_state: CD::ClientState,
-    pub consensus_state: CD::ConsensusState,
+    pub client_state: AnyClientState,
+    pub consensus_state: AnyConsensusState,
 }
 
 /// A type of message that triggers the update of an on-chain (IBC) client with new headers.
 #[derive(Clone, Debug)]
-pub struct MsgUpdateAnyClient<CD: ClientDef> {
+pub struct MsgUpdateAnyClient {
     pub client_id: ClientId,
-    pub header: CD::Header,
+    pub header: AnyHeader,
 }

--- a/modules/src/ics02_client/state.rs
+++ b/modules/src/ics02_client/state.rs
@@ -1,8 +1,6 @@
-use super::client_type::ClientType;
-use crate::ics03_connection::connection::ConnectionEnd;
-use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
-use crate::ics24_host::identifier::{ClientId, ConnectionId};
-use crate::Height;
+use crate::ics02_client::client_type::ClientType;
+use crate::ics23_commitment::commitment::CommitmentRoot;
+use tendermint::block::Height;
 
 #[dyn_clonable::clonable]
 pub trait ConsensusState: Clone + std::fmt::Debug {
@@ -32,40 +30,4 @@ pub trait ClientState: Clone + std::fmt::Debug {
 
     /// Freeze status of the client
     fn is_frozen(&self) -> bool;
-
-    // TODO - to be cleaned up by Romain
-    // fn check_header_and_update_state(
-    //     &self,
-    //     _header: &dyn Header,
-    // ) -> Result<(Box<dyn ClientState>, Box<dyn ConsensusState>), Box<dyn std::error::Error>> {
-    //     todo!()
-    // }
-
-    /// Verification functions as specified in:
-    /// https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics
-    ///
-    /// Verify a `proof` that the consensus state of a given client (at height `consensus_height`)
-    /// matches the input `consensus_state`. The parameter `counterparty_height` represent the
-    /// height of the counterparty chain that this proof assumes (i.e., the height at which this
-    /// proof was computed).
-    fn verify_client_consensus_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &dyn ConsensusState,
-    ) -> Result<(), Box<dyn std::error::Error>>;
-
-    /// Verify a `proof` that a connection state matches that of the input `connection_end`.
-    // TODO: ValidationError seems wrong here.
-    fn verify_connection_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
-    ) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/modules/src/ics03_connection/context.rs
+++ b/modules/src/ics03_connection/context.rs
@@ -3,7 +3,7 @@ use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics03_connection::error::Error;
 use crate::ics23_commitment::commitment::CommitmentPrefix;
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
-use crate::Height;
+use tendermint::block::Height;
 
 /// A context supplying all the necessary dependencies for processing any `ICS3Msg`.
 pub trait ConnectionReader {

--- a/modules/src/ics03_connection/handler/verify.rs
+++ b/modules/src/ics03_connection/handler/verify.rs
@@ -1,4 +1,4 @@
-use crate::ics02_client::state::ClientState;
+use crate::ics02_client::{client_def::AnyClient, client_def::ClientDef, state::ClientState};
 use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics03_connection::context::ConnectionReader;
 use crate::ics03_connection::error::{Error, Kind};
@@ -44,18 +44,22 @@ pub fn verify_connection_proof(
     proof: &CommitmentProof,
 ) -> Result<(), Error> {
     // Fetch the client state (IBC client on the local chain).
-    let client = ctx
+    let client_state = ctx
         .fetch_client_state(connection_end.client_id())
         .ok_or_else(|| Kind::MissingClient.context(connection_end.client_id().to_string()))?;
-    if client.is_frozen() {
+
+    if client_state.is_frozen() {
         return Err(Kind::FrozenClient
             .context(connection_end.client_id().to_string())
             .into());
     }
 
+    let client_def = AnyClient::from_client_type(client_state.client_type());
+
     // Verify the proof for the connection state against the expected connection end.
-    Ok(client
+    Ok(client_def
         .verify_connection_state(
+            &client_state,
             proof_height,
             connection_end.counterparty().prefix(),
             proof,
@@ -87,16 +91,17 @@ pub fn verify_consensus_proof(
         .fetch_self_consensus_state(proof.height())
         .ok_or_else(|| Kind::MissingLocalConsensusState.context(proof.height().to_string()))?;
 
-    Ok(client
-        .verify_client_consensus_state(
-            proof_height,
-            connection_end.counterparty().prefix(),
-            proof.proof(),
-            connection_end.counterparty().client_id(),
-            proof.height(),
-            &expected_consensus,
-        )
-        .map_err(|_| Kind::ConsensusStateVerificationFailure.context(proof.height().to_string()))?)
+    todo!()
+    // Ok(client
+    //     .verify_client_consensus_state(
+    //         proof_height,
+    //         connection_end.counterparty().prefix(),
+    //         proof.proof(),
+    //         connection_end.counterparty().client_id(),
+    //         proof.height(),
+    //         &expected_consensus,
+    //     )
+    //     .map_err(|_| Kind::ConsensusStateVerificationFailure.context(proof.height().to_string()))?)
 }
 
 pub fn check_client_consensus_height(

--- a/modules/src/ics07_tendermint/client_def.rs
+++ b/modules/src/ics07_tendermint/client_def.rs
@@ -3,7 +3,7 @@ use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics07_tendermint::client_state::ClientState;
 use crate::ics07_tendermint::consensus_state::ConsensusState;
 use crate::ics07_tendermint::header::Header;
-use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
+use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof};
 use crate::ics24_host::identifier::ClientId;
 use crate::ics24_host::identifier::ConnectionId;
 use tendermint::block::Height;
@@ -18,33 +18,33 @@ impl ClientDef for TendermintClient {
 
     fn check_header_and_update_state(
         &self,
-        client_state: Self::ClientState,
-        header: Self::Header,
+        _client_state: Self::ClientState,
+        _header: Self::Header,
     ) -> Result<(Self::ClientState, Self::ConsensusState), Box<dyn std::error::Error>> {
         todo!()
     }
 
     fn verify_client_consensus_state(
         &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &Self::ConsensusState,
+        _client_state: &Self::ClientState,
+        _height: Height,
+        _prefix: &CommitmentPrefix,
+        _proof: &CommitmentProof,
+        _client_id: &ClientId,
+        _consensus_height: Height,
+        _expected_consensus_state: &Self::ConsensusState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         todo!()
     }
 
     fn verify_connection_state(
         &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
+        _client_state: &Self::ClientState,
+        _height: Height,
+        _prefix: &CommitmentPrefix,
+        _proof: &CommitmentProof,
+        _connection_id: &ConnectionId,
+        _expected_connection_end: &ConnectionEnd,
     ) -> Result<(), Box<dyn std::error::Error>> {
         todo!()
     }

--- a/modules/src/ics07_tendermint/client_def.rs
+++ b/modules/src/ics07_tendermint/client_def.rs
@@ -1,7 +1,12 @@
 use crate::ics02_client::client_def::ClientDef;
+use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics07_tendermint::client_state::ClientState;
 use crate::ics07_tendermint::consensus_state::ConsensusState;
 use crate::ics07_tendermint::header::Header;
+use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
+use crate::ics24_host::identifier::ClientId;
+use crate::ics24_host::identifier::ConnectionId;
+use tendermint::block::Height;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TendermintClient;
@@ -10,4 +15,37 @@ impl ClientDef for TendermintClient {
     type Header = Header;
     type ClientState = ClientState;
     type ConsensusState = ConsensusState;
+
+    fn check_header_and_update_state(
+        &self,
+        client_state: Self::ClientState,
+        header: Self::Header,
+    ) -> Result<(Self::ClientState, Self::ConsensusState), Box<dyn std::error::Error>> {
+        todo!()
+    }
+
+    fn verify_client_consensus_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        client_id: &ClientId,
+        consensus_height: Height,
+        expected_consensus_state: &Self::ConsensusState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        todo!()
+    }
+
+    fn verify_connection_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        connection_id: &ConnectionId,
+        expected_connection_end: &ConnectionEnd,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        todo!()
+    }
 }

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -2,7 +2,6 @@ use crate::ics02_client::client_type::ClientType;
 use crate::ics07_tendermint::error::{Error, Kind};
 use tendermint::block::Height;
 
-use crate::ics02_client::client_def::AnyHeader;
 use serde_derive::{Deserialize, Serialize};
 use std::time::Duration;
 

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -1,18 +1,10 @@
-#![allow(unreachable_code, unused_variables)]
-// TODO -- clean this up
 use crate::ics02_client::client_type::ClientType;
-use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof};
-
-use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics07_tendermint::error::{Error, Kind};
-use crate::ics24_host::identifier::{ClientId, ConnectionId};
+use tendermint::block::Height;
 
 use crate::ics02_client::client_def::AnyHeader;
-use crate::ics02_client::state::ConsensusState;
-use crate::ics07_tendermint::consensus_state::ConsensusState as tmConsensusState;
 use serde_derive::{Deserialize, Serialize};
 use std::time::Duration;
-use tendermint::block::Height;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ClientState {
@@ -32,8 +24,8 @@ impl ClientState {
         trusting_period: Duration,
         unbonding_period: Duration,
         max_clock_drift: Duration,
-        latest_height: crate::Height,
-        frozen_height: crate::Height,
+        latest_height: Height,
+        frozen_height: Height,
         // proof_specs: Specs
     ) -> Result<ClientState, Error> {
         // Basic validation of trusting period and unbonding period: each should be non-zero.
@@ -77,12 +69,6 @@ impl ClientState {
             latest_height,
         })
     }
-    pub fn check_header_and_update_state(
-        &self,
-        header: AnyHeader,
-    ) -> Result<(ClientState, tmConsensusState), Box<dyn std::error::Error>> {
-        todo!()
-    }
 }
 
 impl crate::ics02_client::state::ClientState for ClientState {
@@ -101,42 +87,6 @@ impl crate::ics02_client::state::ClientState for ClientState {
     fn is_frozen(&self) -> bool {
         // If 'frozen_height' is set to a non-zero value, then the client state is frozen.
         self.frozen_height != Height(0)
-    }
-
-    // fn check_header_and_update_state(
-    //     &self,
-    //     header: &dyn Header,
-    // ) -> Result<
-    //     (
-    //         Box<dyn crate::ics02_client::state::ClientState>,
-    //         Box<dyn ConsensusState>,
-    //     ),
-    //     Box<dyn std::error::Error>,
-    // > {
-    //     todo!()
-    // }
-
-    fn verify_client_consensus_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &dyn ConsensusState,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())
-    }
-
-    fn verify_connection_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())
     }
 }
 
@@ -171,8 +121,8 @@ mod tests {
             trusting_period: Duration,
             unbonding_period: Duration,
             max_clock_drift: Duration,
-            latest_height: crate::Height,
-            frozen_height: crate::Height,
+            latest_height: Height,
+            frozen_height: Height,
         }
 
         // Define a "default" set of parameters to reuse throughout these tests.

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -7,7 +7,7 @@ use tendermint::validator::Set as ValidatorSet;
 use crate::ics02_client::client_type::ClientType;
 use crate::ics07_tendermint::consensus_state::ConsensusState;
 use crate::ics23_commitment::commitment::CommitmentRoot;
-use crate::Height;
+use tendermint::block::Height;
 
 /// Tendermint consensus header
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -30,6 +30,7 @@ pub mod ics20_fungible_token_transfer;
 pub mod ics23_commitment;
 pub mod ics24_host;
 pub mod keys;
+pub mod macros;
 pub mod proofs;
 pub mod try_from_raw;
 pub mod tx_msg;

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -9,7 +9,7 @@
     unused_qualifications,
     rust_2018_idioms
 )]
-#![allow(dead_code, unused_imports, unused_variables)]
+#![allow(dead_code)]
 
 //! Implementation of the following ICS modules:
 //!

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -9,7 +9,7 @@
     unused_qualifications,
     rust_2018_idioms
 )]
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports, unused_variables)]
 
 //! Implementation of the following ICS modules:
 //!

--- a/modules/src/macros.rs
+++ b/modules/src/macros.rs
@@ -1,0 +1,18 @@
+#[macro_export]
+macro_rules! downcast {
+    ( $e1:expr => $p1:path, $( $e:expr => $p:path ),+ $(,)? ) => {
+        downcast!($e1 => $p1).zip(downcast!($($e => $p),+))
+    };
+
+    ($e:expr => $p:path) => {
+        match $e {
+            $p(e) => Some(e),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        }
+    };
+
+    () => {
+        None
+    }
+}

--- a/modules/src/macros.rs
+++ b/modules/src/macros.rs
@@ -1,3 +1,34 @@
+/// Downcast the given arguments to the associated enum variant.
+///
+/// ## Note
+/// Only works for enums whose variants only hold a single value.
+///
+/// ## Example
+///
+/// ```rust
+/// use ibc::downcast;
+///
+/// enum Foo {
+///     Bar(u32),
+///     Baz(bool),
+/// }
+///
+/// let bar = Foo::Bar(42);
+/// let baz = Foo::Baz(true);
+///
+/// if let Some(value) = downcast!(bar => Foo::Bar) {
+///     println!("value is a u32: {}", value);
+/// }
+///
+/// if let Some(value) = downcast!(baz => Foo::Baz) {
+///     println!("value is a bool: {}", value);
+/// }
+///
+/// if let Some((a, b)) = downcast!(bar => Foo::Bar, baz => Foo::Baz) {
+///     println!("a is a u32: {}", a);
+///     println!("b is a bool: {}", b);
+/// }
+/// ```
 #[macro_export]
 macro_rules! downcast {
     ( $e1:expr => $p1:path, $( $e:expr => $p:path ),+ $(,)? ) => {

--- a/modules/src/mock_client/client_def.rs
+++ b/modules/src/mock_client/client_def.rs
@@ -31,32 +31,35 @@ impl ClientDef for MockClient {
 
     fn verify_client_consensus_state(
         &self,
-        client_state: &Self::ClientState,
+        _client_state: &Self::ClientState,
         height: Height,
         prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
+        _proof: &CommitmentProof,
         client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &Self::ConsensusState,
+        _consensus_height: Height,
+        _expected_consensus_state: &Self::ConsensusState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let client_prefixed_path =
             Path::ConsensusState(client_id.clone(), height.value()).to_string();
+
         let _path = apply_prefix(prefix, client_prefixed_path)?;
+
         // TODO - add ctx to all client verification functions
         // let cs = ctx.fetch_self_consensus_state(height);
         // TODO - implement this
         // proof.verify_membership(cs.root(), path, expected_consensus_state)
+
         Ok(())
     }
 
     fn verify_connection_state(
         &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
+        _client_state: &Self::ClientState,
+        _height: Height,
+        _prefix: &CommitmentPrefix,
+        _proof: &CommitmentProof,
+        _connection_id: &ConnectionId,
+        _expected_connection_end: &ConnectionEnd,
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }

--- a/modules/src/mock_client/client_def.rs
+++ b/modules/src/mock_client/client_def.rs
@@ -1,6 +1,13 @@
-use crate::ics02_client::client_def::ClientDef;
+use crate::ics23_commitment::{commitment::CommitmentPrefix, merkle::apply_prefix};
+use crate::ics24_host::identifier::ConnectionId;
+use crate::{ics02_client::client_def::ClientDef, ics24_host::identifier::ClientId};
+use crate::{ics02_client::state::ClientState, ics23_commitment::commitment::CommitmentProof};
+use crate::{ics03_connection::connection::ConnectionEnd, ics24_host::Path};
+
 use crate::mock_client::header::MockHeader;
 use crate::mock_client::state::{MockClientState, MockConsensusState};
+
+use tendermint::block::Height;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MockClient;
@@ -9,4 +16,48 @@ impl ClientDef for MockClient {
     type Header = MockHeader;
     type ClientState = MockClientState;
     type ConsensusState = MockConsensusState;
+
+    fn check_header_and_update_state(
+        &self,
+        client_state: Self::ClientState,
+        header: Self::Header,
+    ) -> Result<(Self::ClientState, Self::ConsensusState), Box<dyn std::error::Error>> {
+        if client_state.latest_height() >= header.height() {
+            return Err("header height is lower than client latest".into());
+        }
+
+        Ok((MockClientState(header), MockConsensusState(header)))
+    }
+
+    fn verify_client_consensus_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        client_id: &ClientId,
+        consensus_height: Height,
+        expected_consensus_state: &Self::ConsensusState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let client_prefixed_path =
+            Path::ConsensusState(client_id.clone(), height.value()).to_string();
+        let _path = apply_prefix(prefix, client_prefixed_path)?;
+        // TODO - add ctx to all client verification functions
+        // let cs = ctx.fetch_self_consensus_state(height);
+        // TODO - implement this
+        // proof.verify_membership(cs.root(), path, expected_consensus_state)
+        Ok(())
+    }
+
+    fn verify_connection_state(
+        &self,
+        client_state: &Self::ClientState,
+        height: Height,
+        prefix: &CommitmentPrefix,
+        proof: &CommitmentProof,
+        connection_id: &ConnectionId,
+        expected_connection_end: &ConnectionEnd,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
 }

--- a/modules/src/mock_client/state.rs
+++ b/modules/src/mock_client/state.rs
@@ -4,11 +4,7 @@ use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState, AnyHead
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::header::Header;
 use crate::ics02_client::state::{ClientState, ConsensusState};
-use crate::ics03_connection::connection::ConnectionEnd;
-use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
-use crate::ics23_commitment::merkle::apply_prefix;
-use crate::ics24_host::identifier::{ClientId, ConnectionId};
-use crate::ics24_host::Path;
+use crate::ics23_commitment::commitment::CommitmentRoot;
 use crate::mock_client::header::MockHeader;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/modules/src/mock_client/state.rs
+++ b/modules/src/mock_client/state.rs
@@ -51,7 +51,7 @@ impl ClientState for MockClientState {
     }
 
     fn client_type(&self) -> ClientType {
-        todo!()
+        ClientType::Mock
     }
 
     fn latest_height(&self) -> Height {

--- a/modules/src/mock_client/state.rs
+++ b/modules/src/mock_client/state.rs
@@ -62,50 +62,6 @@ impl ClientState for MockClientState {
         // TODO
         false
     }
-
-    // fn check_header_and_update_state(
-    //     &self,
-    //     header: &dyn Header,
-    // ) -> Result<(Box<dyn ClientState>, Box<dyn ConsensusState>), Box<dyn std::error::Error>> {
-    //     if self.latest_height() >= header.height() {
-    //         return Err("header height is lower than client latest".into());
-    //     }
-    //
-    //     Ok((
-    //         Box::new(AnyClientState::Mock(MockClientState(header.height().value() as u32))),
-    //         Box::new(AnyConsensusState::Mock(MockConsensusState(header.height().value() as u32))),
-    //     ))
-    // }
-
-    fn verify_client_consensus_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &dyn ConsensusState,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client_prefixed_path =
-            Path::ConsensusState(client_id.clone(), height.value()).to_string();
-        let _path = apply_prefix(prefix, client_prefixed_path)?;
-        // TODO - add ctx to all client verification functions
-        // let cs = ctx.fetch_self_consensus_state(height);
-        // TODO - implement this
-        // proof.verify_membership(cs.root(), path, expected_consensus_state)
-        Ok(())
-    }
-
-    fn verify_connection_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())
-    }
 }
 
 impl From<MockConsensusState> for MockClientState {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

See: #218

## Description

This PR improves the ergonomics of the way we deal with multiple client types at runtime,
ie. the various `Any*` wrappers and the associated traits.

- Removes uses of `dyn ClientState` and `dyn ConsensusState`
- Move validation functions out of the `ClientState` trait and into the `ClientDef` trait
- Add method to get a `AnyClient` from a `ClientType`
- Remove type parameter on messages structs, enums, `process` and `keep` functions
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
