### PR TITLE
Prevent early exit on killall error in dev-env script

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -34,6 +34,11 @@ tomlcfg="$1"
 chainid0="$2"
 chainid1="$3"
 
+if ! [ -f $tomlcfg ]; then
+  echo "[CONFIG_FILE] does not exist or is not a file."
+  usage
+fi
+
 GAIA_DATA="$(pwd)/data"
 
 # Ensure user understands what will be deleted

--- a/dev-env
+++ b/dev-env
@@ -3,22 +3,31 @@
 # Copied from https://github.com/cosmos/relayer and modified to initialize the Rust relayer light clients.
 
 usage() {
-	echo "Missing $1 parameter. Please check if all parameters were specified."
-	echo "Usage: $0 [CONFIG_FILE] [CHAIN_ID_0] [CHAIN_ID_1]"
+  echo "Usage: $0 [CONFIG_FILE] [CHAIN_ID_0] [CHAIN_ID_1]"
   echo "Example: $0 ./config.toml ibc-0 ibc-1"
   exit 1
 }
 
+missing() {
+  echo "Missing $1 parameter. Please check if all parameters were specified."
+  usage
+}
+
 if [ -z "$1" ]; then
-  usage "CONFIG_FILE"
+  missing "CONFIG_FILE"
 fi
 
 if [ -z "$2" ]; then
-  usage "CHAIN_ID_0"
+  missing "CHAIN_ID_0"
 fi
 
 if [ -z "$3" ]; then
-  usage "CHAIN_ID_1"
+  missing "CHAIN_ID_1"
+fi
+
+if [ "$#" -gt 3 ]; then
+  echo "Incorrect number of parameters."
+  usage
 fi
 
 tomlcfg="$1"
@@ -52,8 +61,6 @@ rm -rf "$GAIA_DATA" &> /dev/null
 # Stop existing gaiad processes
 killall gaiad &> /dev/null || true
 killall akash &> /dev/null || true
-
-set -e
 
 echo "Generating gaia configurations..."
 mkdir -p "$GAIA_DATA" && cd "$GAIA_DATA" && cd ../

--- a/dev-env
+++ b/dev-env
@@ -35,7 +35,7 @@ chainid0="$2"
 chainid1="$3"
 
 if ! [ -f $tomlcfg ]; then
-  echo "[CONFIG_FILE] does not exist or is not a file."
+  echo "[CONFIG_FILE] ($1) does not exist or is not a file."
   usage
 fi
 

--- a/dev-env
+++ b/dev-env
@@ -50,8 +50,8 @@ echo "GAIA VERSION INFO: $(gaiad version)"
 rm -rf "$GAIA_DATA" &> /dev/null
 
 # Stop existing gaiad processes
-killall gaiad &> /dev/null
-killall akash &> /dev/null
+killall gaiad &> /dev/null || true
+killall akash &> /dev/null || true
 
 set -e
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The `dev-env` script was exiting early if one of the `killall` commands returned an error.
This PR ignores any errors on those commands with `|| true` but I'm not sure this is the best solution.
Since there's a `set -e` right after the `killall` commands, maybe a better solution would be to remove the `-e` from `#!/bin/bash -e`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.