### PR TITLE
Move the ibc-proto to latest on cosmos-sdk and adapt the code

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -18,7 +18,7 @@ description = """
 tendermint-proto = "0.1.0"
 
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.3.0", path = "../proto" }
+ibc-proto = { version = "0.4.0", path = "../proto" }
 
 anomaly = "0.2.0"
 chrono = "0.4"

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -489,6 +489,8 @@ mod tests {
             max_clock_drift: Duration::from_millis(3000),
             latest_height: tm_header.signed_header.header.height,
             frozen_height: 0_u64.into(),
+            allow_update_after_expiry: false,
+            allow_update_after_misbehaviour: false
         });
 
         let raw: Any = tm_client_state.clone().into();

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -118,6 +118,17 @@ pub enum AnyClientState {
     Mock(MockClientState),
 }
 
+impl AnyClientState {
+    pub fn height(&self) -> Height {
+        match self {
+            AnyClientState::Tendermint(tcs) => tcs.latest_height(),
+
+            #[cfg(test)]
+            AnyClientState::Mock(mcs) => mcs.latest_height(),
+        }
+    }
+}
+
 impl DomainType<Any> for AnyClientState {}
 
 impl TryFrom<Any> for AnyClientState {
@@ -246,15 +257,6 @@ impl From<AnyConsensusState> for Any {
 impl ConsensusState for AnyConsensusState {
     fn client_type(&self) -> ClientType {
         todo!()
-    }
-
-    fn height(&self) -> Height {
-        match self {
-            AnyConsensusState::Tendermint(cs) => cs.height(),
-
-            #[cfg(test)]
-            AnyConsensusState::Mock(cs) => cs.height(),
-        }
     }
 
     fn root(&self) -> &CommitmentRoot {
@@ -490,7 +492,7 @@ mod tests {
             latest_height: tm_header.signed_header.header.height,
             frozen_height: 0_u64.into(),
             allow_update_after_expiry: false,
-            allow_update_after_misbehaviour: false
+            allow_update_after_misbehaviour: false,
         });
 
         let raw: Any = tm_client_state.clone().into();

--- a/modules/src/ics02_client/context.rs
+++ b/modules/src/ics02_client/context.rs
@@ -17,12 +17,20 @@ pub trait ClientKeeper {
         match handler_res {
             CreateResult(res) => {
                 self.store_client_type(res.client_id.clone(), res.client_type)?;
-                self.store_client_state(res.client_id.clone(), res.client_state)?;
-                self.store_consensus_state(res.client_id, res.consensus_state)?;
+                self.store_client_state(res.client_id.clone(), res.client_state.clone())?;
+                self.store_consensus_state(
+                    res.client_id,
+                    res.client_state.height(),
+                    res.consensus_state,
+                )?;
             }
             UpdateResult(res) => {
-                self.store_client_state(res.client_id.clone(), res.client_state)?;
-                self.store_consensus_state(res.client_id, res.consensus_state)?;
+                self.store_client_state(res.client_id.clone(), res.client_state.clone())?;
+                self.store_consensus_state(
+                    res.client_id,
+                    res.client_state.height(),
+                    res.consensus_state,
+                )?;
             }
         }
         Ok(())
@@ -43,6 +51,7 @@ pub trait ClientKeeper {
     fn store_consensus_state(
         &mut self,
         client_id: ClientId,
+        height: Height,
         consensus_state: AnyConsensusState,
     ) -> Result<(), Error>;
 }

--- a/modules/src/ics02_client/context_mock.rs
+++ b/modules/src/ics02_client/context_mock.rs
@@ -3,7 +3,6 @@ use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::ics02_client::error::{Error, Kind};
-use crate::ics02_client::state::ConsensusState;
 use crate::ics24_host::identifier::ClientId;
 use crate::mock_client::header::MockHeader;
 use crate::mock_client::state::{MockClientRecord, MockClientState, MockConsensusState};
@@ -156,6 +155,7 @@ impl ClientKeeper for MockClientContext {
     fn store_consensus_state(
         &mut self,
         client_id: ClientId,
+        height: Height,
         consensus_state: AnyConsensusState,
     ) -> Result<(), Error> {
         match consensus_state {
@@ -167,7 +167,7 @@ impl ClientKeeper for MockClientContext {
                 });
                 client_record
                     .consensus_states
-                    .insert(consensus_state.height(), consensus_state);
+                    .insert(height, consensus_state);
                 Ok(())
             }
             _ => Err(Kind::BadClientState.into()),

--- a/modules/src/ics02_client/handler/create_client.rs
+++ b/modules/src/ics02_client/handler/create_client.rs
@@ -238,6 +238,8 @@ mod tests {
             max_clock_drift: Duration::from_millis(3000),
             latest_height: tm_header.signed_header.header.height,
             frozen_height: 0_u64.into(),
+            allow_update_after_expiry: false,
+            allow_update_after_misbehaviour: false
         });
 
         let msg = MsgCreateAnyClient {

--- a/modules/src/ics02_client/handler/create_client.rs
+++ b/modules/src/ics02_client/handler/create_client.rs
@@ -239,7 +239,7 @@ mod tests {
             latest_height: tm_header.signed_header.header.height,
             frozen_height: 0_u64.into(),
             allow_update_after_expiry: false,
-            allow_update_after_misbehaviour: false
+            allow_update_after_misbehaviour: false,
         });
 
         let msg = MsgCreateAnyClient {

--- a/modules/src/ics02_client/msgs.rs
+++ b/modules/src/ics02_client/msgs.rs
@@ -3,7 +3,7 @@
 //! handles these messages in two layers: first with the general ICS 02 client handler, which
 //! subsequently calls into the chain-specific (e.g., ICS 07) client handler. See:
 //! https://github.com/cosmos/ics/tree/master/spec/ics-002-client-semantics#create.
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use crate::ics02_client::client_def::{AnyClientState, AnyConsensusState, AnyHeader};
 use crate::ics02_client::client_type::ClientType;
@@ -14,6 +14,7 @@ use crate::tx_msg::Msg;
 use ibc_proto::ibc::client::MsgCreateClient as RawMsgCreateClient;
 use tendermint::account::Id as AccountId;
 use tendermint_proto::{DomainType, Error, Kind};
+use std::str::FromStr;
 
 const TYPE_MSG_CREATE_CLIENT: &str = "create_client";
 
@@ -109,7 +110,8 @@ impl TryFrom<RawMsgCreateClient> for MsgCreateAnyClient {
             client_type,
             client_state: AnyClientState::try_from(raw_client_state).unwrap(),
             consensus_state: AnyConsensusState::try_from(raw_consensus_state).unwrap(),
-            signer: AccountId::new(raw.signer[..20].try_into().unwrap()),
+            signer: AccountId::from_str(raw.signer.as_str())
+                .map_err(|e| Kind::DecodeMessage.context(e))?,
         })
     }
 }
@@ -120,7 +122,7 @@ impl From<MsgCreateAnyClient> for RawMsgCreateClient {
             client_id: ics_msg.client_id.to_string(),
             client_state: Some(ics_msg.client_state.into()),
             consensus_state: Some(ics_msg.consensus_state.into()),
-            signer: Vec::from(ics_msg.signer.as_bytes()),
+            signer: ics_msg.signer.to_string(),
         }
     }
 }
@@ -160,6 +162,8 @@ mod tests {
             max_clock_drift: Duration::from_millis(3000),
             latest_height: tm_header.signed_header.header.height,
             frozen_height: 0_u64.into(),
+            allow_update_after_expiry: false,
+            allow_update_after_misbehaviour: false
         });
 
         let msg = MsgCreateAnyClient {

--- a/modules/src/ics02_client/msgs.rs
+++ b/modules/src/ics02_client/msgs.rs
@@ -12,9 +12,9 @@ use crate::ics24_host::identifier::ClientId;
 use crate::tx_msg::Msg;
 
 use ibc_proto::ibc::client::MsgCreateClient as RawMsgCreateClient;
+use std::str::FromStr;
 use tendermint::account::Id as AccountId;
 use tendermint_proto::{DomainType, Error, Kind};
-use std::str::FromStr;
 
 const TYPE_MSG_CREATE_CLIENT: &str = "create_client";
 
@@ -163,7 +163,7 @@ mod tests {
             latest_height: tm_header.signed_header.header.height,
             frozen_height: 0_u64.into(),
             allow_update_after_expiry: false,
-            allow_update_after_misbehaviour: false
+            allow_update_after_misbehaviour: false,
         });
 
         let msg = MsgCreateAnyClient {

--- a/modules/src/ics02_client/state.rs
+++ b/modules/src/ics02_client/state.rs
@@ -7,9 +7,6 @@ pub trait ConsensusState: Clone + std::fmt::Debug {
     /// Type of client associated with this consensus state (eg. Tendermint)
     fn client_type(&self) -> ClientType;
 
-    /// Height of consensus state
-    fn height(&self) -> Height;
-
     /// Commitment root of the consensus state, which is used for key-value pair verification.
     fn root(&self) -> &CommitmentRoot;
 

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -35,11 +35,12 @@ pub enum ConnectionMsg {
 
 #[cfg(test)]
 pub mod test_util {
-    use std::str::{from_utf8, FromStr};
+    use std::str::FromStr;
     use tendermint::account::Id as AccountId;
 
     use ibc_proto::ibc::commitment::MerklePrefix;
     use ibc_proto::ibc::connection::Counterparty as RawCounterparty;
+    use serde_json::from_str;
 
     pub fn get_dummy_proof() -> Vec<u8> {
         "Y29uc2Vuc3VzU3RhdGUvaWJjb25lY2xpZW50LzIy"
@@ -47,14 +48,12 @@ pub mod test_util {
             .to_vec()
     }
 
-    pub fn get_dummy_account_id_bytes() -> Vec<u8> {
-        "0CDA3F47EF3C4906693B170EF650EB968C5F4B2C"
-            .as_bytes()
-            .to_vec()
+    pub fn get_dummy_account_id_raw() -> String {
+        "0CDA3F47EF3C4906693B170EF650EB968C5F4B2C".to_string()
     }
 
     pub fn get_dummy_account_id() -> AccountId {
-        AccountId::from_str(from_utf8(&get_dummy_account_id_bytes()).unwrap()).unwrap()
+        AccountId::from_str(from_str(&get_dummy_account_id_raw()).unwrap()).unwrap()
     }
 
     pub fn get_dummy_counterparty() -> RawCounterparty {

--- a/modules/src/ics03_connection/msgs.rs
+++ b/modules/src/ics03_connection/msgs.rs
@@ -40,7 +40,6 @@ pub mod test_util {
 
     use ibc_proto::ibc::commitment::MerklePrefix;
     use ibc_proto::ibc::connection::Counterparty as RawCounterparty;
-    use serde_json::from_str;
 
     pub fn get_dummy_proof() -> Vec<u8> {
         "Y29uc2Vuc3VzU3RhdGUvaWJjb25lY2xpZW50LzIy"
@@ -53,7 +52,7 @@ pub mod test_util {
     }
 
     pub fn get_dummy_account_id() -> AccountId {
-        AccountId::from_str(from_str(&get_dummy_account_id_raw()).unwrap()).unwrap()
+        AccountId::from_str(&get_dummy_account_id_raw()).unwrap()
     }
 
     pub fn get_dummy_counterparty() -> RawCounterparty {

--- a/modules/src/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_ack.rs
@@ -172,7 +172,7 @@ pub mod test_util {
     use ibc_proto::ibc::client::Height;
     use ibc_proto::ibc::connection::MsgConnectionOpenAck as RawMsgConnectionOpenAck;
 
-    use crate::ics03_connection::msgs::test_util::{get_dummy_proof, get_dummy_account_id_raw};
+    use crate::ics03_connection::msgs::test_util::{get_dummy_account_id_raw, get_dummy_proof};
 
     pub fn get_dummy_msg_conn_open_ack() -> RawMsgConnectionOpenAck {
         RawMsgConnectionOpenAck {

--- a/modules/src/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_ack.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use ibc_proto::ibc::connection::MsgConnectionOpenAck as RawMsgConnectionOpenAck;
 use tendermint_proto::DomainType;
@@ -13,6 +13,7 @@ use crate::ics03_connection::error::{Error, Kind};
 use crate::ics24_host::identifier::ConnectionId;
 use crate::proofs::{ConsensusProof, Proofs};
 use crate::tx_msg::Msg;
+use std::str::FromStr;
 
 /// Message type for the `MsgConnectionOpenAck` message.
 pub const TYPE_MSG_CONNECTION_OPEN_ACK: &str = "connection_open_ack";
@@ -124,11 +125,8 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
                 proof_height,
             )
             .map_err(|e| Kind::InvalidProof.context(e))?,
-            signer: AccountId::new(
-                msg.signer[..20]
-                    .try_into()
-                    .map_err(|e| Kind::InvalidSigner.context(e))?,
-            ),
+            signer: AccountId::from_str(msg.signer.as_str())
+                .map_err(|e| Kind::InvalidSigner.context(e))?,
         })
     }
 }
@@ -164,7 +162,7 @@ impl From<MsgConnectionOpenAck> for RawMsgConnectionOpenAck {
                     })
                 },
             ),
-            signer: Vec::from(ics_msg.signer.as_bytes()),
+            signer: ics_msg.signer.to_string(),
         }
     }
 }
@@ -174,7 +172,7 @@ pub mod test_util {
     use ibc_proto::ibc::client::Height;
     use ibc_proto::ibc::connection::MsgConnectionOpenAck as RawMsgConnectionOpenAck;
 
-    use crate::ics03_connection::msgs::test_util::{get_dummy_account_id, get_dummy_proof};
+    use crate::ics03_connection::msgs::test_util::{get_dummy_proof, get_dummy_account_id_raw};
 
     pub fn get_dummy_msg_conn_open_ack() -> RawMsgConnectionOpenAck {
         RawMsgConnectionOpenAck {
@@ -192,7 +190,7 @@ pub mod test_util {
             }),
             client_state: None,
             proof_client: vec![],
-            signer: Vec::from(get_dummy_account_id().as_bytes()),
+            signer: get_dummy_account_id_raw(),
         }
     }
 }

--- a/modules/src/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_init.rs
@@ -112,7 +112,9 @@ impl From<MsgConnectionOpenInit> for RawMsgConnectionOpenInit {
 pub mod test_util {
     use ibc_proto::ibc::connection::MsgConnectionOpenInit as RawMsgConnectionOpenInit;
 
-    use crate::ics03_connection::msgs::test_util::{get_dummy_account_id_raw, get_dummy_counterparty};
+    use crate::ics03_connection::msgs::test_util::{
+        get_dummy_account_id_raw, get_dummy_counterparty,
+    };
 
     /// Returns a dummy message, for testing only.
     /// Other unit tests may import this if they depend on a MsgConnectionOpenInit.

--- a/modules/src/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_init.rs
@@ -10,6 +10,7 @@ use crate::ics03_connection::connection::Counterparty;
 use crate::ics03_connection::error::{Error, Kind};
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
 use crate::tx_msg::Msg;
+use std::str::FromStr;
 
 /// Message type for the `MsgConnectionOpenInit` message.
 pub const TYPE_MSG_CONNECTION_OPEN_INIT: &str = "connection_open_init";
@@ -90,11 +91,8 @@ impl TryFrom<RawMsgConnectionOpenInit> for MsgConnectionOpenInit {
                 .counterparty
                 .ok_or_else(|| Kind::MissingCounterparty)?
                 .try_into()?,
-            signer: AccountId::new(
-                msg.signer[..20]
-                    .try_into()
-                    .map_err(|e| Kind::InvalidSigner.context(e))?,
-            ),
+            signer: AccountId::from_str(msg.signer.as_str())
+                .map_err(|e| Kind::InvalidSigner.context(e))?,
         })
     }
 }
@@ -105,7 +103,7 @@ impl From<MsgConnectionOpenInit> for RawMsgConnectionOpenInit {
             client_id: ics_msg.client_id.as_str().to_string(),
             connection_id: ics_msg.connection_id.as_str().to_string(),
             counterparty: Some(ics_msg.counterparty.into()),
-            signer: Vec::from(ics_msg.signer.as_bytes()),
+            signer: ics_msg.signer.to_string(),
         }
     }
 }
@@ -114,7 +112,7 @@ impl From<MsgConnectionOpenInit> for RawMsgConnectionOpenInit {
 pub mod test_util {
     use ibc_proto::ibc::connection::MsgConnectionOpenInit as RawMsgConnectionOpenInit;
 
-    use crate::ics03_connection::msgs::test_util::{get_dummy_account_id, get_dummy_counterparty};
+    use crate::ics03_connection::msgs::test_util::{get_dummy_account_id_raw, get_dummy_counterparty};
 
     /// Returns a dummy message, for testing only.
     /// Other unit tests may import this if they depend on a MsgConnectionOpenInit.
@@ -123,7 +121,7 @@ pub mod test_util {
             client_id: "srcclient".to_string(),
             connection_id: "srcconnection".to_string(),
             counterparty: Some(get_dummy_counterparty()),
-            signer: Vec::from(get_dummy_account_id().as_bytes()),
+            signer: get_dummy_account_id_raw(),
         }
     }
 }

--- a/modules/src/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_try.rs
@@ -13,6 +13,7 @@ use crate::ics03_connection::error::{Error, Kind};
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
 use crate::proofs::{ConsensusProof, Proofs};
 use crate::tx_msg::Msg;
+use std::str::FromStr;
 
 /// Message type for the `MsgConnectionOpenTry` message.
 pub const TYPE_MSG_CONNECTION_OPEN_TRY: &str = "connection_open_try";
@@ -147,11 +148,8 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
                 proof_height,
             )
             .map_err(|e| Kind::InvalidProof.context(e))?,
-            signer: AccountId::new(
-                msg.signer[..20]
-                    .try_into()
-                    .map_err(|e| Kind::InvalidSigner.context(e))?,
-            ),
+            signer: AccountId::from_str(msg.signer.as_str())
+                .map_err(|e| Kind::InvalidSigner.context(e))?,
         })
     }
 }
@@ -189,7 +187,7 @@ impl From<MsgConnectionOpenTry> for RawMsgConnectionOpenTry {
                     })
                 },
             ),
-            signer: Vec::from(ics_msg.signer.as_bytes()),
+            signer: ics_msg.signer.to_string(),
         }
     }
 }
@@ -200,7 +198,7 @@ pub mod test_util {
     use ibc_proto::ibc::connection::MsgConnectionOpenTry as RawMsgConnectionOpenTry;
 
     use crate::ics03_connection::msgs::test_util::{
-        get_dummy_account_id, get_dummy_counterparty, get_dummy_proof,
+        get_dummy_account_id_raw, get_dummy_counterparty, get_dummy_proof,
     };
 
     pub fn get_dummy_msg_conn_open_try(
@@ -224,7 +222,7 @@ pub mod test_util {
                 epoch_height: consensus_height,
             }),
             proof_client: vec![],
-            signer: Vec::from(get_dummy_account_id().as_bytes()),
+            signer: get_dummy_account_id_raw(),
         }
     }
 }

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -20,6 +20,8 @@ pub struct ClientState {
     pub max_clock_drift: Duration,
     pub latest_height: Height,
     pub frozen_height: Height,
+    pub allow_update_after_expiry: bool,
+    pub allow_update_after_misbehaviour: bool
 }
 
 impl DomainType<RawClientState> for ClientState {}
@@ -33,6 +35,8 @@ impl ClientState {
         max_clock_drift: Duration,
         latest_height: Height,
         frozen_height: Height,
+        allow_update_after_expiry: bool,
+        allow_update_after_misbehaviour: bool
         // proof_specs: Specs
     ) -> Result<ClientState, Error> {
         // Basic validation of trusting period and unbonding period: each should be non-zero.
@@ -74,6 +78,8 @@ impl ClientState {
             max_clock_drift,
             frozen_height,
             latest_height,
+            allow_update_after_expiry,
+            allow_update_after_misbehaviour
         })
     }
 }
@@ -126,6 +132,8 @@ impl TryFrom<RawClientState> for ClientState {
                 raw.frozen_height
                     .ok_or_else(|| Kind::InvalidRawClientState.context("missing frozen height"))?,
             ),
+            allow_update_after_expiry: raw.allow_update_after_expiry,
+            allow_update_after_misbehaviour: raw.allow_update_after_misbehaviour
         })
     }
 }
@@ -147,6 +155,8 @@ impl From<ClientState> for RawClientState {
                 epoch_height: value.latest_height.value(),
             }), // Todo: upgrade to tendermint v0.17.0 Height
             proof_specs: vec![], // Todo: Why is that not stored?
+            allow_update_after_expiry: false,
+            allow_update_after_misbehaviour: false
         }
     }
 }

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -144,7 +144,7 @@ impl TryFrom<RawClientState> for ClientState {
 impl From<ClientState> for RawClientState {
     fn from(value: ClientState) -> Self {
         RawClientState {
-            chain_id: value.clone().chain_id,
+            chain_id: value.chain_id.clone(),
             trust_level: None, // Todo: Why is trust_level commented out?
             trusting_period: Some(value.trusting_period.into()),
             unbonding_period: Some(value.unbonding_period.into()),

--- a/modules/src/ics07_tendermint/consensus_state.rs
+++ b/modules/src/ics07_tendermint/consensus_state.rs
@@ -16,22 +16,15 @@ use crate::ics23_commitment::commitment::CommitmentRoot;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConsensusState {
-    pub height: crate::Height,
     pub timestamp: Time,
     pub root: CommitmentRoot,
     pub next_validators_hash: Hash,
 }
 
 impl ConsensusState {
-    pub fn new(
-        root: CommitmentRoot,
-        height: crate::Height,
-        timestamp: Time,
-        next_validators_hash: Hash,
-    ) -> Self {
+    pub fn new(root: CommitmentRoot, timestamp: Time, next_validators_hash: Hash) -> Self {
         Self {
             root,
-            height,
             timestamp,
             next_validators_hash,
         }
@@ -41,10 +34,6 @@ impl ConsensusState {
 impl crate::ics02_client::state::ConsensusState for ConsensusState {
     fn client_type(&self) -> ClientType {
         ClientType::Tendermint
-    }
-
-    fn height(&self) -> crate::Height {
-        self.height
     }
 
     fn root(&self) -> &CommitmentRoot {
@@ -74,11 +63,6 @@ impl TryFrom<RawConsensusState> for ConsensusState {
                 .ok_or_else(|| Kind::InvalidRawConsensusState.context("missing commitment root"))?
                 .hash
                 .into(),
-            height: raw
-                .height
-                .ok_or_else(|| Kind::InvalidRawConsensusState.context("missing height"))?
-                .epoch_height
-                .into(),
             timestamp: Utc
                 .timestamp(proto_timestamp.seconds, proto_timestamp.nanos as u32)
                 .into(),
@@ -93,10 +77,6 @@ impl From<ConsensusState> for RawConsensusState {
         RawConsensusState {
             timestamp: Some(value.timestamp.to_system_time().unwrap().into()),
             root: Some(ibc_proto::ibc::commitment::MerkleRoot { hash: value.root.0 }),
-            height: Some(ibc_proto::ibc::client::Height {
-                epoch_number: 0,
-                epoch_height: value.height.value(),
-            }),
             next_validators_hash: value.next_validators_hash.as_bytes().to_vec(),
         }
     }
@@ -106,7 +86,6 @@ impl From<SignedHeader> for ConsensusState {
     fn from(header: SignedHeader) -> Self {
         Self {
             root: CommitmentRoot::from_bytes(&header.header.app_hash),
-            height: header.header.height,
             timestamp: header.header.time,
             next_validators_hash: header.header.next_validators_hash,
         }

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -20,7 +20,6 @@ pub struct Header {
 impl Header {
     pub(crate) fn consensus_state(&self) -> ConsensusState {
         ConsensusState {
-            height: self.signed_header.header.height,
             timestamp: self.signed_header.header.time,
             root: CommitmentRoot::from_bytes(&self.signed_header.header.app_hash),
             next_validators_hash: self.signed_header.header.next_validators_hash,

--- a/modules/src/ics26_routing/context_mock.rs
+++ b/modules/src/ics26_routing/context_mock.rs
@@ -142,10 +142,11 @@ impl ClientKeeper for MockICS26Context {
     fn store_consensus_state(
         &mut self,
         client_id: ClientId,
+        height: Height,
         consensus_state: AnyConsensusState,
     ) -> Result<(), ICS2Error> {
         self.client_context
-            .store_consensus_state(client_id, consensus_state)?;
+            .store_consensus_state(client_id, height, consensus_state)?;
         Ok(())
     }
 }

--- a/modules/src/mock_client/client_def.rs
+++ b/modules/src/mock_client/client_def.rs
@@ -1,7 +1,7 @@
+use crate::ics23_commitment::commitment::CommitmentProof;
 use crate::ics23_commitment::{commitment::CommitmentPrefix, merkle::apply_prefix};
 use crate::ics24_host::identifier::ConnectionId;
 use crate::{ics02_client::client_def::ClientDef, ics24_host::identifier::ClientId};
-use crate::{ics02_client::state::ClientState, ics23_commitment::commitment::CommitmentProof};
 use crate::{ics03_connection::connection::ConnectionEnd, ics24_host::Path};
 
 use crate::mock_client::header::MockHeader;

--- a/modules/src/mock_client/state.rs
+++ b/modules/src/mock_client/state.rs
@@ -40,6 +40,10 @@ pub struct MockClientState(pub MockHeader);
 impl DomainType<RawMockClientState> for MockClientState {}
 
 impl MockClientState {
+    pub fn latest_height(&self) -> Height {
+        (self.0).0
+    }
+
     pub fn check_header_and_update_state(
         &self,
         header: AnyHeader,
@@ -136,7 +140,7 @@ impl From<MockConsensusState> for RawMockConsensusState {
             header: Some(ibc_proto::ibc::mock::Header {
                 height: Some(ibc_proto::ibc::client::Height {
                     epoch_number: 0,
-                    epoch_height: value.height().value(),
+                    epoch_height: value.0.height().into(),
                 }),
             }),
         }
@@ -153,10 +157,6 @@ impl From<MockConsensusState> for AnyConsensusState {
 impl ConsensusState for MockConsensusState {
     fn client_type(&self) -> ClientType {
         todo!()
-    }
-
-    fn height(&self) -> Height {
-        self.0.height()
     }
 
     fn root(&self) -> &CommitmentRoot {

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Greg Szabo <greg@informal.systems>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/proto/src/prost/cosmos.base.abci.v1beta1.rs
+++ b/proto/src/prost/cosmos.base.abci.v1beta1.rs
@@ -17,7 +17,8 @@ pub struct TxResponse {
     /// Result bytes, if any.
     #[prost(string, tag="5")]
     pub data: std::string::String,
-    /// The output of the application's logger (raw string). May be non-deterministic.
+    /// The output of the application's logger (raw string). May be
+    /// non-deterministic.
     #[prost(string, tag="6")]
     pub raw_log: std::string::String,
     /// The output of the application's logger (typed). May be non-deterministic.
@@ -35,8 +36,9 @@ pub struct TxResponse {
     /// The request transaction bytes.
     #[prost(message, optional, tag="11")]
     pub tx: ::std::option::Option<::prost_types::Any>,
-    /// Time of the previous block. For heights > 1, it's the weighted median of the
-    /// timestamps of the valid votes in the block.LastCommit. For height == 1, it's genesis time.
+    /// Time of the previous block. For heights > 1, it's the weighted median of
+    /// the timestamps of the valid votes in the block.LastCommit. For height == 1,
+    /// it's genesis time.
     #[prost(string, tag="12")]
     pub timestamp: std::string::String,
 }
@@ -83,15 +85,15 @@ pub struct GasInfo {
 /// Result is the union of ResponseFormat and ResponseCheckTx.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    /// Data is any data returned from message or handler execution. It MUST be length
-    /// prefixed in order to separate data from multiple message executions.
+    /// Data is any data returned from message or handler execution. It MUST be
+    /// length prefixed in order to separate data from multiple message executions.
     #[prost(bytes, tag="1")]
     pub data: std::vec::Vec<u8>,
     /// Log contains the log information from message or handler execution.
     #[prost(string, tag="2")]
     pub log: std::string::String,
-    /// Events contains a slice of Event objects that were emitted during message or
-    /// handler execution.
+    /// Events contains a slice of Event objects that were emitted during message
+    /// or handler execution.
     #[prost(message, repeated, tag="3")]
     pub events: ::std::vec::Vec<super::super::super::super::tendermint::abci::Event>,
 }
@@ -104,7 +106,8 @@ pub struct SimulationResponse {
     #[prost(message, optional, tag="2")]
     pub result: ::std::option::Option<Result>,
 }
-/// MsgData defines the data returned in a Result object during message execution.
+/// MsgData defines the data returned in a Result object during message
+/// execution.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgData {
     #[prost(string, tag="1")]
@@ -112,10 +115,32 @@ pub struct MsgData {
     #[prost(bytes, tag="2")]
     pub data: std::vec::Vec<u8>,
 }
-/// TxMsgData defines a list of MsgData. A transaction will have a MsgData object for
-/// each message.
+/// TxMsgData defines a list of MsgData. A transaction will have a MsgData object
+/// for each message.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxMsgData {
     #[prost(message, repeated, tag="1")]
     pub data: ::std::vec::Vec<MsgData>,
+}
+/// SearchTxsResult defines a structure for querying txs pageable
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SearchTxsResult {
+    /// Count of all txs
+    #[prost(uint64, tag="1")]
+    pub total_count: u64,
+    /// Count of txs in current page
+    #[prost(uint64, tag="2")]
+    pub count: u64,
+    /// Index of current page, start from 1
+    #[prost(uint64, tag="3")]
+    pub page_number: u64,
+    /// Count of total pages
+    #[prost(uint64, tag="4")]
+    pub page_total: u64,
+    /// Max count txs per page
+    #[prost(uint64, tag="5")]
+    pub limit: u64,
+    /// List of txs in current page
+    #[prost(message, repeated, tag="6")]
+    pub txs: ::std::vec::Vec<TxResponse>,
 }

--- a/proto/src/prost/cosmos.base.crypto.v1beta1.rs
+++ b/proto/src/prost/cosmos.base.crypto.v1beta1.rs
@@ -27,8 +27,8 @@ pub mod public_key {
         AnyPubkey(::prost_types::Any),
     }
 }
-/// PubKeyMultisigThreshold specifies a public key type which nests multiple public
-/// keys and a threshold
+/// PubKeyMultisigThreshold specifies a public key type which nests multiple
+/// public keys and a threshold
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PubKeyMultisigThreshold {
     #[prost(uint32, tag="1")]
@@ -37,8 +37,8 @@ pub struct PubKeyMultisigThreshold {
     pub public_keys: ::std::vec::Vec<PublicKey>,
 }
 /// MultiSignature wraps the signatures from a PubKeyMultisigThreshold.
-/// See cosmos.tx.v1betata1.ModeInfo.Multi for how to specify which signers signed and
-/// with which modes.
+/// See cosmos.tx.v1betata1.ModeInfo.Multi for how to specify which signers
+/// signed and with which modes.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MultiSignature {
     #[prost(bytes, repeated, tag="1")]

--- a/proto/src/prost/cosmos.base.query.v1beta1.rs
+++ b/proto/src/prost/cosmos.base.query.v1beta1.rs
@@ -22,13 +22,14 @@ pub struct PageRequest {
     #[prost(uint64, tag="3")]
     pub limit: u64,
     /// count_total is set to true  to indicate that the result set should include
-    /// a count of the total number of items available for pagination in UIs. count_total
-    /// is only respected when offset is used. It is ignored when key is set.
+    /// a count of the total number of items available for pagination in UIs.
+    /// count_total is only respected when offset is used. It is ignored when key
+    /// is set.
     #[prost(bool, tag="4")]
     pub count_total: bool,
 }
-/// PageResponse is to be embedded in gRPC response messages where the corresponding
-/// request message has used PageRequest.
+/// PageResponse is to be embedded in gRPC response messages where the
+/// corresponding request message has used PageRequest.
 ///
 ///  message SomeResponse {
 ///          repeated Bar results = 1;

--- a/proto/src/prost/cosmos.base.reflection.v1beta1.rs
+++ b/proto/src/prost/cosmos.base.reflection.v1beta1.rs
@@ -9,14 +9,16 @@ pub struct ListAllInterfacesResponse {
     #[prost(string, repeated, tag="1")]
     pub interface_names: ::std::vec::Vec<std::string::String>,
 }
-/// ListImplementationsRequest is the request type of the ListImplementations RPC.
+/// ListImplementationsRequest is the request type of the ListImplementations
+/// RPC.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListImplementationsRequest {
     /// interface_name defines the interface to query the implementations for.
     #[prost(string, tag="1")]
     pub interface_name: std::string::String,
 }
-/// ListImplementationsResponse is the response type of the ListImplementations RPC.
+/// ListImplementationsResponse is the response type of the ListImplementations
+/// RPC.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListImplementationsResponse {
     #[prost(string, repeated, tag="1")]

--- a/proto/src/prost/cosmos.base.store.v1beta1.rs
+++ b/proto/src/prost/cosmos.base.store.v1beta1.rs
@@ -25,3 +25,38 @@ pub struct CommitId {
     #[prost(bytes, tag="2")]
     pub hash: std::vec::Vec<u8>,
 }
+/// SnapshotItem is an item contained in a rootmulti.Store snapshot.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotItem {
+    /// item is the specific type of snapshot item.
+    #[prost(oneof="snapshot_item::Item", tags="1, 2")]
+    pub item: ::std::option::Option<snapshot_item::Item>,
+}
+pub mod snapshot_item {
+    /// item is the specific type of snapshot item.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Item {
+        #[prost(message, tag="1")]
+        Store(super::SnapshotStoreItem),
+        #[prost(message, tag="2")]
+        Iavl(super::SnapshotIavlItem),
+    }
+}
+/// SnapshotStoreItem contains metadata about a snapshotted store.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotStoreItem {
+    #[prost(string, tag="1")]
+    pub name: std::string::String,
+}
+/// SnapshotIAVLItem is an exported IAVL node.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotIavlItem {
+    #[prost(bytes, tag="1")]
+    pub key: std::vec::Vec<u8>,
+    #[prost(bytes, tag="2")]
+    pub value: std::vec::Vec<u8>,
+    #[prost(int64, tag="3")]
+    pub version: i64,
+    #[prost(int32, tag="4")]
+    pub height: i32,
+}

--- a/proto/src/prost/cosmos.tx.signing.v1beta1.rs
+++ b/proto/src/prost/cosmos.tx.signing.v1beta1.rs
@@ -5,14 +5,15 @@ pub struct SignatureDescriptors {
     #[prost(message, repeated, tag="1")]
     pub signatures: ::std::vec::Vec<SignatureDescriptor>,
 }
-/// SignatureDescriptor is a convenience type which represents the full data for a
-/// signature including the public key of the signer, signing modes and the signature
-/// itself. It is primarily used for coordinating signatures between clients.
+/// SignatureDescriptor is a convenience type which represents the full data for
+/// a signature including the public key of the signer, signing modes and the
+/// signature itself. It is primarily used for coordinating signatures between
+/// clients.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignatureDescriptor {
     /// public_key is the public key of the signer
     #[prost(message, optional, tag="1")]
-    pub public_key: ::std::option::Option<super::super::super::base::crypto::v1beta1::PublicKey>,
+    pub public_key: ::std::option::Option<::prost_types::Any>,
     #[prost(message, optional, tag="2")]
     pub data: ::std::option::Option<signature_descriptor::Data>,
     /// sequence is the sequence of the account, which describes the
@@ -66,13 +67,15 @@ pub mod signature_descriptor {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SignMode {
-    /// SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be rejected
+    /// SIGN_MODE_UNSPECIFIED specifies an unknown signing mode and will be
+    /// rejected
     Unspecified = 0,
-    /// SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is verified
-    /// with raw bytes from Tx
+    /// SIGN_MODE_DIRECT specifies a signing mode which uses SignDoc and is
+    /// verified with raw bytes from Tx
     Direct = 1,
-    /// SIGN_MODE_TEXTUAL is a future signing mode that will verify some human-readable
-    /// textual representation on top of the binary representation from SIGN_MODE_DIRECT
+    /// SIGN_MODE_TEXTUAL is a future signing mode that will verify some
+    /// human-readable textual representation on top of the binary representation
+    /// from SIGN_MODE_DIRECT
     Textual = 2,
     /// SIGN_MODE_LEGACY_AMINO_JSON is a backwards compatibility mode which uses
     /// Amino JSON and will be removed in the future

--- a/proto/src/prost/cosmos.tx.v1beta1.rs
+++ b/proto/src/prost/cosmos.tx.v1beta1.rs
@@ -4,39 +4,46 @@ pub struct Tx {
     /// body is the processable content of the transaction
     #[prost(message, optional, tag="1")]
     pub body: ::std::option::Option<TxBody>,
-    /// auth_info is the authorization related content of the transaction, specifically
-    /// signers, signer modes and fee
+    /// auth_info is the authorization related content of the transaction,
+    /// specifically signers, signer modes and fee
     #[prost(message, optional, tag="2")]
     pub auth_info: ::std::option::Option<AuthInfo>,
-    /// signatures is a list of signatures that matches the length and order of AuthInfo's signer_infos to
-    /// allow connecting signature meta information like public key and signing mode by position.
+    /// signatures is a list of signatures that matches the length and order of
+    /// AuthInfo's signer_infos to allow connecting signature meta information like
+    /// public key and signing mode by position.
     #[prost(bytes, repeated, tag="3")]
     pub signatures: ::std::vec::Vec<std::vec::Vec<u8>>,
 }
-/// TxRaw is a variant of Tx that pins the signer's exact binary representation of body and
-/// auth_info. This is used for signing, broadcasting and verification. The binary
-/// `serialize(tx: TxRaw)` is stored in Tendermint and the hash `sha256(serialize(tx: TxRaw))`
-/// becomes the "txhash", commonly used as the transaction ID.
+/// TxRaw is a variant of Tx that pins the signer's exact binary representation
+/// of body and auth_info. This is used for signing, broadcasting and
+/// verification. The binary `serialize(tx: TxRaw)` is stored in Tendermint and
+/// the hash `sha256(serialize(tx: TxRaw))` becomes the "txhash", commonly used
+/// as the transaction ID.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxRaw {
-    /// body_bytes is a protobuf serialization of a TxBody that matches the representation in SignDoc.
+    /// body_bytes is a protobuf serialization of a TxBody that matches the
+    /// representation in SignDoc.
     #[prost(bytes, tag="1")]
     pub body_bytes: std::vec::Vec<u8>,
-    /// auth_info_bytes is a protobuf serialization of an AuthInfo that matches the representation in SignDoc.
+    /// auth_info_bytes is a protobuf serialization of an AuthInfo that matches the
+    /// representation in SignDoc.
     #[prost(bytes, tag="2")]
     pub auth_info_bytes: std::vec::Vec<u8>,
-    /// signatures is a list of signatures that matches the length and order of AuthInfo's signer_infos to
-    /// allow connecting signature meta information like public key and signing mode by position.
+    /// signatures is a list of signatures that matches the length and order of
+    /// AuthInfo's signer_infos to allow connecting signature meta information like
+    /// public key and signing mode by position.
     #[prost(bytes, repeated, tag="3")]
     pub signatures: ::std::vec::Vec<std::vec::Vec<u8>>,
 }
 /// SignDoc is the type used for generating sign bytes for SIGN_MODE_DIRECT.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignDoc {
-    /// body_bytes is protobuf serialization of a TxBody that matches the representation in TxRaw.
+    /// body_bytes is protobuf serialization of a TxBody that matches the
+    /// representation in TxRaw.
     #[prost(bytes, tag="1")]
     pub body_bytes: std::vec::Vec<u8>,
-    /// auth_info_bytes is a protobuf serialization of an AuthInfo that matches the representation in TxRaw.
+    /// auth_info_bytes is a protobuf serialization of an AuthInfo that matches the
+    /// representation in TxRaw.
     #[prost(bytes, tag="2")]
     pub auth_info_bytes: std::vec::Vec<u8>,
     /// chain_id is the unique identifier of the chain this transaction targets.
@@ -51,12 +58,14 @@ pub struct SignDoc {
 /// TxBody is the body of a transaction that all signers sign over.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxBody {
-    /// messages is a list of messages to be executed. The required signers of those messages define
-    /// the number and order of elements in AuthInfo's signer_infos and Tx's signatures.
-    /// Each required signer address is added to the list only the first time it occurs.
+    /// messages is a list of messages to be executed. The required signers of
+    /// those messages define the number and order of elements in AuthInfo's
+    /// signer_infos and Tx's signatures. Each required signer address is added to
+    /// the list only the first time it occurs.
     ///
-    /// By convention, the first required signer (usually from the first message) is referred
-    /// to as the primary signer and pays the fee for the whole transaction.
+    /// By convention, the first required signer (usually from the first message)
+    /// is referred to as the primary signer and pays the fee for the whole
+    /// transaction.
     #[prost(message, repeated, tag="1")]
     pub messages: ::std::vec::Vec<::prost_types::Any>,
     /// memo is any arbitrary memo to be added to the transaction
@@ -77,12 +86,14 @@ pub struct TxBody {
     #[prost(message, repeated, tag="2047")]
     pub non_critical_extension_options: ::std::vec::Vec<::prost_types::Any>,
 }
-/// AuthInfo describes the fee and signer modes that are used to sign a transaction.
+/// AuthInfo describes the fee and signer modes that are used to sign a
+/// transaction.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthInfo {
     /// signer_infos defines the signing modes for the required signers. The number
-    /// and order of elements must match the required signers from TxBody's messages.
-    /// The first element is the primary signer and the one which pays the fee.
+    /// and order of elements must match the required signers from TxBody's
+    /// messages. The first element is the primary signer and the one which pays
+    /// the fee.
     #[prost(message, repeated, tag="1")]
     pub signer_infos: ::std::vec::Vec<SignerInfo>,
     /// Fee is the fee and gas limit for the transaction. The first signer is the
@@ -92,21 +103,22 @@ pub struct AuthInfo {
     #[prost(message, optional, tag="2")]
     pub fee: ::std::option::Option<Fee>,
 }
-/// SignerInfo describes the public key and signing mode of a single top-level signer.
+/// SignerInfo describes the public key and signing mode of a single top-level
+/// signer.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignerInfo {
     /// public_key is the public key of the signer. It is optional for accounts
     /// that already exist in state. If unset, the verifier can use the required \
     /// signer address for this position and lookup the public key.
     #[prost(message, optional, tag="1")]
-    pub public_key: ::std::option::Option<super::super::base::crypto::v1beta1::PublicKey>,
+    pub public_key: ::std::option::Option<::prost_types::Any>,
     /// mode_info describes the signing mode of the signer and is a nested
     /// structure to support nested multisig pubkey's
     #[prost(message, optional, tag="2")]
     pub mode_info: ::std::option::Option<ModeInfo>,
     /// sequence is the sequence of the account, which describes the
-    /// number of committed transactions signed by a given address. It is used to prevent
-    /// replay attacks.
+    /// number of committed transactions signed by a given address. It is used to
+    /// prevent replay attacks.
     #[prost(uint64, tag="3")]
     pub sequence: u64,
 }
@@ -120,7 +132,8 @@ pub struct ModeInfo {
 }
 pub mod mode_info {
     /// Single is the mode info for a single signer. It is structured as a message
-    /// to allow for additional fields such as locale for SIGN_MODE_TEXTUAL in the future
+    /// to allow for additional fields such as locale for SIGN_MODE_TEXTUAL in the
+    /// future
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Single {
         /// mode is the signing mode of the single signer

--- a/proto/src/prost/ibc.channel.rs
+++ b/proto/src/prost/ibc.channel.rs
@@ -8,8 +8,8 @@ pub struct MsgChannelOpenInit {
     pub channel_id: std::string::String,
     #[prost(message, optional, tag="3")]
     pub channel: ::std::option::Option<Channel>,
-    #[prost(bytes, tag="4")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="4")]
+    pub signer: std::string::String,
 }
 /// MsgChannelOpenInit  defines a msg sent by a Relayer to try to open a channel
 /// on Chain B.
@@ -27,8 +27,8 @@ pub struct MsgChannelOpenTry {
     pub proof_init: std::vec::Vec<u8>,
     #[prost(message, optional, tag="6")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="7")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="7")]
+    pub signer: std::string::String,
 }
 /// MsgChannelOpenAck defines a msg sent by a Relayer to Chain A to acknowledge
 /// the change of channel state to TRYOPEN on Chain B.
@@ -44,8 +44,8 @@ pub struct MsgChannelOpenAck {
     pub proof_try: std::vec::Vec<u8>,
     #[prost(message, optional, tag="5")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="6")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="6")]
+    pub signer: std::string::String,
 }
 /// MsgChannelOpenConfirm defines a msg sent by a Relayer to Chain B to
 /// acknowledge the change of channel state to OPEN on Chain A.
@@ -59,10 +59,10 @@ pub struct MsgChannelOpenConfirm {
     pub proof_ack: std::vec::Vec<u8>,
     #[prost(message, optional, tag="4")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="5")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="5")]
+    pub signer: std::string::String,
 }
-/// MsgChannelOpenConfirm defines a msg sent by a Relayer to Chain A
+/// MsgChannelCloseInit defines a msg sent by a Relayer to Chain A
 /// to close a channel with Chain B.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MsgChannelCloseInit {
@@ -70,8 +70,8 @@ pub struct MsgChannelCloseInit {
     pub port_id: std::string::String,
     #[prost(string, tag="2")]
     pub channel_id: std::string::String,
-    #[prost(bytes, tag="3")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="3")]
+    pub signer: std::string::String,
 }
 /// MsgChannelCloseConfirm defines a msg sent by a Relayer to Chain B
 /// to acknowledge the change of channel state to CLOSED on Chain A.
@@ -85,8 +85,8 @@ pub struct MsgChannelCloseConfirm {
     pub proof_init: std::vec::Vec<u8>,
     #[prost(message, optional, tag="4")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="5")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="5")]
+    pub signer: std::string::String,
 }
 /// MsgRecvPacket receives incoming IBC packet
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -97,8 +97,8 @@ pub struct MsgRecvPacket {
     pub proof: std::vec::Vec<u8>,
     #[prost(message, optional, tag="3")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="4")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="4")]
+    pub signer: std::string::String,
 }
 /// MsgTimeout receives timed-out packet
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -111,8 +111,8 @@ pub struct MsgTimeout {
     pub proof_height: ::std::option::Option<super::client::Height>,
     #[prost(uint64, tag="4")]
     pub next_sequence_recv: u64,
-    #[prost(bytes, tag="5")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="5")]
+    pub signer: std::string::String,
 }
 /// MsgTimeoutOnClose timed-out packet upon counterparty channel closure.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -127,8 +127,8 @@ pub struct MsgTimeoutOnClose {
     pub proof_height: ::std::option::Option<super::client::Height>,
     #[prost(uint64, tag="5")]
     pub next_sequence_recv: u64,
-    #[prost(bytes, tag="6")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="6")]
+    pub signer: std::string::String,
 }
 /// MsgAcknowledgement receives incoming IBC acknowledgement
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -141,8 +141,8 @@ pub struct MsgAcknowledgement {
     pub proof: std::vec::Vec<u8>,
     #[prost(message, optional, tag="4")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="5")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="5")]
+    pub signer: std::string::String,
 }
 /// Channel defines pipeline for exactly-once packet delivery between specific
 /// modules on separate blockchains, which has at least one end capable of
@@ -158,8 +158,8 @@ pub struct Channel {
     /// counterparty channel end
     #[prost(message, optional, tag="3")]
     pub counterparty: ::std::option::Option<Counterparty>,
-    /// list of connection identifiers, in order, along which packets sent on this
-    /// channel will travel
+    /// list of connection identifiers, in order, along which packets sent on
+    /// this channel will travel
     #[prost(string, repeated, tag="4")]
     pub connection_hops: ::std::vec::Vec<std::string::String>,
     /// opaque channel version, which is agreed upon during the handshake
@@ -179,8 +179,8 @@ pub struct IdentifiedChannel {
     /// counterparty channel end
     #[prost(message, optional, tag="3")]
     pub counterparty: ::std::option::Option<Counterparty>,
-    /// list of connection identifiers, in order, along which packets sent on this
-    /// channel will travel
+    /// list of connection identifiers, in order, along which packets sent on
+    /// this channel will travel
     #[prost(string, repeated, tag="4")]
     pub connection_hops: ::std::vec::Vec<std::string::String>,
     /// opaque channel version, which is agreed upon during the handshake
@@ -206,9 +206,9 @@ pub struct Counterparty {
 /// Packet defines a type that carries data across different chains through IBC
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Packet {
-    /// number corresponds to the order of sends and receives, where a Packet with
-    /// an earlier sequence number must be sent and received before a Packet with a
-    /// later sequence number.
+    /// number corresponds to the order of sends and receives, where a Packet
+    /// with an earlier sequence number must be sent and received before a Packet
+    /// with a later sequence number.
     #[prost(uint64, tag="1")]
     pub sequence: u64,
     /// identifies the port on the sending chain.
@@ -249,6 +249,29 @@ pub struct PacketAckCommitment {
     /// packet commitment hash.
     #[prost(bytes, tag="4")]
     pub hash: std::vec::Vec<u8>,
+}
+/// Acknowledgement is the recommended acknowledgement format to be used by
+/// app-specific protocols.
+/// NOTE: The field numbers 21 and 22 were explicitly chosen to avoid accidental
+/// conflicts with other protobuf message formats used for acknowledgements.
+/// The first byte of any message with this format will be the non-ASCII values
+/// `0xaa` (result) or `0xb2` (error). Implemented as defined by ICS:
+/// https://github.com/cosmos/ics/tree/master/spec/ics-004-channel-and-packet-semantics#acknowledgement-envelope
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Acknowledgement {
+    /// response contains either a result or an error and must be non-empty
+    #[prost(oneof="acknowledgement::Response", tags="21, 22")]
+    pub response: ::std::option::Option<acknowledgement::Response>,
+}
+pub mod acknowledgement {
+    /// response contains either a result or an error and must be non-empty
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        #[prost(bytes, tag="21")]
+        Result(std::vec::Vec<u8>),
+        #[prost(string, tag="22")]
+        Error(std::string::String),
+    }
 }
 /// State defines if a channel is in one of the following states:
 /// CLOSED, INIT, TRYOPEN, OPEN or UNINITIALIZED.
@@ -536,10 +559,10 @@ pub struct QueryPacketAcknowledgementResponse {
     #[prost(message, optional, tag="4")]
     pub proof_height: ::std::option::Option<super::client::Height>,
 }
-/// QueryUnrelayedPacketsRequest is the request type for the
-/// Query/UnrelayedPackets RPC method
+/// QueryUnreceivedPacketsRequest is the request type for the
+/// Query/UnreceivedPackets RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryUnrelayedPacketsRequest {
+pub struct QueryUnreceivedPacketsRequest {
     /// port unique identifier
     #[prost(string, tag="1")]
     pub port_id: std::string::String,
@@ -549,16 +572,37 @@ pub struct QueryUnrelayedPacketsRequest {
     /// list of packet sequences
     #[prost(uint64, repeated, tag="3")]
     pub packet_commitment_sequences: ::std::vec::Vec<u64>,
-    /// flag indicating if the return value is packet commitments or
-    /// acknowledgements
-    #[prost(bool, tag="4")]
-    pub acknowledgements: bool,
 }
-/// QueryUnrelayedPacketsResponse is the request type for the
-/// Query/UnrelayedPacketCommitments RPC method
+/// QueryUnreceivedPacketsResponse is the response type for the
+/// Query/UnreceivedPacketCommitments RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryUnrelayedPacketsResponse {
-    /// list of unrelayed packet sequences
+pub struct QueryUnreceivedPacketsResponse {
+    /// list of unreceived packet sequences
+    #[prost(uint64, repeated, tag="1")]
+    pub sequences: ::std::vec::Vec<u64>,
+    /// query block height
+    #[prost(message, optional, tag="2")]
+    pub height: ::std::option::Option<super::client::Height>,
+}
+/// QueryUnrelayedAcksRequest is the request type for the
+/// Query/UnrelayedAcks RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryUnrelayedAcksRequest {
+    /// port unique identifier
+    #[prost(string, tag="1")]
+    pub port_id: std::string::String,
+    /// channel unique identifier
+    #[prost(string, tag="2")]
+    pub channel_id: std::string::String,
+    /// list of commitment sequences
+    #[prost(uint64, repeated, tag="3")]
+    pub packet_commitment_sequences: ::std::vec::Vec<u64>,
+}
+/// QueryUnrelayedAcksResponse is the response type for the
+/// Query/UnrelayedAcks RPC method
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryUnrelayedAcksResponse {
+    /// list of unrelayed acknowledgement sequences
     #[prost(uint64, repeated, tag="1")]
     pub sequences: ::std::vec::Vec<u64>,
     /// query block height

--- a/proto/src/prost/ibc.client.rs
+++ b/proto/src/prost/ibc.client.rs
@@ -1,4 +1,4 @@
-/// IdentifiedClientState defines a client state with additional client
+/// IdentifiedClientState defines a client state with an additional client
 /// identifier field.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IdentifiedClientState {
@@ -9,6 +9,16 @@ pub struct IdentifiedClientState {
     #[prost(message, optional, tag="2")]
     pub client_state: ::std::option::Option<::prost_types::Any>,
 }
+/// ConsensusStateWithHeight defines a consensus state with an additional height field.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConsensusStateWithHeight {
+    /// consensus state height
+    #[prost(message, optional, tag="1")]
+    pub height: ::std::option::Option<Height>,
+    /// consensus state
+    #[prost(message, optional, tag="2")]
+    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+}
 /// ClientConsensusStates defines all the stored consensus states for a given
 /// client.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -16,9 +26,27 @@ pub struct ClientConsensusStates {
     /// client identifier
     #[prost(string, tag="1")]
     pub client_id: std::string::String,
-    /// consensus states associated with the client
+    /// consensus states and their heights associated with the client
     #[prost(message, repeated, tag="2")]
-    pub consensus_states: ::std::vec::Vec<::prost_types::Any>,
+    pub consensus_states: ::std::vec::Vec<ConsensusStateWithHeight>,
+}
+/// ClientUpdateProposal is a governance proposal. If it passes, the client is
+/// updated with the provided header. The update may fail if the header is not
+/// valid given certain conditions specified by the client implementation.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClientUpdateProposal {
+    /// the title of the update proposal
+    #[prost(string, tag="1")]
+    pub title: std::string::String,
+    /// the description of the proposal
+    #[prost(string, tag="2")]
+    pub description: std::string::String,
+    /// the client identifier for the client to be updated if the proposal passes
+    #[prost(string, tag="3")]
+    pub client_id: std::string::String,
+    /// the header used to update the client if the proposal passes
+    #[prost(message, optional, tag="4")]
+    pub header: ::std::option::Option<::prost_types::Any>,
 }
 /// MsgCreateClient defines a message to create an IBC client
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -34,8 +62,8 @@ pub struct MsgCreateClient {
     #[prost(message, optional, tag="3")]
     pub consensus_state: ::std::option::Option<::prost_types::Any>,
     /// signer address
-    #[prost(bytes, tag="4")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="4")]
+    pub signer: std::string::String,
 }
 /// MsgUpdateClient defines an sdk.Msg to update a IBC client state using
 /// the given header.
@@ -48,8 +76,8 @@ pub struct MsgUpdateClient {
     #[prost(message, optional, tag="2")]
     pub header: ::std::option::Option<::prost_types::Any>,
     /// signer address
-    #[prost(bytes, tag="3")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="3")]
+    pub signer: std::string::String,
 }
 /// MsgSubmitMisbehaviour defines an sdk.Msg type that submits Evidence for
 /// light client misbehaviour.
@@ -62,8 +90,8 @@ pub struct MsgSubmitMisbehaviour {
     #[prost(message, optional, tag="2")]
     pub misbehaviour: ::std::option::Option<::prost_types::Any>,
     /// signer address
-    #[prost(bytes, tag="3")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="3")]
+    pub signer: std::string::String,
 }
 /// Height is a monotonically increasing data type
 /// that can be compared against another Height for the purposes of updating and
@@ -141,24 +169,27 @@ pub struct QueryClientStatesResponse {
     #[prost(message, optional, tag="2")]
     pub pagination: ::std::option::Option<super::super::cosmos::base::query::v1beta1::PageResponse>,
 }
-/// QueryConsensusStateRequest is the request type for the Query/ConsensusState RPC method. Besides
-/// the consensus state, it includes a proof and the height from which the proof was retrieved.
+/// QueryConsensusStateRequest is the request type for the Query/ConsensusState
+/// RPC method. Besides the consensus state, it includes a proof and the height
+/// from which the proof was retrieved.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryConsensusStateRequest {
     /// client identifier
     #[prost(string, tag="1")]
     pub client_id: std::string::String,
-    /// consensus state epoch number 
+    /// consensus state epoch number
     #[prost(uint64, tag="2")]
     pub epoch_number: u64,
     /// consensus state epoch height
     #[prost(uint64, tag="3")]
     pub epoch_height: u64,
-    /// latest_height overrrides the height field and queries the latest stored ConsensusState
+    /// latest_height overrrides the height field and queries the latest stored
+    /// ConsensusState
     #[prost(bool, tag="4")]
     pub latest_height: bool,
 }
-/// QueryConsensusStateResponse is the response type for the Query/ConsensusState RPC method
+/// QueryConsensusStateResponse is the response type for the Query/ConsensusState
+/// RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryConsensusStateResponse {
     /// consensus state associated with the client identifier at the given height
@@ -174,7 +205,8 @@ pub struct QueryConsensusStateResponse {
     #[prost(message, optional, tag="4")]
     pub proof_height: ::std::option::Option<Height>,
 }
-/// QueryConsensusStatesRequest is the request type for the Query/ConsensusStates RPC method.
+/// QueryConsensusStatesRequest is the request type for the Query/ConsensusStates
+/// RPC method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryConsensusStatesRequest {
     /// client identifier
@@ -184,12 +216,13 @@ pub struct QueryConsensusStatesRequest {
     #[prost(message, optional, tag="2")]
     pub pagination: ::std::option::Option<super::super::cosmos::base::query::v1beta1::PageRequest>,
 }
-/// QueryConsensusStatesResponse is the response type for the Query/ConsensusStates RPC method
+/// QueryConsensusStatesResponse is the response type for the
+/// Query/ConsensusStates RPC method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryConsensusStatesResponse {
     /// consensus states associated with the identifier
     #[prost(message, repeated, tag="1")]
-    pub consensus_states: ::std::vec::Vec<::prost_types::Any>,
+    pub consensus_states: ::std::vec::Vec<ConsensusStateWithHeight>,
     /// pagination response
     #[prost(message, optional, tag="2")]
     pub pagination: ::std::option::Option<super::super::cosmos::base::query::v1beta1::PageResponse>,

--- a/proto/src/prost/ibc.commitment.rs
+++ b/proto/src/prost/ibc.commitment.rs
@@ -6,23 +6,24 @@ pub struct MerkleRoot {
     pub hash: std::vec::Vec<u8>,
 }
 /// MerklePrefix is merkle path prefixed to the key.
-/// The constructed key from the Path and the key will be append(Path.KeyPath, append(Path.KeyPrefix, key...))
+/// The constructed key from the Path and the key will be append(Path.KeyPath,
+/// append(Path.KeyPrefix, key...))
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerklePrefix {
     #[prost(bytes, tag="1")]
     pub key_prefix: std::vec::Vec<u8>,
 }
-/// MerklePath is the path used to verify commitment proofs, which can be an arbitrary
-/// structured object (defined by a commitment type).
+/// MerklePath is the path used to verify commitment proofs, which can be an
+/// arbitrary structured object (defined by a commitment type).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerklePath {
     #[prost(message, optional, tag="1")]
     pub key_path: ::std::option::Option<KeyPath>,
 }
 /// MerkleProof is a wrapper type that contains a merkle proof.
-/// It demonstrates membership or non-membership for an element or set of elements,
-/// verifiable in conjunction with a known commitment root. Proofs should be
-/// succinct.
+/// It demonstrates membership or non-membership for an element or set of
+/// elements, verifiable in conjunction with a known commitment root. Proofs
+/// should be succinct.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MerkleProof {
     #[prost(message, optional, tag="1")]

--- a/proto/src/prost/ibc.connection.rs
+++ b/proto/src/prost/ibc.connection.rs
@@ -8,8 +8,8 @@ pub struct MsgConnectionOpenInit {
     pub connection_id: std::string::String,
     #[prost(message, optional, tag="3")]
     pub counterparty: ::std::option::Option<Counterparty>,
-    #[prost(bytes, tag="4")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="4")]
+    pub signer: std::string::String,
 }
 /// MsgConnectionOpenTry defines a msg sent by a Relayer to try to open a
 /// connection on Chain B.
@@ -39,8 +39,8 @@ pub struct MsgConnectionOpenTry {
     pub proof_consensus: std::vec::Vec<u8>,
     #[prost(message, optional, tag="10")]
     pub consensus_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="11")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="11")]
+    pub signer: std::string::String,
 }
 /// MsgConnectionOpenAck defines a msg sent by a Relayer to Chain A to
 /// acknowledge the change of connection state to TRYOPEN on Chain B.
@@ -66,8 +66,8 @@ pub struct MsgConnectionOpenAck {
     pub proof_consensus: std::vec::Vec<u8>,
     #[prost(message, optional, tag="8")]
     pub consensus_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="9")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="9")]
+    pub signer: std::string::String,
 }
 /// MsgConnectionOpenConfirm defines a msg sent by a Relayer to Chain B to
 /// acknowledge the change of connection state to OPEN on Chain A.
@@ -80,8 +80,8 @@ pub struct MsgConnectionOpenConfirm {
     pub proof_ack: std::vec::Vec<u8>,
     #[prost(message, optional, tag="3")]
     pub proof_height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="4")]
-    pub signer: std::vec::Vec<u8>,
+    #[prost(string, tag="4")]
+    pub signer: std::string::String,
 }
 // ICS03 - Connection Data Structures as defined in
 // https://github.com/cosmos/ics/tree/master/spec/ics-003-connection-semantics#data-structures

--- a/proto/src/prost/ibc.lightclients.solomachine.v1.rs
+++ b/proto/src/prost/ibc.lightclients.solomachine.v1.rs
@@ -2,21 +2,30 @@
 /// state and if the client is frozen.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientState {
-    /// frozen sequence of the solo machine
-    #[prost(uint64, tag="1")]
-    pub frozen_sequence: u64,
-    #[prost(message, optional, tag="2")]
-    pub consensus_state: ::std::option::Option<ConsensusState>,
-}
-/// ConsensusState defines a solo machine consensus state
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ConsensusState {
-    /// current sequence of the consensus state
+    /// latest sequence of the client state
     #[prost(uint64, tag="1")]
     pub sequence: u64,
+    /// frozen sequence of the solo machine
+    #[prost(uint64, tag="2")]
+    pub frozen_sequence: u64,
+    #[prost(message, optional, tag="3")]
+    pub consensus_state: ::std::option::Option<ConsensusState>,
+    /// when set to true, will allow governance to update a solo machine client.
+    /// The client will be unfrozen if it is frozen.
+    #[prost(bool, tag="4")]
+    pub allow_update_after_proposal: bool,
+}
+/// ConsensusState defines a solo machine consensus state. The sequence of a consensus state
+/// is contained in the "height" key used in storing the consensus state.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConsensusState {
     /// public key of the solo machine
-    #[prost(message, optional, tag="2")]
-    pub public_key: ::std::option::Option<super::super::super::super::cosmos::base::crypto::v1beta1::PublicKey>,
+    #[prost(message, optional, tag="1")]
+    pub public_key: ::std::option::Option<::prost_types::Any>,
+    /// diversifier allows the same public key to be re-used across different solo machine clients
+    /// (potentially on different chains) without being considered misbehaviour.
+    #[prost(string, tag="2")]
+    pub diversifier: std::string::String,
     #[prost(uint64, tag="3")]
     pub timestamp: u64,
 }
@@ -26,10 +35,14 @@ pub struct Header {
     /// sequence to update solo machine public key at
     #[prost(uint64, tag="1")]
     pub sequence: u64,
-    #[prost(bytes, tag="2")]
+    #[prost(uint64, tag="2")]
+    pub timestamp: u64,
+    #[prost(bytes, tag="3")]
     pub signature: std::vec::Vec<u8>,
-    #[prost(message, optional, tag="3")]
-    pub new_public_key: ::std::option::Option<super::super::super::super::cosmos::base::crypto::v1beta1::PublicKey>,
+    #[prost(message, optional, tag="4")]
+    pub new_public_key: ::std::option::Option<::prost_types::Any>,
+    #[prost(string, tag="5")]
+    pub new_diversifier: std::string::String,
 }
 /// Misbehaviour defines misbehaviour for a solo machine which consists
 /// of a sequence and two signatures over different messages at that sequence.
@@ -61,4 +74,96 @@ pub struct TimestampedSignature {
     pub signature: std::vec::Vec<u8>,
     #[prost(uint64, tag="2")]
     pub timestamp: u64,
+}
+/// SignBytes defines the signed bytes used for signature verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignBytes {
+    #[prost(uint64, tag="1")]
+    pub sequence: u64,
+    #[prost(uint64, tag="2")]
+    pub timestamp: u64,
+    #[prost(string, tag="3")]
+    pub diversifier: std::string::String,
+    /// marshaled data
+    #[prost(bytes, tag="4")]
+    pub data: std::vec::Vec<u8>,
+}
+/// HeaderData returns the SignBytes data for misbehaviour verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HeaderData {
+    /// header public key
+    #[prost(message, optional, tag="1")]
+    pub new_pub_key: ::std::option::Option<::prost_types::Any>,
+    /// header diversifier
+    #[prost(string, tag="2")]
+    pub new_diversifier: std::string::String,
+}
+/// ClientStateData returns the SignBytes data for client state verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ClientStateData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    pub client_state: ::std::option::Option<::prost_types::Any>,
+}
+/// ConsensusStateSignBytes returns the SignBytes data for consensus state
+/// verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConsensusStateData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    pub consensus_state: ::std::option::Option<::prost_types::Any>,
+}
+/// ConnectionStateSignBytes returns the SignBytes data for connection state
+/// verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConnectionStateData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    pub connection: ::std::option::Option<super::super::super::connection::ConnectionEnd>,
+}
+/// ChannelStateSignBytes returns the SignBytes data for channel state
+/// verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChannelStateData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(message, optional, tag="2")]
+    pub channel: ::std::option::Option<super::super::super::channel::Channel>,
+}
+/// PacketCommitmentSignBytes returns the SignBytes data for packet commitment
+/// verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PacketCommitmentData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(bytes, tag="2")]
+    pub commitment: std::vec::Vec<u8>,
+}
+/// PacketAcknowledgementSignBytes returns the SignBytes data for acknowledgement
+/// verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PacketAcknowledgementData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(bytes, tag="2")]
+    pub acknowledgement: std::vec::Vec<u8>,
+}
+/// PacketAcknowledgementAbsenceSignBytes returns the SignBytes data for
+/// acknowledgement absence verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PacketAcknowledgementAbsenseData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+}
+/// NextSequenceRecv returns the SignBytes data for verification of the next
+/// sequence to be received.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NextSequenceRecvData {
+    #[prost(bytes, tag="1")]
+    pub path: std::vec::Vec<u8>,
+    #[prost(uint64, tag="2")]
+    pub next_seq_recv: u64,
 }

--- a/proto/src/prost/ibc.tendermint.rs
+++ b/proto/src/prost/ibc.tendermint.rs
@@ -25,6 +25,14 @@ pub struct ClientState {
     /// Proof specifications used in verifying counterparty state
     #[prost(message, repeated, tag="8")]
     pub proof_specs: ::std::vec::Vec<super::super::ics23::ProofSpec>,
+    /// This flag, when set to true, will allow governance to recover a client
+    /// which has expired
+    #[prost(bool, tag="9")]
+    pub allow_update_after_expiry: bool,
+    /// This flag, when set to true, will allow governance to unfreeze a client
+    /// whose chain has experienced a misbehaviour event
+    #[prost(bool, tag="10")]
+    pub allow_update_after_misbehaviour: bool,
 }
 /// ConsensusState defines the consensus state from Tendermint.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -36,10 +44,7 @@ pub struct ConsensusState {
     /// commitment root (i.e app hash)
     #[prost(message, optional, tag="2")]
     pub root: ::std::option::Option<super::commitment::MerkleRoot>,
-    /// height at which the consensus state was stored.
-    #[prost(message, optional, tag="3")]
-    pub height: ::std::option::Option<super::client::Height>,
-    #[prost(bytes, tag="4")]
+    #[prost(bytes, tag="3")]
     pub next_validators_hash: std::vec::Vec<u8>,
 }
 /// Misbehaviour is a wrapper over two conflicting Headers

--- a/proto/src/prost/ibc.transfer.rs
+++ b/proto/src/prost/ibc.transfer.rs
@@ -13,8 +13,8 @@ pub struct MsgTransfer {
     #[prost(message, optional, tag="3")]
     pub token: ::std::option::Option<super::super::cosmos::base::v1beta1::Coin>,
     /// the sender address
-    #[prost(bytes, tag="4")]
-    pub sender: std::vec::Vec<u8>,
+    #[prost(string, tag="4")]
+    pub sender: std::string::String,
     /// the recipient address on the destination chain
     #[prost(string, tag="5")]
     pub receiver: std::string::String,
@@ -45,23 +45,12 @@ pub struct FungibleTokenPacketData {
     #[prost(string, tag="4")]
     pub receiver: std::string::String,
 }
-/// FungibleTokenPacketAcknowledgement contains a boolean success flag and an
-/// optional error msg error msg is empty string on success See spec for
-/// onAcknowledgePacket:
-/// https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#packet-relay
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FungibleTokenPacketAcknowledgement {
-    #[prost(bool, tag="1")]
-    pub success: bool,
-    #[prost(string, tag="2")]
-    pub error: std::string::String,
-}
-/// DenomTrace contains the base denomination for ICS20 fungible tokens and the source tracing
-/// information path.
+/// DenomTrace contains the base denomination for ICS20 fungible tokens and the
+/// source tracing information path.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DenomTrace {
-    /// path defines the chain of port/channel identifiers used for tracing the source of the fungible
-    /// token.
+    /// path defines the chain of port/channel identifiers used for tracing the
+    /// source of the fungible token.
     #[prost(string, tag="1")]
     pub path: std::string::String,
     /// base denomination of the relayed fungible token.
@@ -69,39 +58,46 @@ pub struct DenomTrace {
     pub base_denom: std::string::String,
 }
 /// Params defines the set of IBC transfer parameters.
-/// NOTE: To prevent a single token from being transferred, set the TransfersEnabled parameter to
-/// true and then set the bank module's SendEnabled parameter for the denomination to false.
+/// NOTE: To prevent a single token from being transferred, set the
+/// TransfersEnabled parameter to true and then set the bank module's SendEnabled
+/// parameter for the denomination to false.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Params {
-    /// send_enabled enables or disables all cross-chain token transfers from this chain.
+    /// send_enabled enables or disables all cross-chain token transfers from this
+    /// chain.
     #[prost(bool, tag="1")]
     pub send_enabled: bool,
-    /// receive_enabled enables or disables all cross-chain token transfers to this chain.
+    /// receive_enabled enables or disables all cross-chain token transfers to this
+    /// chain.
     #[prost(bool, tag="2")]
     pub receive_enabled: bool,
 }
-/// QueryDenomTraceRequest is the request type for the Query/DenomTrace RPC method
+/// QueryDenomTraceRequest is the request type for the Query/DenomTrace RPC
+/// method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomTraceRequest {
     /// hash (in hex format) of the denomination trace information.
     #[prost(string, tag="1")]
     pub hash: std::string::String,
 }
-/// QueryDenomTraceResponse is the response type for the Query/DenomTrace RPC method.
+/// QueryDenomTraceResponse is the response type for the Query/DenomTrace RPC
+/// method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomTraceResponse {
     /// denom_trace returns the requested denomination trace information.
     #[prost(message, optional, tag="1")]
     pub denom_trace: ::std::option::Option<DenomTrace>,
 }
-/// QueryConnectionsRequest is the request type for the Query/DenomTraces RPC method
+/// QueryConnectionsRequest is the request type for the Query/DenomTraces RPC
+/// method
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomTracesRequest {
     /// pagination defines an optional pagination for the request.
     #[prost(message, optional, tag="1")]
     pub pagination: ::std::option::Option<super::super::cosmos::base::query::v1beta1::PageRequest>,
 }
-/// QueryConnectionsResponse is the response type for the Query/DenomTraces RPC method.
+/// QueryConnectionsResponse is the response type for the Query/DenomTraces RPC
+/// method.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomTracesResponse {
     /// denom_traces returns all denominations trace information.

--- a/proto/src/prost/tendermint.abci.rs
+++ b/proto/src/prost/tendermint.abci.rs
@@ -505,8 +505,8 @@ pub struct VoteInfo {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Evidence {
-    #[prost(string, tag="1")]
-    pub r#type: std::string::String,
+    #[prost(enumeration="EvidenceType", tag="1")]
+    pub r#type: i32,
     /// The offending validator
     #[prost(message, optional, tag="2")]
     pub validator: ::std::option::Option<Validator>,
@@ -548,4 +548,11 @@ pub struct Snapshot {
 pub enum CheckTxType {
     New = 0,
     Recheck = 1,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum EvidenceType {
+    Unknown = 0,
+    DuplicateVote = 1,
+    LightClientAttack = 2,
 }

--- a/proto/src/prost/tendermint.crypto.rs
+++ b/proto/src/prost/tendermint.crypto.rs
@@ -58,17 +58,3 @@ pub mod public_key {
         Ed25519(std::vec::Vec<u8>),
     }
 }
-/// PrivateKey defines the keys available for use with Tendermint Validators
-/// WARNING PrivateKey is used for internal purposes only
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PrivateKey {
-    #[prost(oneof="private_key::Sum", tags="1")]
-    pub sum: ::std::option::Option<private_key::Sum>,
-}
-pub mod private_key {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Sum {
-        #[prost(bytes, tag="1")]
-        Ed25519(std::vec::Vec<u8>),
-    }
-}

--- a/proto/src/prost/tendermint.types.rs
+++ b/proto/src/prost/tendermint.types.rs
@@ -188,6 +188,13 @@ pub struct SignedHeader {
     pub commit: ::std::option::Option<Commit>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LightBlock {
+    #[prost(message, optional, tag="1")]
+    pub signed_header: ::std::option::Option<SignedHeader>,
+    #[prost(message, optional, tag="2")]
+    pub validator_set: ::std::option::Option<ValidatorSet>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockMeta {
     #[prost(message, optional, tag="1")]
     pub block_id: ::std::option::Option<BlockId>,
@@ -281,11 +288,6 @@ pub struct EvidenceParams {
     /// Default is 50
     #[prost(uint32, tag="3")]
     pub max_num: u32,
-    /// Proof trial period dictates the time given for nodes accused of amnesia evidence, incorrectly
-    /// voting twice in two different rounds to respond with their respective proofs.
-    /// Default is half the max age in blocks: 50,000
-    #[prost(int64, tag="4")]
-    pub proof_trial_period: i64,
 }
 /// ValidatorParams restrict the public key types validators can use.
 /// NOTE: uses ABCI pubkey naming, not Amino names.

--- a/relayer/src/tx/client.rs
+++ b/relayer/src/tx/client.rs
@@ -39,19 +39,22 @@ pub fn create_client(opts: CreateClientOptions) -> Result<(), Error> {
 
     // Get the latest header from the source chain and build the consensus state.
     let src_chain = CosmosSDKChain::from_config(opts.clone().src_chain_config)?;
-    let tm_consensus_state = block_on(query_latest_header::<CosmosSDKChain>(&src_chain))
-        .map_err(|e| {
+    let tm_latest_header =
+        block_on(query_latest_header::<CosmosSDKChain>(&src_chain)).map_err(|e| {
             Kind::CreateClient(
                 opts.dest_client_id.clone(),
                 "failed to get the latest header".into(),
             )
             .context(e)
-        })
-        .map(|light_block| {
-            ibc::ics07_tendermint::consensus_state::ConsensusState::from(light_block.signed_header)
         })?;
 
-    let any_consensus_state = AnyConsensusState::Tendermint(tm_consensus_state.clone());
+    let height = tm_latest_header.signed_header.header.height;
+
+    let tm_consensus_state = ibc::ics07_tendermint::consensus_state::ConsensusState::from(
+        tm_latest_header.signed_header,
+    );
+
+    let any_consensus_state = AnyConsensusState::Tendermint(tm_consensus_state);
 
     // Build the client state.
     let any_client_state = ibc::ics07_tendermint::client_state::ClientState::new(
@@ -59,8 +62,10 @@ pub fn create_client(opts: CreateClientOptions) -> Result<(), Error> {
         src_chain.trusting_period(),
         src_chain.unbonding_period(),
         Duration::from_millis(3000),
-        tm_consensus_state.height,
+        height,
         Height(0),
+        false,
+        false,
     )
     .map_err(|e| {
         Kind::CreateClient(


### PR DESCRIPTION
Closes: #273

## Description
Move to latest proto defs in ibc-proto v0.4.0 and adapt `modules` to use these.

______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
