### PR TITLE
Remove Uninitialized from connection state

### DIFF
--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -9,7 +9,7 @@ use crate::Height;
 #[derive(Clone, Debug, Error)]
 pub enum Kind {
     #[error("connection state unknown")]
-    UnknownState,
+    InvalidState(i32),
 
     #[error("connection exists (was initialized) already: {0}")]
     ConnectionExistsAlready(ConnectionId),


### PR DESCRIPTION

Closes: #217

## Description
Removed the unitialized state. Tried to fix this in channel but the whole channel code is in a bad state and it needs to be reworked along the lines of connection. We will take care of it in a different PR.

______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
