### PR TITLE
Migration to ibc_proto v.0.3.0

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -28,6 +28,8 @@ serde = "1.0.104"
 serde_json = "1"
 tracing = "0.1.13"
 prost = "0.6.1"
+prost-types = { version = "0.6.1" }
+
 bytes = "0.5.5"
 dyn-clonable = "0.9.0"
 

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -16,10 +16,10 @@ description = """
 
 [dependencies]
 tendermint = "0.15.0"
-tendermint-rpc = { version = "0.15.0", features=["client"] }
+tendermint-rpc = { version = "0.15.0", features = ["client"] }
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = "0.2.2"
+ibc-proto = "0.3.0"
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -19,7 +19,7 @@ tendermint = "0.15.0"
 tendermint-rpc = { version = "0.15.0", features=["client"] }
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = "0.1.0"
+ibc-proto = "0.2.2"
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/src/address.rs
+++ b/modules/src/address.rs
@@ -1,1 +1,1 @@
-pub struct AccAddress(Vec<u8>;
+pub struct AccAddress(Vec<u8>);

--- a/modules/src/context.rs
+++ b/modules/src/context.rs
@@ -3,19 +3,27 @@ use tendermint::block::Height;
 
 #[cfg(test)]
 use crate::ics02_client::client_def::AnyConsensusState;
+use crate::ics07_tendermint;
 #[cfg(test)]
 use crate::mock_client::header::MockHeader;
 #[cfg(test)]
 use crate::mock_client::state::MockConsensusState;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SelfChainType {
+    Tendermint,
+    #[cfg(test)]
+    Mock,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SelfHeader {
-    // Tendermint(tendermint::header::Header),
+    Tendermint(ics07_tendermint::header::Header),
     #[cfg(test)]
     Mock(MockHeader),
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct HistoricalInfo {
     pub header: SelfHeader,
 }
@@ -28,6 +36,7 @@ impl From<MockHeader> for AnyConsensusState {
 }
 
 pub trait ChainReader {
+    fn chain_type(&self) -> SelfChainType;
     fn self_historical_info(&self, height: Height) -> Option<&HistoricalInfo>;
 }
 

--- a/modules/src/context.rs
+++ b/modules/src/context.rs
@@ -37,7 +37,7 @@ impl From<MockHeader> for AnyConsensusState {
 
 pub trait ChainReader {
     fn chain_type(&self) -> SelfChainType;
-    fn self_historical_info(&self, height: Height) -> Option<&HistoricalInfo>;
+    fn self_historical_info(&self, height: Height) -> Option<HistoricalInfo>;
 }
 
 pub trait ChainKeeper {

--- a/modules/src/context_mock.rs
+++ b/modules/src/context_mock.rs
@@ -1,10 +1,10 @@
-use crate::context::{ChainKeeper, ChainReader, HistoricalInfo, SelfHeader};
+use crate::context::{ChainKeeper, ChainReader, HistoricalInfo, SelfChainType, SelfHeader};
 use crate::mock_client::header::MockHeader;
 use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
 use tendermint::block::Height;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct MockChainContext {
     pub max_size: usize,
     pub latest: Height,
@@ -40,32 +40,37 @@ impl MockChainContext {
         }
     }
 
-    /// Used for testing
     pub fn validate(&self) -> Result<(), Box<dyn Error>> {
-        // check that the number of entries is not higher than max_size
-        if self.history.len() > self.max_size {
-            return Err("too many entries".to_string().into());
-        }
-
-        // check latest is properly updated with highest header height
-        let SelfHeader::Mock(lh) = self.history[self.history.len() - 1].header;
-        if lh.height() != self.latest {
-            return Err("latest height is not updated".to_string().into());
-        }
-
-        // check that all headers are in sequential order
-        for i in 1..self.history.len() {
-            let SelfHeader::Mock(ph) = self.history[i - 1].header;
-            let SelfHeader::Mock(h) = self.history[i].header;
-            if ph.height().increment() != h.height() {
-                return Err("headers in history not sequential".to_string().into());
-            }
-        }
+        // TODO
         Ok(())
+        //         // check that the number of entries is not higher than max_size
+        //         if self.history.len() > self.max_size {
+        //             return Err("too many entries".to_string().into());
+        //         }
+        //
+        //         // check latest is properly updated with highest header height
+        //         let SelfHeader::Mock(lh) = self.history[self.history.len() - 1].header;
+        //         if lh.height() != self.latest {
+        //             return Err("latest height is not updated".to_string().into());
+        //         }
+        //
+        //         // check that all headers are in sequential order
+        //         for i in 1..self.history.len() {
+        //             let SelfHeader::Mock(ph) = self.history[i - 1].header;
+        //             let SelfHeader::Mock(h) = self.history[i].header;
+        //             if ph.height().increment() != h.height() {
+        //                 return Err("headers in history not sequential".to_string().into());
+        //             }
+        //         }
+        //         Ok(())
     }
 }
 
 impl ChainReader for MockChainContext {
+    fn chain_type(&self) -> SelfChainType {
+        SelfChainType::Mock
+    }
+
     fn self_historical_info(&self, height: Height) -> Option<&HistoricalInfo> {
         let l = height.value() as usize;
         let h = self.latest.value() as usize;

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -112,6 +112,37 @@ impl ClientState for AnyClientState {
         }
     }
 
+    fn verify_client_full_state(
+        &self,
+        height: Height,
+        root: &CommitmentRoot,
+        prefix: &CommitmentPrefix,
+        client_id: &ClientId,
+        proof: &CommitmentProof,
+        expected_client_state: &dyn ClientState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
+            AnyClientState::Tendermint(tm_state) => tm_state.verify_client_full_state(
+                height,
+                root,
+                prefix,
+                client_id,
+                proof,
+                expected_client_state,
+            ),
+
+            #[cfg(test)]
+            AnyClientState::Mock(mock_state) => mock_state.verify_client_full_state(
+                height,
+                root,
+                prefix,
+                client_id,
+                proof,
+                expected_client_state,
+            ),
+        }
+    }
+
     // fn check_header_and_update_state(
     //     &self,
     //     header: &dyn Header,

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -51,7 +51,7 @@ impl Header for AnyHeader {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AnyClientState {
     Tendermint(crate::ics07_tendermint::client_state::ClientState),
 

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -359,9 +359,7 @@ impl ClientDef for AnyClient {
             }
         }
     }
-    /// Verification functions as specified in:
-    /// https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics
-    ///
+
     fn verify_client_full_state(
         &self,
         client_state: &Self::ClientState,

--- a/modules/src/ics02_client/error.rs
+++ b/modules/src/ics02_client/error.rs
@@ -28,6 +28,18 @@ pub enum Kind {
     #[error("header verification failed")]
     HeaderVerificationFailure,
 
+    #[error("unknown client state type: {0}")]
+    UnknownClientStateType(String),
+
+    #[error("invalid raw client state")]
+    InvalidRawClientState,
+
+    #[error("invalid raw header")]
+    InvalidRawHeader,
+
+    #[error("Protobuf decoding failure")]
+    ProtoDecodingFailure,
+
     #[error("mismatch between client and arguments types, expected: {0:?}")]
     ClientArgsTypeMismatch(ClientType),
 }

--- a/modules/src/ics02_client/state.rs
+++ b/modules/src/ics02_client/state.rs
@@ -44,6 +44,17 @@ pub trait ClientState: Clone + std::fmt::Debug {
     /// Verification functions as specified in:
     /// https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics
     ///
+    fn verify_client_full_state(
+        &self,
+        height: Height,
+        root: &CommitmentRoot,
+        prefix: &CommitmentPrefix,
+        client_id: &ClientId,
+        proof: &CommitmentProof,
+        expected_client_state: &dyn ClientState,
+    ) -> Result<(), Box<dyn std::error::Error>>;
+
+    ///
     /// Verify a `proof` that the consensus state of a given client (at height `consensus_height`)
     /// matches the input `consensus_state`. The parameter `counterparty_height` represent the
     /// height of the counterparty chain that this proof assumes (i.e., the height at which this

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -1,12 +1,14 @@
 use crate::ics03_connection::error::{Error, Kind};
 use crate::ics23_commitment::commitment::CommitmentPrefix;
+use crate::ics24_host::error::ValidationError;
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
 use crate::try_from_raw::TryFromRaw;
-use serde_derive::{Deserialize, Serialize};
 
-// Import proto declarations.
-use crate::ics24_host::error::ValidationError;
-use ibc_proto::connection::{ConnectionEnd as RawConnectionEnd, Counterparty as RawCounterparty};
+use ibc_proto::ibc::connection::{
+    ConnectionEnd as RawConnectionEnd, Counterparty as RawCounterparty,
+};
+
+use serde_derive::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -21,7 +21,6 @@ impl TryFromRaw for ConnectionEnd {
     type RawType = RawConnectionEnd;
     type Error = anomaly::Error<Kind>;
     fn try_from(value: RawConnectionEnd) -> Result<Self, Self::Error> {
-
         Ok(Self::new(
             State::from_i32(value.state),
             value

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -21,9 +21,6 @@ impl TryFromRaw for ConnectionEnd {
     type RawType = RawConnectionEnd;
     type Error = anomaly::Error<Kind>;
     fn try_from(value: RawConnectionEnd) -> Result<Self, Self::Error> {
-        if value.id == "" {
-            return Err(Kind::ConnectionNotFound.into());
-        }
 
         Ok(Self::new(
             State::from_i32(value.state),

--- a/modules/src/ics03_connection/context.rs
+++ b/modules/src/ics03_connection/context.rs
@@ -1,3 +1,4 @@
+use crate::context::SelfChainType;
 use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState};
 use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics03_connection::error::Error;
@@ -18,6 +19,8 @@ pub trait ConnectionReader {
 
     /// Returns the number of consensus state historical entries for the local chain.
     fn chain_consensus_states_history_size(&self) -> usize;
+
+    fn chain_type(&self) -> SelfChainType;
 
     /// Returns the prefix that the local chain uses in the KV store.
     fn commitment_prefix(&self) -> CommitmentPrefix;

--- a/modules/src/ics03_connection/context_mock.rs
+++ b/modules/src/ics03_connection/context_mock.rs
@@ -87,11 +87,7 @@ impl ConnectionReader for MockConnectionContext {
     }
 
     fn fetch_self_consensus_state(&self, height: Height) -> Option<AnyConsensusState> {
-        let hi = self
-            .chain_context
-            .self_historical_info(height)?
-            .header
-            .clone();
+        let hi = self.chain_context.self_historical_info(height)?.header;
         match hi {
             #[cfg(test)]
             SelfHeader::Mock(h) => Some(h.into()),

--- a/modules/src/ics03_connection/context_mock.rs
+++ b/modules/src/ics03_connection/context_mock.rs
@@ -1,4 +1,4 @@
-use crate::context::{ChainReader, SelfHeader};
+use crate::context::{ChainReader, SelfChainType, SelfHeader};
 use crate::context_mock::MockChainContext;
 use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState};
 use crate::ics02_client::context::ClientReader;
@@ -82,11 +82,20 @@ impl ConnectionReader for MockConnectionContext {
         self.client_context.consensus_state(client_id, height)
     }
 
+    fn chain_type(&self) -> SelfChainType {
+        SelfChainType::Mock
+    }
+
     fn fetch_self_consensus_state(&self, height: Height) -> Option<AnyConsensusState> {
-        let hi = self.chain_context.self_historical_info(height)?.header;
+        let hi = self
+            .chain_context
+            .self_historical_info(height)?
+            .header
+            .clone();
         match hi {
             #[cfg(test)]
             SelfHeader::Mock(h) => Some(h.into()),
+            _ => None,
         }
     }
 }

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -35,6 +35,12 @@ pub enum Kind {
     #[error("invalid address")]
     InvalidAddress,
 
+    #[error("missing consensus proof height in opentTry")]
+    MissingProofHeight,
+
+    #[error("missing consensus proof height in opentTry")]
+    MissingConsesusHeight,
+
     #[error("invalid connection proof")]
     InvalidProof,
 

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -35,11 +35,11 @@ pub enum Kind {
     #[error("invalid address")]
     InvalidAddress,
 
-    #[error("missing consensus proof height in opentTry")]
+    #[error("missing consensus proof height")]
     MissingProofHeight,
 
-    #[error("missing consensus proof height in opentTry")]
-    MissingConsesusHeight,
+    #[error("missing consensus proof height")]
+    MissingConsensusHeight,
 
     #[error("invalid connection proof")]
     InvalidProof,

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -62,6 +62,9 @@ pub enum Kind {
     #[error("the client id does not match any client state")]
     MissingClient,
 
+    #[error("client proof must be present")]
+    NullClientProof,
+
     #[error("the client is frozen")]
     FrozenClient,
 

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -77,6 +77,9 @@ pub enum Kind {
     #[error("the local consensus state could not be retrieved")]
     MissingLocalConsensusState,
 
+    #[error("the client state proof verification failed")]
+    ClientStateVerificationFailure,
+
     #[error("the consensus proof verification failed")]
     ConsensusStateVerificationFailure,
 }

--- a/modules/src/ics03_connection/handler.rs
+++ b/modules/src/ics03_connection/handler.rs
@@ -95,7 +95,7 @@ where
                 result,
                 log,
                 events,
-            } = conn_open_try::process(ctx, msg)?;
+            } = conn_open_try::process(ctx, *msg)?;
 
             keep(ctx, result.clone())?;
             Ok(HandlerOutput::builder()

--- a/modules/src/ics03_connection/handler/conn_open_try.rs
+++ b/modules/src/ics03_connection/handler/conn_open_try.rs
@@ -126,20 +126,20 @@ mod tests {
                 ctx: default_context
                     .clone()
                     .with_client_state(dummy_msg.client_id(), 10),
-                msg: ConnectionMsg::ConnectionOpenTry(dummy_msg.clone()),
+                msg: ConnectionMsg::ConnectionOpenTry(Box::new(dummy_msg.clone())),
                 want_pass: true,
             },
             Test {
                 name: "Processing fails because no client exists".to_string(),
                 ctx: default_context.clone(),
-                msg: ConnectionMsg::ConnectionOpenTry(dummy_msg.clone()),
+                msg: ConnectionMsg::ConnectionOpenTry(Box::new(dummy_msg.clone())),
                 want_pass: false,
             },
             Test {
                 name: "Processing fails because connection exists in the store already".to_string(),
                 ctx: default_context
                     .add_connection(dummy_msg.connection_id().clone(), try_conn_end.clone()),
-                msg: ConnectionMsg::ConnectionOpenTry(dummy_msg.clone()),
+                msg: ConnectionMsg::ConnectionOpenTry(Box::new(dummy_msg.clone())),
                 want_pass: false,
             },
         ]

--- a/modules/src/ics03_connection/handler/conn_open_try.rs
+++ b/modules/src/ics03_connection/handler/conn_open_try.rs
@@ -60,6 +60,7 @@ pub(crate) fn process(
     verify_proofs(
         ctx,
         msg.connection_id(),
+        msg.client_state(),
         &new_connection_end,
         &expected_conn,
         msg.proofs(),

--- a/modules/src/ics03_connection/handler/verify.rs
+++ b/modules/src/ics03_connection/handler/verify.rs
@@ -91,7 +91,7 @@ pub fn verify_client_proof(
 ) -> Result<(), Error> {
     let client = ctx
         .fetch_client_state(connection_end.client_id())
-        .ok_or_else(|| { Kind::MissingClient(connection_end.client_id().clone())})?;
+        .ok_or_else(|| Kind::MissingClient(connection_end.client_id().clone()))?;
 
     let consensus_state = ctx
         .fetch_client_consensus_state(connection_end.client_id(), proof_height)

--- a/modules/src/ics03_connection/handler/verify.rs
+++ b/modules/src/ics03_connection/handler/verify.rs
@@ -26,9 +26,8 @@ pub fn verify_proofs(
     )?;
 
     // If a client proof is present verify it.
-    match client_state {
-        None => (),
-        Some(state) => verify_client_proof(
+    if let Some(state) = client_state {
+        verify_client_proof(
             ctx,
             connection_end,
             state,
@@ -37,8 +36,8 @@ pub fn verify_proofs(
                 .client_proof()
                 .as_ref()
                 .ok_or_else(|| Kind::NullClientProof)?,
-        )?,
-    };
+        )?;
+    }
 
     // If a consensus proof is present verify it.
     match proofs.consensus_proof() {

--- a/modules/src/ics03_connection/handler/verify.rs
+++ b/modules/src/ics03_connection/handler/verify.rs
@@ -91,7 +91,7 @@ pub fn verify_client_proof(
 ) -> Result<(), Error> {
     let client = ctx
         .fetch_client_state(connection_end.client_id())
-        .ok_or_else(|| Kind::MissingClient.context(connection_end.client_id().to_string()))?;
+        .ok_or_else(|| { Kind::MissingClient(connection_end.client_id().clone())})?;
 
     let consensus_state = ctx
         .fetch_client_consensus_state(connection_end.client_id(), proof_height)

--- a/modules/src/ics03_connection/handler/verify.rs
+++ b/modules/src/ics03_connection/handler/verify.rs
@@ -107,6 +107,7 @@ pub fn verify_client_proof(
 
     Ok(client_def
         .verify_client_full_state(
+            &client_state,
             proof_height,
             consensus_state.root(),
             connection_end.counterparty().prefix(),

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -211,13 +211,16 @@ impl TryFromRaw for MsgConnectionOpenTry {
     type RawType = RawMsgConnectionOpenTry;
     type Error = anomaly::Error<Kind>;
     fn try_from(msg: RawMsgConnectionOpenTry) -> Result<Self, Self::Error> {
-        let proof_height = msg.proof_height
-            .ok_or_else(||Kind::MissingProofHeight)?.epoch_height;
-        let consensus_height = msg.consensus_height
-            .ok_or_else(|| Kind::MissingConsesusHeight)?.epoch_height;
-        let consensus_proof_obj =
-            ConsensusProof::new(msg.proof_consensus.into(),consensus_height)
-                .map_err(|e| Kind::InvalidProof.context(e))?;
+        let proof_height = msg
+            .proof_height
+            .ok_or_else(|| Kind::MissingProofHeight)?
+            .epoch_height;
+        let consensus_height = msg
+            .consensus_height
+            .ok_or_else(|| Kind::MissingConsesusHeight)?
+            .epoch_height;
+        let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
+            .map_err(|e| Kind::InvalidProof.context(e))?;
 
         Ok(Self {
             connection_id: msg
@@ -314,13 +317,16 @@ impl TryFromRaw for MsgConnectionOpenAck {
     type Error = anomaly::Error<Kind>;
 
     fn try_from(msg: RawMsgConnectionOpenAck) -> Result<Self, Self::Error> {
-        let proof_height = msg.proof_height
-            .ok_or_else(||Kind::MissingProofHeight)?.epoch_height;
-        let consensus_height = msg.consensus_height
-            .ok_or_else(|| Kind::MissingConsesusHeight)?.epoch_height;
-        let consensus_proof_obj =
-            ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
-                .map_err(|e| Kind::InvalidProof.context(e))?;
+        let proof_height = msg
+            .proof_height
+            .ok_or_else(|| Kind::MissingProofHeight)?
+            .epoch_height;
+        let consensus_height = msg
+            .consensus_height
+            .ok_or_else(|| Kind::MissingConsesusHeight)?
+            .epoch_height;
+        let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
+            .map_err(|e| Kind::InvalidProof.context(e))?;
 
         Ok(Self {
             connection_id: msg
@@ -393,8 +399,10 @@ impl TryFromRaw for MsgConnectionOpenConfirm {
     type Error = anomaly::Error<Kind>;
 
     fn try_from(msg: RawMsgConnectionOpenConfirm) -> Result<Self, Self::Error> {
-        let proof_height = msg.proof_height
-            .ok_or_else(||Kind::MissingProofHeight)?.epoch_height;
+        let proof_height = msg
+            .proof_height
+            .ok_or_else(|| Kind::MissingProofHeight)?
+            .epoch_height;
         Ok(Self {
             connection_id: msg
                 .connection_id
@@ -418,8 +426,8 @@ pub mod test_util {
     use ibc_proto::connection::MsgConnectionOpenInit as RawMsgConnectionOpenInit;
     use ibc_proto::connection::MsgConnectionOpenTry as RawMsgConnectionOpenTry;
 
-    use ibc_proto::commitment::MerklePrefix;
     use ibc_proto::client::Height;
+    use ibc_proto::commitment::MerklePrefix;
 
     pub fn get_dummy_proof() -> Vec<u8> {
         "Y29uc2Vuc3VzU3RhdGUvaWJjb25lY2xpZW50LzIy"
@@ -465,11 +473,17 @@ pub mod test_util {
             counterparty: Some(get_dummy_counterparty()),
             counterparty_versions: vec!["1.0.0".to_string()],
             proof_init: get_dummy_proof(),
-            proof_height: Some(Height{ epoch_number: 1, epoch_height: proof_height }),
+            proof_height: Some(Height {
+                epoch_number: 1,
+                epoch_height: proof_height,
+            }),
             proof_consensus: get_dummy_proof(),
-            consensus_height: Some(Height{ epoch_number: 1, epoch_height: consensus_height }),
+            consensus_height: Some(Height {
+                epoch_number: 1,
+                epoch_height: consensus_height,
+            }),
             signer: get_dummy_account_id(),
-            proof_client: vec![]
+            proof_client: vec![],
         }
     }
 
@@ -478,12 +492,18 @@ pub mod test_util {
             connection_id: "srcconnection".to_string(),
             version: "1.0.0".to_string(),
             proof_try: get_dummy_proof(),
-            proof_height: Some(Height{ epoch_number: 1, epoch_height: 10 }),
+            proof_height: Some(Height {
+                epoch_number: 1,
+                epoch_height: 10,
+            }),
             proof_consensus: get_dummy_proof(),
-            consensus_height: Some(Height{ epoch_number: 1, epoch_height: 10 }),
+            consensus_height: Some(Height {
+                epoch_number: 1,
+                epoch_height: 10,
+            }),
             signer: get_dummy_account_id(),
             client_state: None,
-            proof_client: vec![]
+            proof_client: vec![],
         }
     }
 
@@ -491,7 +511,10 @@ pub mod test_util {
         RawMsgConnectionOpenConfirm {
             connection_id: "srcconnection".to_string(),
             proof_ack: get_dummy_proof(),
-            proof_height: Some(Height{ epoch_number: 1, epoch_height: 10 }),
+            proof_height: Some(Height {
+                epoch_number: 1,
+                epoch_height: 10,
+            }),
             signer: get_dummy_account_id(),
         }
     }
@@ -508,12 +531,12 @@ mod tests {
         MsgConnectionOpenAck, MsgConnectionOpenConfirm, MsgConnectionOpenTry,
     };
     use crate::try_from_raw::TryFromRaw;
+    use ibc_proto::client::Height;
     use ibc_proto::connection::Counterparty as RawCounterparty;
     use ibc_proto::connection::MsgConnectionOpenAck as RawMsgConnectionOpenAck;
     use ibc_proto::connection::MsgConnectionOpenConfirm as RawMsgConnectionOpenConfirm;
     use ibc_proto::connection::MsgConnectionOpenInit as RawMsgConnectionOpenInit;
     use ibc_proto::connection::MsgConnectionOpenTry as RawMsgConnectionOpenTry;
-    use ibc_proto::client::Height;
 
     #[test]
     fn parse_connection_open_init_msg() {
@@ -590,7 +613,8 @@ mod tests {
 
         let default_try_msg = get_dummy_msg_conn_open_try(10, 34);
 
-        let tests: Vec<Test> = vec![
+        let tests: Vec<Test> =
+            vec![
             Test {
                 name: "Good parameters".to_string(),
                 raw: default_try_msg.clone(),
@@ -678,8 +702,8 @@ mod tests {
                 want_pass: false,
             },
         ]
-        .into_iter()
-        .collect();
+            .into_iter()
+            .collect();
 
         for test in tests {
             let msg = MsgConnectionOpenTry::try_from(test.raw.clone());
@@ -731,7 +755,10 @@ mod tests {
             Test {
                 name: "Bad proof height, height is 0".to_string(),
                 raw: RawMsgConnectionOpenAck {
-                    proof_height: Some(Height{ epoch_number: 1, epoch_height: 0 }),
+                    proof_height: Some(Height {
+                        epoch_number: 1,
+                        epoch_height: 0,
+                    }),
                     ..default_ack_msg.clone()
                 },
                 want_pass: false,
@@ -739,7 +766,10 @@ mod tests {
             Test {
                 name: "Bad consensus height, height is 0".to_string(),
                 raw: RawMsgConnectionOpenAck {
-                    consensus_height: Some(Height{ epoch_number: 1, epoch_height: 0 }),
+                    consensus_height: Some(Height {
+                        epoch_number: 1,
+                        epoch_height: 0,
+                    }),
                     ..default_ack_msg
                 },
                 want_pass: false,
@@ -789,7 +819,10 @@ mod tests {
             Test {
                 name: "Bad proof height, height is 0".to_string(),
                 raw: RawMsgConnectionOpenConfirm {
-                    proof_height: Some(Height{ epoch_number: 1, epoch_height: 0 }),
+                    proof_height: Some(Height {
+                        epoch_number: 1,
+                        epoch_height: 0,
+                    }),
                     ..default_ack_msg
                 },
                 want_pass: false,

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -742,8 +742,8 @@ mod tests {
                     ..default_try_msg
                 },
                 want_pass: false,
-            },
-        ]
+            }
+            ]
             .into_iter()
             .collect();
 

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -237,7 +237,7 @@ impl TryFromRaw for MsgConnectionOpenTry {
             .epoch_height;
         let consensus_height = msg
             .consensus_height
-            .ok_or_else(|| Kind::MissingConsesusHeight)?
+            .ok_or_else(|| Kind::MissingConsensusHeight)?
             .epoch_height;
         let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
             .map_err(|e| Kind::InvalidProof.context(e))?;
@@ -357,7 +357,7 @@ impl TryFromRaw for MsgConnectionOpenAck {
             .epoch_height;
         let consensus_height = msg
             .consensus_height
-            .ok_or_else(|| Kind::MissingConsesusHeight)?
+            .ok_or_else(|| Kind::MissingConsensusHeight)?
             .epoch_height;
         let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
             .map_err(|e| Kind::InvalidProof.context(e))?;

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -1,10 +1,12 @@
 use crate::ics04_channel::error::{self, Error, Kind};
 use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 use crate::try_from_raw::TryFromRaw;
+
+use ibc_proto::ibc::channel::Channel as RawChannel;
+
 use anomaly::fail;
-use core::str::FromStr;
-use ibc_proto::channel::Channel as RawChannel;
 use serde_derive::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChannelEnd {
@@ -221,11 +223,13 @@ impl State {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use crate::ics04_channel::channel::ChannelEnd;
     use crate::try_from_raw::TryFromRaw;
-    use core::str::FromStr;
-    use ibc_proto::channel::Channel as RawChannel;
-    use ibc_proto::channel::Counterparty as RawCounterparty;
+
+    use ibc_proto::ibc::channel::Channel as RawChannel;
+    use ibc_proto::ibc::channel::Counterparty as RawCounterparty;
 
     #[test]
     fn channel_end_try_from_raw() {

--- a/modules/src/ics04_channel/msgs.rs
+++ b/modules/src/ics04_channel/msgs.rs
@@ -130,7 +130,7 @@ impl MsgChannelOpenTry {
             ),
             counterparty_version: validate_version(counterparty_version)
                 .map_err(|e| Kind::InvalidVersion.context(e))?,
-            proofs: Proofs::new(proof_init, None, proofs_height)
+            proofs: Proofs::new(proof_init, None, None, proofs_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -190,7 +190,7 @@ impl MsgChannelOpenAck {
                 .map_err(|e| Kind::IdentifierError.context(e))?,
             counterparty_version: validate_version(counterparty_version)
                 .map_err(|e| Kind::InvalidVersion.context(e))?,
-            proofs: Proofs::new(proof_try, None, proofs_height)
+            proofs: Proofs::new(proof_try, None, None, proofs_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -248,7 +248,7 @@ impl MsgChannelOpenConfirm {
             channel_id: channel_id
                 .parse()
                 .map_err(|e| Kind::IdentifierError.context(e))?,
-            proofs: Proofs::new(proof_ack, None, proofs_height)
+            proofs: Proofs::new(proof_ack, None, None, proofs_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -359,7 +359,7 @@ impl MsgChannelCloseConfirm {
             channel_id: channel_id
                 .parse()
                 .map_err(|e| Kind::IdentifierError.context(e))?,
-            proofs: Proofs::new(proof_init, None, proofs_height)
+            proofs: Proofs::new(proof_init, None, None, proofs_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -412,7 +412,7 @@ impl MsgPacket {
             packet: packet
                 .validate()
                 .map_err(|e| Kind::InvalidPacket.context(e))?,
-            proofs: Proofs::new(proof, None, proof_height)
+            proofs: Proofs::new(proof, None, None, proof_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -474,7 +474,7 @@ impl MsgTimeout {
                 .validate()
                 .map_err(|e| Kind::InvalidPacket.context(e))?,
             next_sequence_recv,
-            proofs: Proofs::new(proof, None, proof_height)
+            proofs: Proofs::new(proof, None, None, proof_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -534,7 +534,7 @@ impl MsgAcknowledgement {
                 .validate()
                 .map_err(|e| Kind::InvalidPacket.context(e))?,
             acknowledgement,
-            proofs: Proofs::new(proof, None, proof_height)
+            proofs: Proofs::new(proof, None, None, proof_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })

--- a/modules/src/ics07_tendermint/client_def.rs
+++ b/modules/src/ics07_tendermint/client_def.rs
@@ -1,4 +1,4 @@
-use crate::ics02_client::client_def::ClientDef;
+use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState, ClientDef};
 use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics07_tendermint::client_state::ClientState;
 use crate::ics07_tendermint::consensus_state::ConsensusState;
@@ -32,7 +32,7 @@ impl ClientDef for TendermintClient {
         _proof: &CommitmentProof,
         _client_id: &ClientId,
         _consensus_height: Height,
-        _expected_consensus_state: &Self::ConsensusState,
+        _expected_consensus_state: &AnyConsensusState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         todo!()
     }
@@ -51,12 +51,13 @@ impl ClientDef for TendermintClient {
 
     fn verify_client_full_state(
         &self,
+        _client_state: &Self::ClientState,
         _height: Height,
         _root: &CommitmentRoot,
         _prefix: &CommitmentPrefix,
         _client_id: &ClientId,
         _proof: &CommitmentProof,
-        _expected_client_state: &Self::ClientState,
+        _expected_client_state: &AnyClientState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         unimplemented!()
     }

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -1,7 +1,7 @@
 #![allow(unreachable_code, unused_variables)]
 // TODO -- clean this up
 use crate::ics02_client::client_type::ClientType;
-use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof};
+use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProof, CommitmentRoot};
 
 use crate::ics03_connection::connection::ConnectionEnd;
 use crate::ics07_tendermint::error::{Error, Kind};
@@ -101,6 +101,18 @@ impl crate::ics02_client::state::ClientState for ClientState {
     fn is_frozen(&self) -> bool {
         // If 'frozen_height' is set to a non-zero value, then the client state is frozen.
         self.frozen_height != Height(0)
+    }
+
+    fn verify_client_full_state(
+        &self,
+        height: Height,
+        root: &CommitmentRoot,
+        prefix: &CommitmentPrefix,
+        client_id: &ClientId,
+        proof: &CommitmentProof,
+        expected_client_state: &dyn crate::ics02_client::state::ClientState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unimplemented!()
     }
 
     // fn check_header_and_update_state(

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -1,8 +1,10 @@
 use crate::ics02_client::client_type::ClientType;
-
 use crate::ics07_tendermint::error::{Error, Kind};
+use crate::try_from_raw::TryFromRaw;
+
 use serde_derive::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{convert::TryInto, time::Duration};
+
 use tendermint::block::Height;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -87,6 +89,44 @@ impl crate::ics02_client::state::ClientState for ClientState {
         // If 'frozen_height' is set to a non-zero value, then the client state is frozen.
         self.frozen_height != Height(0)
     }
+}
+
+impl TryFromRaw for ClientState {
+    type Error = Error;
+    type RawType = ibc_proto::ibc::tendermint::ClientState;
+
+    fn try_from(raw: Self::RawType) -> Result<Self, Self::Error> {
+        Ok(Self {
+            chain_id: raw.chain_id,
+            trusting_period: raw
+                .trusting_period
+                .ok_or_else(|| Kind::InvalidRawClientState.context("missing trusting period"))?
+                .try_into()
+                .map_err(|_| Kind::InvalidRawClientState.context("negative trusting period"))?,
+            unbonding_period: raw
+                .unbonding_period
+                .ok_or_else(|| Kind::InvalidRawClientState.context("missing unbonding period"))?
+                .try_into()
+                .map_err(|_| Kind::InvalidRawClientState.context("negative unbonding period"))?,
+            max_clock_drift: raw
+                .max_clock_drift
+                .ok_or_else(|| Kind::InvalidRawClientState.context("missing max clock drift"))?
+                .try_into()
+                .map_err(|_| Kind::InvalidRawClientState.context("negative max clock drift"))?,
+            latest_height: decode_height(
+                raw.latest_height
+                    .ok_or_else(|| Kind::InvalidRawClientState.context("missing latest height"))?,
+            ),
+            frozen_height: decode_height(
+                raw.frozen_height
+                    .ok_or_else(|| Kind::InvalidRawClientState.context("missing frozen height"))?,
+            ),
+        })
+    }
+}
+
+fn decode_height(height: ibc_proto::ibc::client::Height) -> Height {
+    Height(height.epoch_height) // FIXME: This is wrong as it does not take the epoch into account
 }
 
 #[cfg(test)]

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -19,6 +19,9 @@ pub enum Kind {
 
     #[error("validation error")]
     ValidationError,
+
+    #[error("invalid raw client state")]
+    InvalidRawClientState,
 }
 
 impl Kind {

--- a/modules/src/ics23_commitment/merkle.rs
+++ b/modules/src/ics23_commitment/merkle.rs
@@ -1,5 +1,6 @@
 use crate::ics23_commitment::commitment::CommitmentPrefix;
-use ibc_proto::commitment::MerklePath;
+
+use ibc_proto::ibc::commitment::MerklePath;
 
 pub fn apply_prefix(
     prefix: &CommitmentPrefix,

--- a/modules/src/mock_client/client_def.rs
+++ b/modules/src/mock_client/client_def.rs
@@ -7,6 +7,7 @@ use crate::{ics03_connection::connection::ConnectionEnd, ics24_host::Path};
 use crate::mock_client::header::MockHeader;
 use crate::mock_client::state::{MockClientState, MockConsensusState};
 
+use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState};
 use crate::ics23_commitment::commitment::CommitmentRoot;
 use tendermint::block::Height;
 
@@ -38,7 +39,7 @@ impl ClientDef for MockClient {
         _proof: &CommitmentProof,
         client_id: &ClientId,
         _consensus_height: Height,
-        _expected_consensus_state: &Self::ConsensusState,
+        _expected_consensus_state: &AnyConsensusState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let client_prefixed_path =
             Path::ConsensusState(client_id.clone(), height.value()).to_string();
@@ -67,12 +68,13 @@ impl ClientDef for MockClient {
 
     fn verify_client_full_state(
         &self,
+        _client_state: &Self::ClientState,
         _height: Height,
         _root: &CommitmentRoot,
         _prefix: &CommitmentPrefix,
         _client_id: &ClientId,
         _proof: &CommitmentProof,
-        _expected_client_state: &Self::ClientState,
+        _expected_client_state: &AnyClientState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }

--- a/modules/src/mock_client/header.rs
+++ b/modules/src/mock_client/header.rs
@@ -1,6 +1,9 @@
 use crate::ics02_client::client_def::AnyHeader;
 use crate::ics02_client::client_type::ClientType;
+use crate::ics02_client::error::{self, Error};
 use crate::ics02_client::header::Header;
+use crate::try_from_raw::TryFromRaw;
+
 use serde_derive::{Deserialize, Serialize};
 use tendermint::block::Height;
 
@@ -27,4 +30,18 @@ impl Header for MockHeader {
     fn height(&self) -> Height {
         todo!()
     }
+}
+
+impl TryFromRaw for MockHeader {
+    type Error = Error;
+    type RawType = ibc_proto::ibc::mock::Header;
+
+    fn try_from(raw: Self::RawType) -> Result<Self, Self::Error> {
+        let proto_height = raw.height.ok_or_else(|| error::Kind::InvalidRawHeader)?;
+        Ok(Self(decode_height(proto_height)))
+    }
+}
+
+fn decode_height(height: ibc_proto::ibc::client::Height) -> Height {
+    Height(height.epoch_height) // FIXME: This is wrong as it does not take the epoch into account
 }

--- a/modules/src/mock_client/state.rs
+++ b/modules/src/mock_client/state.rs
@@ -91,65 +91,6 @@ impl ClientState for MockClientState {
         // TODO
         false
     }
-
-    /*
-    fn verify_client_full_state(
-        &self,
-        height: Height,
-        root: &CommitmentRoot,
-        prefix: &CommitmentPrefix,
-        client_id: &ClientId,
-        proof: &CommitmentProof,
-        expected_client_state: &dyn ClientState,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        unimplemented!()
-    }
-
-    // fn check_header_and_update_state(
-    //     &self,
-    //     header: &dyn Header,
-    // ) -> Result<(Box<dyn ClientState>, Box<dyn ConsensusState>), Box<dyn std::error::Error>> {
-    //     if self.latest_height() >= header.height() {
-    //         return Err("header height is lower than client latest".into());
-    //     }
-    //
-    //     Ok((
-    //         Box::new(AnyClientState::Mock(MockClientState(header.height().value() as u32))),
-    //         Box::new(AnyConsensusState::Mock(MockConsensusState(header.height().value() as u32))),
-    //     ))
-    // }
-
-    fn verify_client_consensus_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &dyn ConsensusState,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client_prefixed_path =
-            Path::ConsensusState(client_id.clone(), height.value()).to_string();
-        let _path = apply_prefix(prefix, client_prefixed_path)?;
-        // TODO - add ctx to all client verification functions
-        // let cs = ctx.fetch_self_consensus_state(height);
-        // TODO - implement this
-        // proof.verify_membership(cs.root(), path, expected_consensus_state)
-        Ok(())
-    }
-
-    fn verify_connection_state(
-        &self,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProof,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())
-    }
-
-     */
 }
 
 impl From<MockConsensusState> for MockClientState {

--- a/modules/src/mock_client/state.rs
+++ b/modules/src/mock_client/state.rs
@@ -63,6 +63,18 @@ impl ClientState for MockClientState {
         false
     }
 
+    fn verify_client_full_state(
+        &self,
+        height: Height,
+        root: &CommitmentRoot,
+        prefix: &CommitmentPrefix,
+        client_id: &ClientId,
+        proof: &CommitmentProof,
+        expected_client_state: &dyn ClientState,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        unimplemented!()
+    }
+
     // fn check_header_and_update_state(
     //     &self,
     //     header: &dyn Header,

--- a/modules/src/proofs.rs
+++ b/modules/src/proofs.rs
@@ -5,6 +5,7 @@ use tendermint::block::Height;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Proofs {
     object_proof: CommitmentProof,
+    client_proof: Option<CommitmentProof>,
     consensus_proof: Option<ConsensusProof>,
     /// Height for both the above proofs
     height: Height,
@@ -13,6 +14,7 @@ pub struct Proofs {
 impl Proofs {
     pub fn new(
         object_proof: CommitmentProof,
+        client_proof: Option<CommitmentProof>,
         consensus_proof: Option<ConsensusProof>,
         height: u64,
     ) -> Result<Self, String> {
@@ -26,6 +28,7 @@ impl Proofs {
 
         Ok(Self {
             object_proof,
+            client_proof,
             consensus_proof,
             height: Height(height),
         })
@@ -45,6 +48,11 @@ impl Proofs {
     /// Getter for the object-specific proof (e.g., proof for connection state or channel state).
     pub fn object_proof(&self) -> &CommitmentProof {
         &self.object_proof
+    }
+
+    /// Getter for the client_proof
+    pub fn client_proof(&self) -> &Option<CommitmentProof> {
+        &self.client_proof
     }
 }
 


### PR DESCRIPTION
Closes: #226

## Description
Migrate to ibc_proto v0.3.0.

Includes minimal changes such that the code compiles and tests pass. In particular:

- the client state in the handshake messages is not deserialized and therefore further ignored
- the epoch in the new type `Height` is ignored and the deserialization code only extracts the `EpochHeight` in the current `Height` type which is u64.


______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
