### PR TITLE
ClientState implementation with DomainTypes

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,6 +17,7 @@ description = """
 [dependencies]
 tendermint = "0.15.0"
 tendermint-rpc = { version = "0.15.0", features = ["client"] }
+tendermint-proto = "0.1.0"
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.3.0", path = "../proto" }

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -32,7 +32,7 @@ use tendermint::account::Id as AccountId;
 use tendermint::block::Height;
 
 use serde_derive::{Deserialize, Serialize};
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::str::{from_utf8, FromStr};
 
 /// Message type for the `MsgConnectionOpenInit` message.

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -1,11 +1,15 @@
 use crate::ics02_client::client_type::ClientType;
 use crate::ics07_tendermint::error::{Error, Kind};
-use crate::try_from_raw::TryFromRaw;
 
 use serde_derive::{Deserialize, Serialize};
-use std::{convert::TryInto, time::Duration};
+use std::{
+    convert::{TryFrom, TryInto},
+    time::Duration,
+};
 
+use ibc_proto::ibc::tendermint::ClientState as RawClientState;
 use tendermint::block::Height;
+use tendermint_proto::DomainType;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ClientState {
@@ -17,6 +21,8 @@ pub struct ClientState {
     pub latest_height: Height,
     pub frozen_height: Height,
 }
+
+impl DomainType<RawClientState> for ClientState {}
 
 impl ClientState {
     pub fn new(
@@ -91,11 +97,10 @@ impl crate::ics02_client::state::ClientState for ClientState {
     }
 }
 
-impl TryFromRaw for ClientState {
-    type RawType = ibc_proto::ibc::tendermint::ClientState;
+impl TryFrom<RawClientState> for ClientState {
     type Error = Error;
 
-    fn try_from(raw: Self::RawType) -> Result<Self, Self::Error> {
+    fn try_from(raw: RawClientState) -> Result<Self, Self::Error> {
         Ok(Self {
             chain_id: raw.chain_id,
             trusting_period: raw
@@ -122,6 +127,27 @@ impl TryFromRaw for ClientState {
                     .ok_or_else(|| Kind::InvalidRawClientState.context("missing frozen height"))?,
             ),
         })
+    }
+}
+
+impl From<ClientState> for RawClientState {
+    fn from(value: ClientState) -> Self {
+        RawClientState {
+            chain_id: value.chain_id,
+            trust_level: None, // Todo: Why is trust_level commented out?
+            trusting_period: Some(value.trusting_period.into()),
+            unbonding_period: Some(value.unbonding_period.into()),
+            max_clock_drift: Some(value.max_clock_drift.into()),
+            frozen_height: Some(ibc_proto::ibc::client::Height {
+                epoch_number: 0,
+                epoch_height: value.frozen_height.value(),
+            }), // Todo: upgrade to tendermint v0.17.0 Height
+            latest_height: Some(ibc_proto::ibc::client::Height {
+                epoch_number: 0,
+                epoch_height: value.latest_height.value(),
+            }), // Todo: upgrade to tendermint v0.17.0 Height
+            proof_specs: vec![], // Todo: Why is that not stored?
+        }
     }
 }
 
@@ -167,9 +193,9 @@ mod tests {
         // Define a "default" set of parameters to reuse throughout these tests.
         let default_params: ClientStateParams = ClientStateParams {
             id: "thisisthechainid".to_string(),
-            trusting_period: Duration::from_secs(64000),
-            unbonding_period: Duration::from_secs(128000),
-            max_clock_drift: Duration::from_millis(3000),
+            trusting_period: Duration::new(64000, 0),
+            unbonding_period: Duration::new(128000, 0),
+            max_clock_drift: Duration::new(3, 0),
             latest_height: Height(10),
             frozen_height: Height(0),
         };
@@ -197,7 +223,7 @@ mod tests {
             Test {
                 name: "Invalid unbonding period".to_string(),
                 params: ClientStateParams {
-                    unbonding_period: Duration::from_secs(0),
+                    unbonding_period: Duration::default(),
                     ..default_params.clone()
                 },
                 want_pass: false,
@@ -205,7 +231,7 @@ mod tests {
             Test {
                 name: "Invalid (too small) trusting period".to_string(),
                 params: ClientStateParams {
-                    trusting_period: Duration::from_secs(0),
+                    trusting_period: Duration::default(),
                     ..default_params.clone()
                 },
                 want_pass: false,
@@ -213,8 +239,8 @@ mod tests {
             Test {
                 name: "Invalid (too large) trusting period w.r.t. unbonding period".to_string(),
                 params: ClientStateParams {
-                    trusting_period: Duration::from_secs(11),
-                    unbonding_period: Duration::from_secs(10),
+                    trusting_period: Duration::new(11, 0),
+                    unbonding_period: Duration::new(10, 0),
                     ..default_params
                 },
                 want_pass: false,
@@ -229,8 +255,8 @@ mod tests {
             let cs_result = ClientState::new(
                 p.id,
                 p.trusting_period,
-                p.unbonding_period,
-                p.max_clock_drift,
+                p.unbonding_period.into(),
+                p.max_clock_drift.into(),
                 p.latest_height,
                 p.frozen_height,
             );

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -255,8 +255,8 @@ mod tests {
             let cs_result = ClientState::new(
                 p.id,
                 p.trusting_period,
-                p.unbonding_period.into(),
-                p.max_clock_drift.into(),
+                p.unbonding_period,
+                p.max_clock_drift,
                 p.latest_height,
                 p.frozen_height,
             );

--- a/modules/src/ics23_commitment/commitment.rs
+++ b/modules/src/ics23_commitment/commitment.rs
@@ -3,7 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct CommitmentRoot(pub Vec<u8>);
+pub struct CommitmentRoot(pub Vec<u8>); // Todo: write constructor
 impl CommitmentRoot {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         Self {

--- a/modules/src/ics23_commitment/commitment.rs
+++ b/modules/src/ics23_commitment/commitment.rs
@@ -3,7 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct CommitmentRoot(Vec<u8>);
+pub struct CommitmentRoot(pub Vec<u8>);
 impl CommitmentRoot {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         Self {

--- a/proto/definitions/mock/ibc.mock.proto
+++ b/proto/definitions/mock/ibc.mock.proto
@@ -10,3 +10,7 @@ message Header {
 message ClientState {
   Header header = 1;
 }
+
+message ConsensusState {
+  Header header = 1;
+}

--- a/proto/src/prost/ibc.mock.rs
+++ b/proto/src/prost/ibc.mock.rs
@@ -8,3 +8,8 @@ pub struct ClientState {
     #[prost(message, optional, tag="1")]
     pub header: ::std::option::Option<Header>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConsensusState {
+    #[prost(message, optional, tag="1")]
+    pub header: ::std::option::Option<Header>,
+}

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 relayer = { path = "../relayer" }
 ibc = { path = "../modules" }
 tendermint = "0.15.0"
+tendermint-proto = "0.1.0"
 
 abscissa_tokio = "0.5.1"
 anomaly = "0.2.0"

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -81,7 +81,7 @@ impl Runnable for QueryClientStateCmd {
         let chain = CosmosSDKChain::from_config(chain_config).unwrap();
 
         let res: Result<AnyClientState, Error> = chain
-            .query2(ClientState(opts.client_id), opts.height, opts.proof)
+            .abci_query(ClientState(opts.client_id), opts.height, opts.proof)
             .map_err(|e| Kind::Query.context(e).into())
             .and_then(|v| {
                 AnyClientState::decode_vec(&v).map_err(|e| Kind::Query.context(e).into())
@@ -170,7 +170,7 @@ impl Runnable for QueryClientConsensusCmd {
 
         let chain = CosmosSDKChain::from_config(chain_config).unwrap();
         let res: Result<AnyConsensusState, Error> = chain
-            .query2(
+            .abci_query(
                 ClientConsensusState(opts.client_id, opts.consensus_height),
                 opts.height,
                 opts.proof,

--- a/relayer-cli/src/error.rs
+++ b/relayer-cli/src/error.rs
@@ -16,6 +16,10 @@ pub enum Kind {
     /// Input/output error
     #[error("I/O error")]
     Io,
+
+    /// Error during network query
+    #[error("query error")]
+    Query,
 }
 
 impl Kind {

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 ibc = { path = "../modules" }
 tendermint = "0.15.0"
 tendermint-rpc = { version = "0.15.0", features=["client"] }
+tendermint-proto = "0.1.0"
 anomaly = "0.2.0"
 async-trait = "0.1.24"
 humantime-serde = "1.0.0"

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -52,6 +52,9 @@ pub trait Chain {
     where
         T: TryFromRaw;
 
+    /// Perform a generic `query`, and return the corresponding response data.
+    fn query2(&self, data: Path, height: u64, prove: bool) -> Result<Vec<u8>, Self::Error>;
+
     /// Returns the chain's identifier
     fn id(&self) -> &ChainId {
         &self.config().id

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -47,13 +47,16 @@ pub trait Chain {
     // From the "Asynchronous Programming in Rust" book:
     //   Important extensions like `async fn` syntax in trait methods are still unimplemented
     // https://rust-lang.github.io/async-book/01_getting_started/03_state_of_async_rust.html
-    // Todo: More generic chains might want to deal with domain types differently (no T).
+    // DEPRECATED: implement abci_query instead. Since this will be removed before the next release
+    // I'm commenting out the deprectaed warning. It would just confuse the clippy check in CI.
+    //#[deprecated(since = "0.0.4", note = "please use `abci_query` instead")]
     fn query<T>(&self, data: Path, height: u64, prove: bool) -> Result<T, Self::Error>
     where
         T: TryFromRaw;
 
-    /// Perform a generic `query`, and return the corresponding response data.
-    fn query2(&self, data: Path, height: u64, prove: bool) -> Result<Vec<u8>, Self::Error>;
+    /// Perform a generic `query` using ABCI, and return the corresponding response data.
+    /// The naming is foreshadowing for an upcoming `grpc_query` function in the future.
+    fn abci_query(&self, data: Path, height: u64, prove: bool) -> Result<Vec<u8>, Self::Error>;
 
     /// Returns the chain's identifier
     fn id(&self) -> &ChainId {

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -76,7 +76,7 @@ impl Chain for CosmosSDKChain {
             .and_then(|r| T::try_from(r).map_err(|e| Kind::ResponseParsing.context(e).into()))
     }
 
-    fn query2(&self, data: Path, height: u64, prove: bool) -> Result<Vec<u8>, Self::Error> {
+    fn abci_query(&self, data: Path, height: u64, prove: bool) -> Result<Vec<u8>, Self::Error> {
         let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).unwrap();
         if !data.is_provable() & prove {
             return Err(Kind::Store

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -76,6 +76,23 @@ impl Chain for CosmosSDKChain {
             .and_then(|r| T::try_from(r).map_err(|e| Kind::ResponseParsing.context(e).into()))
     }
 
+    fn query2(&self, data: Path, height: u64, prove: bool) -> Result<Vec<u8>, Self::Error> {
+        let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).unwrap();
+        if !data.is_provable() & prove {
+            return Err(Kind::Store
+                .context("requested proof for a path in the privateStore")
+                .into());
+        }
+        let response = block_on(abci_query(&self, path, data.to_string(), height, prove))?;
+
+        // Verify response proof, if requested.
+        if prove {
+            dbg!("Todo: implement proof verification."); // Todo: Verify proof
+        }
+
+        Ok(response)
+    }
+
     fn config(&self) -> &ChainConfig {
         &self.config
     }


### PR DESCRIPTION
Part of #249. Not the full implementation yet, but this piece of code is ready to be used.

First stab at implementing DomainTypes in IBC.
* Note the simplified TryFrom implementations in modules/src/ics02_client/client_def.rs
* Note that the new requirement of implementing the From trait for encoding to protobuf highlights missing pieces of the domain implementation. (It's easy to see and to implement domain logic and it's not hidden inside the encoding trenches.)
* Note the implementation of the new `Chain::query2` function that returns `Vec<u8>`. The original `query` should be replaced with this. (Showing it side-by-side for now.) Some chains might not want to use DomainTypes and they can still implement `query` this way because of the general `Vec<u8>` return. Unfortunately, the disadvantage is that the decoding needs to be done at a higher level (see the AnyClientState query) but with DomainTypes, it's literally just calling one `decode_vec()` function.
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
