### PR TITLE
Back to pub header in block

### DIFF
--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -128,7 +128,7 @@ pub fn get_all_events(result: RpcEvent) -> Result<Vec<IBCEvent>, String> {
     match &result.data {
         RpcEventData::NewBlock { block, .. } => {
             let block = block.as_ref().ok_or("missing block")?;
-            vals.push(NewBlock::new(block.header().height).into());
+            vals.push(NewBlock::new(block.header.height).into());
         }
 
         RpcEventData::Tx { .. } => {

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -27,8 +27,8 @@ impl crate::ics02_client::header::Header for Header {
 
     fn height(&self) -> Height {
         Height::new(
-            ChainId::chain_version(self.signed_header.header().chain_id.to_string()),
-            u64::from(self.signed_header.header().height),
+            ChainId::chain_version(self.signed_header.header.chain_id.to_string()),
+            u64::from(self.signed_header.header.height),
         )
     }
 }
@@ -91,8 +91,7 @@ pub mod test_util {
     pub fn get_dummy_tendermint_header() -> tendermint::block::Header {
         serde_json::from_str::<SignedHeader>(include_str!("../../tests/support/signed_header.json"))
             .unwrap()
-            .header()
-            .clone()
+            .header
     }
 
     // TODO: This should be replaced with a ::default() or ::produce().

--- a/relayer-cli/src/tasks/light_client.rs
+++ b/relayer-cli/src/tasks/light_client.rs
@@ -128,8 +128,8 @@ async fn client_task(chain_id: chain::Id, handle: SupervisorHandle) -> Result<()
             info!(
                 chain.id = %chain_id,
                 "spawned new client now at trusted state: {} at height {}",
-                trusted_state.signed_header.header().hash(),
-                trusted_state.signed_header.header().height,
+                trusted_state.signed_header.header.hash(),
+                trusted_state.signed_header.header.height,
             );
 
             update_client(chain_id, handle).await?;
@@ -168,8 +168,8 @@ async fn update_client(chain_id: chain::Id, handle0: SupervisorHandle) -> Result
             Ok(trusted_state) => info!(
                 chain.id = %chain_id,
                 "client updated to trusted state: {} at height {}",
-                trusted_state.signed_header.header().hash(),
-                trusted_state.signed_header.header().height
+                trusted_state.signed_header.header.hash(),
+                trusted_state.signed_header.header.height
             ),
 
             Err(err) => error!(chain.id = %chain_id, "error when updating headers: {}", err),

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -106,7 +106,7 @@ impl CosmosSDKChain {
         let client = self.rpc_client();
 
         let signed_header = fetch_signed_header(client, height)?;
-        assert_eq!(height, signed_header.header().height);
+        assert_eq!(height, signed_header.header.height);
 
         // Get the validator list.
         let validators = fetch_validators(client, height)?;
@@ -114,7 +114,7 @@ impl CosmosSDKChain {
         // Get the proposer.
         let proposer = validators
             .iter()
-            .find(|v| v.address == signed_header.header().proposer_address)
+            .find(|v| v.address == signed_header.header.proposer_address)
             .ok_or_else(|| Kind::EmptyResponseValue)?;
 
         let voting_power: u64 = validators.iter().map(|v| v.voting_power.value()).sum();
@@ -344,8 +344,7 @@ impl Chain for CosmosSDKChain {
         let latest_header = self
             .query_light_block_at_height(tm_height)?
             .signed_header
-            .header()
-            .clone();
+            .header;
 
         // Build the consensus state.
         let consensus_state =


### PR DESCRIPTION

Closes: #XXX

## Description
Adapt to last tendermint-rs dep changes, `header()` getter removed, now `pub header` in `Block`.
______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.