### PR TITLE
Replacing dirs crate (unmaintained) with dirs-next (maintained)

### DIFF
--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -37,7 +37,7 @@ bech32 = "0.7.2"
 itertools = "0.9.0"
 dyn-clonable = "0.9.0"
 tonic = "0.3.1"
-dirs = "3.0.1"
+dirs-next = "2.0.0"
 
 [dependencies.tendermint]
 version = "=0.17.0-rc3"

--- a/relayer/src/keyring/store.rs
+++ b/relayer/src/keyring/store.rs
@@ -287,7 +287,7 @@ fn get_address(pk: ExtendedPubKey) -> Vec<u8> {
 }
 
 fn get_test_backend_folder(chain_config: &ChainConfig) -> Result<PathBuf, Error> {
-    let home = dirs::home_dir();
+    let home = dirs_next::home_dir();
     match home {
         Some(h) => {
             let folder = Path::new(h.as_path())


### PR DESCRIPTION
Closes: #418

## Description

Small change, just replacing `dirs` crate that is not maintained anymore with `dirs-netx` that is maintained.

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [X] Re-reviewed `Files changed` in the Github PR explorer.