### PR TITLE
Fix new Clippy warnings as of Rust 1.48

### DIFF
--- a/modules/src/ics02_client/msgs/update_client.rs
+++ b/modules/src/ics02_client/msgs/update_client.rs
@@ -68,7 +68,7 @@ impl TryFrom<RawMsgUpdateClient> for MsgUpdateAnyClient {
     type Error = Error;
 
     fn try_from(raw: RawMsgUpdateClient) -> Result<Self, Self::Error> {
-        let raw_header = raw.header.ok_or_else(|| Kind::InvalidRawHeader)?;
+        let raw_header = raw.header.ok_or(Kind::InvalidRawHeader)?;
         let signer = string_to_account(raw.signer).map_err(|e| Kind::InvalidAddress.context(e))?;
 
         Ok(MsgUpdateAnyClient {

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -33,7 +33,7 @@ impl TryFrom<RawConnectionEnd> for ConnectionEnd {
                 .map_err(|e| Kind::IdentifierError.context(e))?,
             value
                 .counterparty
-                .ok_or_else(|| Kind::MissingCounterparty)?
+                .ok_or(Kind::MissingCounterparty)?
                 .try_into()?,
             value.versions,
         )?)
@@ -144,7 +144,7 @@ impl TryFrom<RawCounterparty> for Counterparty {
             connection_id,
             value
                 .prefix
-                .ok_or_else(|| Kind::MissingCounterparty)?
+                .ok_or(Kind::MissingCounterparty)?
                 .key_prefix
                 .into(),
         ))

--- a/modules/src/ics03_connection/handler/verify.rs
+++ b/modules/src/ics03_connection/handler/verify.rs
@@ -39,7 +39,7 @@ pub fn verify_proofs(
             proofs
                 .client_proof()
                 .as_ref()
-                .ok_or_else(|| Kind::NullClientProof)?,
+                .ok_or(Kind::NullClientProof)?,
         )?;
     }
 

--- a/modules/src/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_ack.rs
@@ -100,7 +100,7 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
 
         let consensus_height = msg
             .consensus_height
-            .ok_or_else(|| Kind::MissingConsensusHeight)?
+            .ok_or(Kind::MissingConsensusHeight)?
             .try_into() // Cast from the raw height type into the domain type.
             .map_err(|e| Kind::InvalidProof.context(e))?;
         let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
@@ -108,7 +108,7 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
 
         let proof_height = msg
             .proof_height
-            .ok_or_else(|| Kind::MissingProofHeight)?
+            .ok_or(Kind::MissingProofHeight)?
             .try_into()
             .map_err(|e| Kind::InvalidProof.context(e))?;
 

--- a/modules/src/ics03_connection/msgs/conn_open_confirm.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_confirm.rs
@@ -69,7 +69,7 @@ impl TryFrom<RawMsgConnectionOpenConfirm> for MsgConnectionOpenConfirm {
 
         let proof_height = msg
             .proof_height
-            .ok_or_else(|| Kind::MissingProofHeight)?
+            .ok_or(Kind::MissingProofHeight)?
             .try_into() // Cast from the raw height type into the domain type.
             .map_err(|e| Kind::InvalidProof.context(e))?;
         Ok(Self {

--- a/modules/src/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_init.rs
@@ -94,7 +94,7 @@ impl TryFrom<RawMsgConnectionOpenInit> for MsgConnectionOpenInit {
                 .map_err(|e| Kind::IdentifierError.context(e))?,
             counterparty: msg
                 .counterparty
-                .ok_or_else(|| Kind::MissingCounterparty)?
+                .ok_or(Kind::MissingCounterparty)?
                 .try_into()?,
             version: validate_version(msg.version).map_err(|e| Kind::InvalidVersion.context(e))?,
             signer,

--- a/modules/src/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_try.rs
@@ -115,7 +115,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
     fn try_from(msg: RawMsgConnectionOpenTry) -> Result<Self, Self::Error> {
         let consensus_height = msg
             .consensus_height
-            .ok_or_else(|| Kind::MissingConsensusHeight)?
+            .ok_or(Kind::MissingConsensusHeight)?
             .try_into() // Cast from the raw height type into the domain type.
             .map_err(|e| Kind::InvalidProof.context(e))?;
 
@@ -124,7 +124,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
 
         let proof_height = msg
             .proof_height
-            .ok_or_else(|| Kind::MissingProofHeight)?
+            .ok_or(Kind::MissingProofHeight)?
             .try_into()
             .map_err(|e| Kind::InvalidProof.context(e))?;
 
@@ -155,7 +155,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
             counterparty_chosen_connection_id,
             counterparty: msg
                 .counterparty
-                .ok_or_else(|| Kind::MissingCounterparty)?
+                .ok_or(Kind::MissingCounterparty)?
                 .try_into()?,
             counterparty_versions: validate_versions(msg.counterparty_versions)
                 .map_err(|e| Kind::InvalidVersion.context(e))?,

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -33,7 +33,7 @@ impl TryFrom<RawChannel> for ChannelEnd {
         // Assemble the 'remote' attribute of the Channel, which represents the Counterparty.
         let remote = value
             .counterparty
-            .ok_or_else(|| Kind::MissingCounterparty)?
+            .ok_or(Kind::MissingCounterparty)?
             .try_into()?;
 
         // Parse each item in connection_hops into a ConnectionId.

--- a/modules/src/ics04_channel/msgs/chan_close_confirm.rs
+++ b/modules/src/ics04_channel/msgs/chan_close_confirm.rs
@@ -86,7 +86,7 @@ impl TryFrom<RawMsgChannelCloseConfirm> for MsgChannelCloseConfirm {
             None,
             raw_msg
                 .proof_height
-                .ok_or_else(|| Kind::MissingHeight)?
+                .ok_or(Kind::MissingHeight)?
                 .try_into()
                 .map_err(|e| Kind::InvalidProof.context(e))?,
         )

--- a/modules/src/ics04_channel/msgs/chan_open_ack.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_ack.rs
@@ -95,7 +95,7 @@ impl TryFrom<RawMsgChannelOpenAck> for MsgChannelOpenAck {
             None,
             raw_msg
                 .proof_height
-                .ok_or_else(|| Kind::MissingHeight)?
+                .ok_or(Kind::MissingHeight)?
                 .try_into()
                 .map_err(|e| Kind::InvalidProof.context(e))?,
         )

--- a/modules/src/ics04_channel/msgs/chan_open_confirm.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_confirm.rs
@@ -90,7 +90,7 @@ impl TryFrom<RawMsgChannelOpenConfirm> for MsgChannelOpenConfirm {
             None,
             raw_msg
                 .proof_height
-                .ok_or_else(|| Kind::MissingHeight)?
+                .ok_or(Kind::MissingHeight)?
                 .try_into()
                 .map_err(|e| Kind::InvalidProof.context(e))?,
         )

--- a/modules/src/ics04_channel/msgs/chan_open_init.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_init.rs
@@ -66,10 +66,7 @@ impl TryFrom<RawMsgChannelOpenInit> for MsgChannelOpenInit {
                 .channel_id
                 .parse()
                 .map_err(|e| Kind::IdentifierError.context(e))?,
-            channel: raw_msg
-                .channel
-                .ok_or_else(|| Kind::MissingChannel)?
-                .try_into()?,
+            channel: raw_msg.channel.ok_or(Kind::MissingChannel)?.try_into()?,
             signer,
         })
     }

--- a/modules/src/ics04_channel/msgs/chan_open_try.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_try.rs
@@ -67,7 +67,7 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
             None,
             raw_msg
                 .proof_height
-                .ok_or_else(|| Kind::MissingHeight)?
+                .ok_or(Kind::MissingHeight)?
                 .try_into()
                 .map_err(|e| Kind::InvalidProof.context(e))?,
         )
@@ -89,10 +89,7 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
                 .parse()
                 .map_err(|e| Kind::IdentifierError.context(e))?,
             counterparty_chosen_channel_id,
-            channel: raw_msg
-                .channel
-                .ok_or_else(|| Kind::MissingChannel)?
-                .try_into()?,
+            channel: raw_msg.channel.ok_or(Kind::MissingChannel)?.try_into()?,
             counterparty_version: validate_version(raw_msg.counterparty_version)?,
             proofs,
             signer,

--- a/modules/src/ics04_channel/msgs/recv_packet.rs
+++ b/modules/src/ics04_channel/msgs/recv_packet.rs
@@ -86,7 +86,7 @@ impl TryFrom<RawMsgRecvPacket> for MsgRecvPacket {
             None,
             raw_msg
                 .proof_height
-                .ok_or_else(|| Kind::MissingHeight)?
+                .ok_or(Kind::MissingHeight)?
                 .try_into()
                 .map_err(|e| Kind::InvalidProof.context(e))?,
         )

--- a/relayer-cli/src/commands/v0.rs
+++ b/relayer-cli/src/commands/v0.rs
@@ -39,11 +39,12 @@ pub fn v0_task(config: Config) -> Result<(), BoxError> {
     let src_chain_config = config
         .chains
         .get(0)
-        .ok_or_else(|| "Configuration for source chain (position 0 in chains config) not found")?;
+        .ok_or("Configuration for source chain (position 0 in chains config) not found")?;
+
     let dst_chain_config = config
         .chains
         .get(1)
-        .ok_or_else(|| "Configuration for dest. chain (position 1 in chains config) not found")?;
+        .ok_or("Configuration for dest. chain (position 1 in chains config) not found")?;
 
     let src_chain = ChainRuntime::new(src_chain_config);
     let dst_chain = ChainRuntime::new(dst_chain_config);
@@ -64,14 +65,14 @@ pub fn v0_task(config: Config) -> Result<(), BoxError> {
         src_chain_config
             .client_ids
             .get(0)
-            .ok_or_else(|| "Config for client on source chain not found")?,
+            .ok_or("Config for client on source chain not found")?,
     )
     .map_err(|e| format!("Error validating client identifier for src chain ({:?})", e))?;
     let client_dst_id = ClientId::from_str(
         dst_chain_config
             .client_ids
             .get(0)
-            .ok_or_else(|| "Config for client for dest. chain not found")?,
+            .ok_or("Config for client for dest. chain not found")?,
     )
     .map_err(|e| format!("Error validating client identifier for dst chain ({:?})", e))?;
 

--- a/relayer-cli/src/config.rs
+++ b/relayer-cli/src/config.rs
@@ -18,6 +18,6 @@ pub fn config_path() -> Result<PathBuf, BoxError> {
     assert!(args.next().is_some(), "expected one argument but got zero");
     let args = args.collect::<Vec<_>>();
     let app = EntryPoint::<CliCmd>::parse_args_default(args.as_slice())?;
-    let config_path = app.config.ok_or_else(|| "no config file specified")?;
+    let config_path = app.config.ok_or("no config file specified")?;
     Ok(config_path)
 }

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -149,7 +149,7 @@ impl CosmosSDKChain {
         let proposer = validators
             .iter()
             .find(|v| v.address == signed_header.header.proposer_address)
-            .ok_or_else(|| Kind::EmptyResponseValue)?;
+            .ok_or(Kind::EmptyResponseValue)?;
 
         let voting_power: u64 = validators.iter().map(|v| v.voting_power.value()).sum();
 


### PR DESCRIPTION

## Description

Fix new Clippy warnings as of Rust 1.48

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.