### PR TITLE
the ibc crate now uses the local ibc-proto crate

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -19,7 +19,7 @@ tendermint = "0.15.0"
 tendermint-rpc = { version = "0.15.0", features = ["client"] }
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = "0.3.0"
+ibc-proto = { path = "../proto" }
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -19,7 +19,7 @@ tendermint = "0.15.0"
 tendermint-rpc = { version = "0.15.0", features = ["client"] }
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { path = "../proto" }
+ibc-proto = { version = "0.3.0", path = "../proto" }
 
 anomaly = "0.2.0"
 thiserror = "1.0.11"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(warnings, trivial_casts, trivial_numeric_casts, unused_import_braces)]
 #![allow(clippy::large_enum_variant)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/ibc-proto/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/ibc-proto/0.3.0")]
 
 pub mod cosmos {
     pub mod base {


### PR DESCRIPTION
Closes: #142 

## Description
The ibc crate (modules folder) now uses the ibc-proto crate defined in this repository. (proto folder).

I also updated the version in html_url for ibc-proto but it's too late for v0.3.0. We should make sure we update it in the next release.

______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
