### PR TITLE
Fix query client consensus command

### DIFF
--- a/modules/src/ics24_host/path.rs
+++ b/modules/src/ics24_host/path.rs
@@ -11,7 +11,11 @@ pub const IBC_QUERY_PATH: &str = "store/ibc/key";
 pub enum Path {
     ClientType(ClientId),
     ClientState(ClientId),
-    ClientConsensusState(ClientId, u64, u64),
+    ClientConsensusState {
+        client_id: ClientId,
+        epoch: u64,
+        height: u64,
+    },
     ClientConnections(ClientId),
     Connections(ConnectionId),
     Ports(PortId),
@@ -19,8 +23,16 @@ pub enum Path {
     SeqSends(PortId, ChannelId),
     SeqRecvs(PortId, ChannelId),
     SeqAcks(PortId, ChannelId),
-    Commitments(PortId, ChannelId, u64),
-    Acks(PortId, ChannelId, u64),
+    Commitments {
+        port_id: PortId,
+        channel_id: ChannelId,
+        sequence: u64,
+    },
+    Acks {
+        port_id: PortId,
+        channel_id: ChannelId,
+        sequence: u64,
+    },
 }
 
 impl Path {
@@ -44,14 +56,20 @@ impl Path {
 impl Display for Path {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match &self {
-            Path::ClientType(id) => write!(f, "clients/{}/clientType", id),
-            Path::ClientState(id) => write!(f, "clients/{}/clientState", id),
-            Path::ClientConsensusState(id, epoch, height) => {
-                write!(f, "clients/{}/consensusState/{}-{}", id, epoch, height)
-            }
-            Path::ClientConnections(id) => write!(f, "clients/{}/connections", id),
-            Path::Connections(id) => write!(f, "connections/{}", id),
-            Path::Ports(id) => write!(f, "ports/{}", id),
+            Path::ClientType(client_id) => write!(f, "clients/{}/clientType", client_id),
+            Path::ClientState(client_id) => write!(f, "clients/{}/clientState", client_id),
+            Path::ClientConsensusState {
+                client_id,
+                epoch,
+                height,
+            } => write!(
+                f,
+                "clients/{}/consensusState/{}-{}",
+                client_id, epoch, height
+            ),
+            Path::ClientConnections(client_id) => write!(f, "clients/{}/connections", client_id),
+            Path::Connections(connection_id) => write!(f, "connections/{}", connection_id),
+            Path::Ports(port_id) => write!(f, "ports/{}", port_id),
             Path::ChannelEnds(port_id, channel_id) => {
                 write!(f, "channelEnds/ports/{}/channels/{}", port_id, channel_id)
             }
@@ -70,15 +88,23 @@ impl Display for Path {
                 "seqAcks/ports/{}/channels/{}/nextSequenceAck",
                 port_id, channel_id
             ),
-            Path::Commitments(port_id, channel_id, seq) => write!(
+            Path::Commitments {
+                port_id,
+                channel_id,
+                sequence,
+            } => write!(
                 f,
                 "commitments/ports/{}/channels/{}/packets/{}",
-                port_id, channel_id, seq
+                port_id, channel_id, sequence
             ),
-            Path::Acks(port_id, channel_id, seq) => write!(
+            Path::Acks {
+                port_id,
+                channel_id,
+                sequence,
+            } => write!(
                 f,
                 "acks/ports/{}/channels/{}/acknowledgements/{}",
-                port_id, channel_id, seq
+                port_id, channel_id, sequence
             ),
         }
     }

--- a/modules/src/ics24_host/path.rs
+++ b/modules/src/ics24_host/path.rs
@@ -11,7 +11,7 @@ pub const IBC_QUERY_PATH: &str = "store/ibc/key";
 pub enum Path {
     ClientType(ClientId),
     ClientState(ClientId),
-    ClientConsensusState(ClientId, u64),
+    ClientConsensusState(ClientId, u64, u64),
     ClientConnections(ClientId),
     Connections(ConnectionId),
     Ports(PortId),
@@ -46,8 +46,8 @@ impl Display for Path {
         match &self {
             Path::ClientType(id) => write!(f, "clients/{}/clientType", id),
             Path::ClientState(id) => write!(f, "clients/{}/clientState", id),
-            Path::ClientConsensusState(id, height) => {
-                write!(f, "clients/{}/consensusState/{}", id, height)
+            Path::ClientConsensusState(id, epoch, height) => {
+                write!(f, "clients/{}/consensusState/{}-{}", id, epoch, height)
             }
             Path::ClientConnections(id) => write!(f, "clients/{}/connections", id),
             Path::Connections(id) => write!(f, "connections/{}", id),

--- a/modules/src/mock_client/client_def.rs
+++ b/modules/src/mock_client/client_def.rs
@@ -42,7 +42,8 @@ impl ClientDef for MockClient {
         _expected_consensus_state: &AnyConsensusState,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let client_prefixed_path =
-            Path::ClientConsensusState(client_id.clone(), height.value()).to_string();
+            // TODO - will pick epoch from new type Height
+            Path::ClientConsensusState(client_id.clone(), 0, height.value()).to_string();
 
         let _path = apply_prefix(prefix, client_prefixed_path)?;
 

--- a/modules/src/mock_client/client_def.rs
+++ b/modules/src/mock_client/client_def.rs
@@ -43,7 +43,7 @@ impl ClientDef for MockClient {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let client_prefixed_path =
             // TODO - will pick epoch from new type Height
-            Path::ClientConsensusState(client_id.clone(), 0, height.value()).to_string();
+            Path::ClientConsensusState{client_id: client_id.clone(), epoch: 0, height: height.value()}.to_string();
 
         let _path = apply_prefix(prefix, client_prefixed_path)?;
 

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -179,7 +179,11 @@ impl Runnable for QueryClientConsensusCmd {
         let chain = CosmosSDKChain::from_config(chain_config).unwrap();
         let res: Result<AnyConsensusState, Error> = chain
             .query(
-                ClientConsensusState(opts.client_id, opts.consensus_epoch, opts.consensus_height),
+                ClientConsensusState {
+                    client_id: opts.client_id,
+                    epoch: opts.consensus_epoch,
+                    height: opts.consensus_height,
+                },
                 opts.height,
                 opts.proof,
             )


### PR DESCRIPTION

Closes: #286

## Description
Added new query parameter for the epoch value.
Running the query against the gaiad/ go relayer setup:
```
$ rrly -c simple_config.toml query client consensus ibc0 ibconeclient 0 28
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/relayer -c simple_config.toml query client consensus ibc0 ibconeclient 0 28`
     Options QueryClientConsensusOptions { client_id: ClientId("ibconeclient"), consensus_epoch: 0, consensus_height: 28, height: 0, proof: true }
[relayer/src/chain/cosmos.rs:63] "Todo: implement proof verification." = "Todo: implement proof verification."
client consensus state query result:  Tendermint(ConsensusState { timestamp: Time(2020-10-06T11:06:11.147301Z), root: CommitmentRoot([2, 140, 56, 156, 164, 1, 214, 81, 231, 130, 237, 6, 5, 85, 55, 52, 79, 27, 43, 202, 19, 49, 199, 249, 140, 146, 23, 88, 44, 151, 104, 246]), next_validators_hash: Hash::Sha256(702F9DF2C25EAC1CE7C19DC03E7AA10E3FD9BF1E65EE2A9B96DAEE3DD2E65FC5) })
```
