### PR TITLE
Rename proto-compiler cli arg

### DIFF
--- a/proto-compiler/src/cmd/clone.rs
+++ b/proto-compiler/src/cmd/clone.rs
@@ -18,7 +18,7 @@ pub struct CloneCmd {
 
     /// where to checkout the repository
     #[argh(option, short = 'o')]
-    path: PathBuf,
+    out: PathBuf,
 }
 
 impl CloneCmd {
@@ -32,13 +32,13 @@ impl CloneCmd {
     pub fn run(&self) {
         self.validate();
 
-        let repo = if self.path.exists() {
+        let repo = if self.out.exists() {
             println!(
                 "[info ] Found Cosmos SDK source at '{}'",
-                self.path.display()
+                self.out.display()
             );
 
-            Repository::open(&self.path).unwrap_or_else(|e| {
+            Repository::open(&self.out).unwrap_or_else(|e| {
                 println!("[error] Failed to open repository: {}", e);
                 process::exit(1)
             })
@@ -47,12 +47,12 @@ impl CloneCmd {
 
             let url = "https://github.com/cosmos/cosmos-sdk";
 
-            let repo = Repository::clone(url, &self.path).unwrap_or_else(|e| {
+            let repo = Repository::clone(url, &self.out).unwrap_or_else(|e| {
                 println!("[error] Failed to clone the repository: {}", e);
                 process::exit(1)
             });
 
-            println!("[info ] Cloned at '{}'", self.path.display());
+            println!("[info ] Cloned at '{}'", self.out.display());
 
             repo
         };


### PR DESCRIPTION
Changed `clone-sdk --path` to `clone-sdk --out` to match readme.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #419

## Description

Rename `path` to `out` in order to match Readme command examples.

The shortand is `-o`, so I assume that the intended argument was `--out` and not `--path`.


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.