### PR TITLE
Allow overriding peer_id, height and hash in light add command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Special thanks to external contributors for this release: @CharlyCst ([#347]).
     - Implement the relayer CLI for connection handshake messages ([#358], [#359], [#360])
     - Implement the relayer CLI for channel handshake messages ([#371], [#372], [#373], [#374])
     - Implement commands to add and list keys for a chain ([#363])
+    - Allow overriding peer_id, height and hash in light add command ([#428])
 - [proto-compiler]
     - Refactor and allow specifying a commit at which the Cosmos SDK should be checked out ([#366])
     - Add a `--tag` option to the `clone-sdk` command to check out a tag instead of a commit ([#369])
@@ -48,6 +49,7 @@ Special thanks to external contributors for this release: @CharlyCst ([#347]).
 [#374]: https://github.com/informalsystems/ibc-rs/issues/374
 [#389]: https://github.com/informalsystems/ibc-rs/issues/389
 [#403]: https://github.com/informalsystems/ibc-rs/issues/403
+[#428]: https://github.com/informalsystems/ibc-rs/issues/428
 [proto-compiler]: https://github.com/informalsystems/ibc-rs/tree/master/proto-compiler
 
 ### IMPROVEMENTS


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #428

## Description

Add parameters to the `light add` command to override the peer id, height and hash which are otherwise fetched from the node.

```
USAGE:
    relayer-cli light add <OPTIONS>

DESCRIPTION:
    add a light client peer for a given chain

POSITIONAL ARGUMENTS:
    address                   RPC network address (required)

FLAGS:
    -c, --chain-id CHAIN-ID   identifier of the chain (required)
    -s, --store STORE         path to light client store for this peer (required)
    -p, --primary             whether this is the primary peer
    -f, --force               allow overriding an existing peer
    -y, --yes                 skip confirmation
    --peer-id PEER-ID         override peer id (optional)
    --height HEIGHT           override height (optional)
    --hash HASH               override hash (optional)
```


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.