### PR TITLE
Fix the flexible conn id for connection messages

### DIFF
--- a/modules/src/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/ics03_connection/handler/conn_open_ack.rs
@@ -31,8 +31,9 @@ pub(crate) fn process(
 
             // Check that if the msg's counterparty connection id is not empty then it matches
             // the old connection's counterparty.
-            let counterparty_matches = msg.counterparty_connection_id().as_str().is_empty()
-                || old_conn_end.counterparty().connection_id() == msg.counterparty_connection_id();
+            let counterparty_matches = msg.counterparty_connection_id().is_none()
+                || old_conn_end.counterparty().connection_id().clone()
+                    == msg.counterparty_connection_id().unwrap();
 
             if state_is_consistent && counterparty_matches {
                 Ok(old_conn_end.clone())
@@ -118,7 +119,7 @@ mod tests {
         let msg_ack = MsgConnectionOpenAck::try_from(get_dummy_msg_conn_open_ack()).unwrap();
         let counterparty = Counterparty::new(
             client_id.clone(),
-            msg_ack.counterparty_connection_id().clone(),
+            msg_ack.counterparty_connection_id().unwrap(),
             CommitmentPrefix::from(vec![]),
         )
         .unwrap();
@@ -148,7 +149,7 @@ mod tests {
         // Build a connection end that will exercise the successful path.
         let correct_counterparty = Counterparty::new(
             client_id.clone(),
-            msg_ack.counterparty_connection_id().clone(),
+            msg_ack.counterparty_connection_id().unwrap(),
             CommitmentPrefix::from(b"ibc".to_vec()),
         )
         .unwrap();


### PR DESCRIPTION

Closes: #332

## Description
While the message handlers are correct, the encoding for the new connection id fields in Try and Ack connection message domain types should be `Option<ConnectionId>`
Focused code review and more tests will be done as part https://github.com/informalsystems/ibc-rs/issues/306.
______

For contributor use:

- [ ] Unit tests written
- [ ] Added test to CI if applicable 
- [ ] Updated CHANGELOG_PENDING.md
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments
- [ ] Re-reviewed `Files changed` in the Github PR explorer
