### PR TITLE
Relayer fixes after profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@
 - [relayer]
   - Performance improvements ([#514])
 
+- [modules]
+  -  Clean the validate_basic method ([#94])
+
 - Update to `tendermint-rs` v0.17.1 ([#517])
 
+[#94]: https://github.com/informalsystems/ibc-rs/issues/94
 [#470]: https://github.com/informalsystems/ibc-rs/issues/470
 [#500]: https://github.com/informalsystems/ibc-rs/issues/500
 [#505]: https://github.com/informalsystems/ibc-rs/issues/505

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,19 @@
 
 - [relayer-cli]
   - Replace `ChannelConfig` in `Channel::new` ([#511])
+  - Add `packet-send` CLI ([#470])
+
+- [relayer]
+  - Performance improvements ([#514])
 
 - Update to `tendermint-rs` v0.17.1 ([#517])
 
-
+[#470]: https://github.com/informalsystems/ibc-rs/issues/470
 [#500]: https://github.com/informalsystems/ibc-rs/issues/500
 [#505]: https://github.com/informalsystems/ibc-rs/issues/505
 [#507]: https://github.com/informalsystems/ibc-rs/issues/507
 [#511]: https://github.com/informalsystems/ibc-rs/pull/511
+[#514]: https://github.com/informalsystems/ibc-rs/issues/514
 [#517]: https://github.com/informalsystems/ibc-rs/issues/517
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,14 @@
 
 - [relayer]
   - Performance improvements ([#514])
+  - Fix for mismatching `bitcoin` dep ([#525])
+
+- [modules]
+  -  Clean the validate_basic method ([#94])
 
 - Update to `tendermint-rs` v0.17.1 ([#517])
 
+[#94]: https://github.com/informalsystems/ibc-rs/issues/94
 [#470]: https://github.com/informalsystems/ibc-rs/issues/470
 [#500]: https://github.com/informalsystems/ibc-rs/issues/500
 [#505]: https://github.com/informalsystems/ibc-rs/issues/505
@@ -28,6 +33,7 @@
 [#511]: https://github.com/informalsystems/ibc-rs/pull/511
 [#514]: https://github.com/informalsystems/ibc-rs/issues/514
 [#517]: https://github.com/informalsystems/ibc-rs/issues/517
+[#525]: https://github.com/informalsystems/ibc-rs/issues/525
 
 
 ## v0.0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,8 @@
 - [relayer]
   - Performance improvements ([#514])
 
-- [modules]
-  -  Clean the validate_basic method ([#94])
-
 - Update to `tendermint-rs` v0.17.1 ([#517])
 
-[#94]: https://github.com/informalsystems/ibc-rs/issues/94
 [#470]: https://github.com/informalsystems/ibc-rs/issues/470
 [#500]: https://github.com/informalsystems/ibc-rs/issues/500
 [#505]: https://github.com/informalsystems/ibc-rs/issues/505

--- a/modules/src/application/ics20_fungible_token_transfer/msgs/transfer.rs
+++ b/modules/src/application/ics20_fungible_token_transfer/msgs/transfer.rs
@@ -43,10 +43,6 @@ impl Msg for MsgTransfer {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics02_client/msgs/create_client.rs
+++ b/modules/src/ics02_client/msgs/create_client.rs
@@ -61,11 +61,6 @@ impl Msg for MsgCreateAnyClient {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate since all fields are validated on creation.
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics02_client/msgs/update_client.rs
+++ b/modules/src/ics02_client/msgs/update_client.rs
@@ -44,11 +44,6 @@ impl Msg for MsgUpdateAnyClient {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate since all fields are validated on creation.
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_ack.rs
@@ -72,10 +72,6 @@ impl Msg for MsgConnectionOpenAck {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        Ok(())
-    }
-
     fn get_signers(&self) -> Vec<AccountId> {
         vec![self.signer]
     }

--- a/modules/src/ics03_connection/msgs/conn_open_confirm.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_confirm.rs
@@ -41,10 +41,6 @@ impl Msg for MsgConnectionOpenConfirm {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Error> {
-        Ok(())
-    }
-
     fn get_signers(&self) -> Vec<AccountId> {
         vec![self.signer]
     }

--- a/modules/src/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_init.rs
@@ -50,13 +50,6 @@ impl Msg for MsgConnectionOpenInit {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // All the validation is performed on creation
-        self.counterparty
-            .validate_basic()
-            .map_err(|e| Kind::InvalidCounterparty.context(e).into())
-    }
-
     fn get_signers(&self) -> Vec<AccountId> {
         vec![self.signer]
     }

--- a/modules/src/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_try.rs
@@ -93,12 +93,6 @@ impl Msg for MsgConnectionOpenTry {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        self.counterparty
-            .validate_basic()
-            .map_err(|e| Kind::InvalidCounterparty.context(e).into())
-    }
-
     fn get_signers(&self) -> Vec<AccountId> {
         vec![self.signer]
     }

--- a/modules/src/ics04_channel/events.rs
+++ b/modules/src/ics04_channel/events.rs
@@ -53,6 +53,8 @@ fn event_types() -> HashSet<String> {
         CLOSE_CONFIRM_EVENT_TYPE.to_string(),
         SEND_PACKET.to_string(),
         WRITE_ACK.to_string(),
+        ACK_PACKET.to_string(),
+        TIMEOUT.to_string(),
     ]
     .into_iter()
     .collect()
@@ -119,6 +121,14 @@ pub fn try_from_tx(event: tendermint::abci::Event) -> Option<IBCEvent> {
                 ack,
             },
         )),
+        ACK_PACKET => Some(IBCEvent::AcknowledgePacketChannel(AcknowledgePacket {
+            height: Default::default(),
+            packet,
+        })),
+        TIMEOUT => Some(IBCEvent::TimeoutPacketChannel(TimeoutPacket {
+            height: Default::default(),
+            packet,
+        })),
         _ => None,
     }
 }

--- a/modules/src/ics04_channel/msgs/acknowledgement.rs
+++ b/modules/src/ics04_channel/msgs/acknowledgement.rs
@@ -46,12 +46,6 @@ impl Msg for MsgAcknowledgement {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics04_channel/msgs/chan_close_confirm.rs
+++ b/modules/src/ics04_channel/msgs/chan_close_confirm.rs
@@ -28,12 +28,6 @@ impl Msg for MsgChannelCloseConfirm {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
-    }
-
     fn get_signers(&self) -> Vec<AccountId> {
         vec![self.signer]
     }

--- a/modules/src/ics04_channel/msgs/chan_close_init.rs
+++ b/modules/src/ics04_channel/msgs/chan_close_init.rs
@@ -46,12 +46,6 @@ impl Msg for MsgChannelCloseInit {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
-    }
-
     fn get_signers(&self) -> Vec<AccountId> {
         vec![self.signer]
     }

--- a/modules/src/ics04_channel/msgs/chan_open_ack.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_ack.rs
@@ -32,12 +32,6 @@ impl Msg for MsgChannelOpenAck {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics04_channel/msgs/chan_open_confirm.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_confirm.rs
@@ -55,12 +55,6 @@ impl Msg for MsgChannelOpenConfirm {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics04_channel/msgs/chan_open_init.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_init.rs
@@ -29,10 +29,6 @@ impl Msg for MsgChannelOpenInit {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        self.channel.validate_basic()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics04_channel/msgs/chan_open_try.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_try.rs
@@ -33,10 +33,6 @@ impl Msg for MsgChannelOpenTry {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        self.channel.validate_basic()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/ics04_channel/msgs/recv_packet.rs
+++ b/modules/src/ics04_channel/msgs/recv_packet.rs
@@ -23,19 +23,12 @@ pub struct MsgRecvPacket {
 }
 
 impl MsgRecvPacket {
-    #[allow(dead_code, unreachable_code, unused_variables)]
     pub fn new(packet: Packet, proofs: Proofs, signer: AccountId) -> Result<MsgRecvPacket, Error> {
         Ok(Self {
             packet,
             proofs,
             signer,
         })
-    }
-
-    // returns the base64-encoded bytes used for the
-    // data field when signing the packet
-    pub fn get_data_bytes() -> Vec<u8> {
-        todo!()
     }
 }
 
@@ -44,12 +37,6 @@ impl Msg for MsgRecvPacket {
 
     fn route(&self) -> String {
         crate::keys::ROUTER_KEY.to_string()
-    }
-
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
     }
 
     fn type_url(&self) -> String {

--- a/modules/src/ics04_channel/msgs/timeout.rs
+++ b/modules/src/ics04_channel/msgs/timeout.rs
@@ -46,12 +46,6 @@ impl Msg for MsgTimeout {
         crate::keys::ROUTER_KEY.to_string()
     }
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError> {
-        // Nothing to validate
-        // All the validation is performed on creation
-        Ok(())
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/modules/src/tx_msg.rs
+++ b/modules/src/tx_msg.rs
@@ -7,8 +7,6 @@ pub trait Msg: Clone {
     // TODO -- clarify what is this function supposed to do & its connection to ICS26 routing mod.
     fn route(&self) -> String;
 
-    fn validate_basic(&self) -> Result<(), Self::ValidationError>;
-
     fn get_sign_bytes<M: From<Self> + prost::Message>(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         let raw_msg: M = self.clone().into();

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -83,8 +83,8 @@ impl Runnable for QueryPacketCommitmentsCmd {
             Ok(cs) => status_info!(
                 "Result for packet commitments query at height",
                 "{:?} {:#?}",
-                cs.0,
-                cs.1
+                cs.1,
+                cs.0
             ),
             Err(e) => status_info!("Error encountered on packet commitments query:", "{}", e),
         }

--- a/relayer-cli/src/commands/tx/packet.rs
+++ b/relayer-cli/src/commands/tx/packet.rs
@@ -9,7 +9,8 @@ use ibc::ics24_host::identifier::{ChannelId, ClientId, PortId};
 use relayer::chain::runtime::ChainRuntime;
 use relayer::chain::CosmosSDKChain;
 use relayer::link::{
-    build_and_send_ack_packet_messages, build_and_send_recv_packet_messages, PacketOptions,
+    build_and_send_ack_packet_messages, build_and_send_recv_packet_messages, PacketEnvelope,
+    PacketOptions,
 };
 
 #[derive(Clone, Command, Debug, Options)]
@@ -55,13 +56,15 @@ impl TxRawPacketRecvCmd {
 
         let opts = PacketOptions {
             packet_src_chain_config: src_chain_config.clone(),
-            packet_src_client_id: self.src_client_id.clone(),
-            packet_src_port_id: self.src_port_id.clone(),
-            packet_src_channel_id: self.src_channel_id.clone(),
             packet_dst_chain_config: dest_chain_config.clone(),
-            packet_dst_client_id: self.dest_client_id.clone(),
-            packet_dst_port_id: self.dst_port_id.clone(),
-            packet_dst_channel_id: self.dst_channel_id.clone(),
+            packet_envelope: PacketEnvelope {
+                packet_src_client_id: self.src_client_id.clone(),
+                packet_src_port_id: self.src_port_id.clone(),
+                packet_src_channel_id: self.src_channel_id.clone(),
+                packet_dst_client_id: self.dest_client_id.clone(),
+                packet_dst_port_id: self.dst_port_id.clone(),
+                packet_dst_channel_id: self.dst_channel_id.clone(),
+            },
         };
 
         Ok(opts)
@@ -91,7 +94,11 @@ impl Runnable for TxRawPacketRecvCmd {
                 .map_err(|e| Kind::Tx.context(e).into());
 
         match res {
-            Ok(ev) => status_info!("packet recv, result: ", "{:#?}", ev),
+            Ok(events) => status_info!(
+                "packet recv, result: ",
+                "{:#?}",
+                serde_json::to_string(&events).unwrap()
+            ),
             Err(e) => status_info!("packet recv failed, error: ", "{}", e),
         }
     }
@@ -140,13 +147,15 @@ impl TxRawPacketAckCmd {
 
         let opts = PacketOptions {
             packet_src_chain_config: src_chain_config.clone(),
-            packet_src_client_id: self.src_client_id.clone(),
-            packet_src_port_id: self.src_port_id.clone(),
-            packet_src_channel_id: self.src_channel_id.clone(),
             packet_dst_chain_config: dest_chain_config.clone(),
-            packet_dst_client_id: self.dest_client_id.clone(),
-            packet_dst_port_id: self.dst_port_id.clone(),
-            packet_dst_channel_id: self.dst_channel_id.clone(),
+            packet_envelope: PacketEnvelope {
+                packet_src_client_id: self.src_client_id.clone(),
+                packet_src_port_id: self.src_port_id.clone(),
+                packet_src_channel_id: self.src_channel_id.clone(),
+                packet_dst_client_id: self.dest_client_id.clone(),
+                packet_dst_port_id: self.dst_port_id.clone(),
+                packet_dst_channel_id: self.dst_channel_id.clone(),
+            },
         };
 
         Ok(opts)
@@ -176,7 +185,11 @@ impl Runnable for TxRawPacketAckCmd {
                 .map_err(|e| Kind::Tx.context(e).into());
 
         match res {
-            Ok(ev) => status_info!("packet ack, result: ", "{:#?}", ev),
+            Ok(events) => status_info!(
+                "packet ack, result: ",
+                "{:#?}",
+                serde_json::to_string(&events).unwrap()
+            ),
             Err(e) => status_info!("packet ack failed, error: ", "{}", e),
         }
     }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -30,7 +30,7 @@ retry = "1.1.0"
 crossbeam-channel = "0.5.0"
 k256 = { version = "0.7.1", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
-bitcoin = { version = "=0.25"}
+bitcoin = { version= "0.25"}
 bitcoin-wallet = "1.1.0"
 hdpath = { version = "0.6.0", features = ["with-bitcoin"] }
 rust-crypto = "0.2.36"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -30,7 +30,7 @@ retry = "1.1.0"
 crossbeam-channel = "0.5.0"
 k256 = { version = "0.7.1", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
-bitcoin = { version= "0.25"}
+bitcoin = { version = "=0.25"}
 bitcoin-wallet = "1.1.0"
 hdpath = { version = "0.6.0", features = ["with-bitcoin"] }
 rust-crypto = "0.2.36"

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -31,7 +31,7 @@ use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 use ibc::events::IBCEvent;
 use ibc::ics02_client::header::Header;
 use ibc::ics02_client::state::{ClientState, ConsensusState};
-use ibc::ics03_connection::connection::ConnectionEnd;
+use ibc::ics03_connection::connection::{ConnectionEnd, State};
 use ibc::ics03_connection::version::{get_compatible_versions, Version};
 use ibc::ics04_channel::channel::{ChannelEnd, QueryPacketEventDataRequest};
 use ibc::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofBytes};
@@ -228,8 +228,7 @@ pub trait Chain: Sized {
     }
 
     /// Builds the required proofs and the client state for connection handshake messages.
-    /// The proofs and client state must be obtained from queries at same height with value
-    /// `height - 1`
+    /// The proofs and client state must be obtained from queries at same height.
     fn build_connection_proofs_and_client_state(
         &self,
         message_type: ConnectionMsgType,
@@ -237,14 +236,30 @@ pub trait Chain: Sized {
         client_id: &ClientId,
         height: ICSHeight,
     ) -> Result<(Option<Self::ClientState>, Proofs), Error> {
-        // Set the height of the queries at height - 1
-        let query_height = height
-            .decrement()
-            .map_err(|e| Kind::InvalidHeight.context(e))?;
+        let (connection_end, connection_proof) = self.proven_connection(&connection_id, height)?;
 
-        // Collect all proofs as required
-        let connection_proof =
-            CommitmentProofBytes::from(self.proven_connection(&connection_id, query_height)?.1);
+        // Check that the connection state is compatible with the message
+        match message_type {
+            ConnectionMsgType::OpenTry => {
+                if !connection_end.state_matches(&State::Init)
+                    && !connection_end.state_matches(&State::TryOpen)
+                {
+                    return Err(Kind::ConnOpenTry("bad connection state".to_string()).into());
+                }
+            }
+            ConnectionMsgType::OpenAck => {
+                if !connection_end.state_matches(&State::TryOpen)
+                    && !connection_end.state_matches(&State::Open)
+                {
+                    return Err(Kind::ConnOpenTry("bad connection state".to_string()).into());
+                }
+            }
+            ConnectionMsgType::OpenConfirm => {
+                if !connection_end.state_matches(&State::Open) {
+                    return Err(Kind::ConnOpenTry("bad connection state".to_string()).into());
+                }
+            }
+        }
 
         let mut client_state = None;
         let mut client_proof = None;
@@ -253,7 +268,7 @@ pub trait Chain: Sized {
         match message_type {
             ConnectionMsgType::OpenTry | ConnectionMsgType::OpenAck => {
                 let (client_state_value, client_state_proof) =
-                    self.proven_client_state(&client_id, query_height)?;
+                    self.proven_client_state(&client_id, height)?;
 
                 client_proof = Some(CommitmentProofBytes::from(client_state_proof));
 
@@ -261,7 +276,7 @@ pub trait Chain: Sized {
                     .proven_client_consensus(
                         &client_id,
                         client_state_value.latest_height(),
-                        query_height,
+                        height,
                     )?
                     .1;
 
@@ -282,8 +297,13 @@ pub trait Chain: Sized {
 
         Ok((
             client_state,
-            Proofs::new(connection_proof, client_proof, consensus_proof, height)
-                .map_err(|_| Kind::MalformedProof)?,
+            Proofs::new(
+                CommitmentProofBytes::from(connection_proof),
+                client_proof,
+                consensus_proof,
+                height.increment(),
+            )
+            .map_err(|_| Kind::MalformedProof)?,
         ))
     }
 
@@ -298,23 +318,19 @@ pub trait Chain: Sized {
     }
 
     /// Builds the proof for channel handshake messages.
-    /// The proof must be obtained from queries at height `height - 1`
+    /// The proof is obtained from queries at height `height`
     fn build_channel_proofs(
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
         height: ICSHeight,
     ) -> Result<Proofs, Error> {
-        // Set the height of the queries at height - 1
-        let query_height = height
-            .decrement()
-            .map_err(|e| Kind::InvalidHeight.context(e))?;
-
         // Collect all proofs as required
         let channel_proof =
-            CommitmentProofBytes::from(self.proven_channel(port_id, channel_id, query_height)?.1);
+            CommitmentProofBytes::from(self.proven_channel(port_id, channel_id, height)?.1);
 
-        Ok(Proofs::new(channel_proof, None, None, height).map_err(|_| Kind::MalformedProof)?)
+        Ok(Proofs::new(channel_proof, None, None, height.increment())
+            .map_err(|_| Kind::MalformedProof)?)
     }
 
     fn query_packet_commitments(

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -67,6 +67,7 @@ use crate::event::monitor::{EventBatch, EventMonitor};
 use crate::keyring::store::{KeyEntry, KeyRing, KeyRingOperations, StoreBackend};
 use crate::light_client::tendermint::LightClient as TMLightClient;
 use crate::light_client::LightClient;
+use crate::util::block_on;
 use ibc::ics04_channel::packet::Sequence;
 
 // TODO size this properly
@@ -97,9 +98,7 @@ impl CosmosSDKChain {
         let request =
             tonic::Request::new(ibc_proto::cosmos::staking::v1beta1::QueryParamsRequest {});
 
-        let response = self
-            .block_on(client.params(request))?
-            .map_err(|e| Kind::Grpc.context(e))?;
+        let response = block_on(client.params(request)).map_err(|e| Kind::Grpc.context(e))?;
 
         let res = response
             .into_inner()
@@ -122,8 +121,7 @@ impl CosmosSDKChain {
     /// Query the consensus parameters via an RPC query
     /// Specific to the SDK and used only for Tendermint client create
     pub fn query_consensus_params(&self) -> Result<Params, Error> {
-        Ok(self
-            .block_on(self.rpc_client().genesis())?
+        Ok(block_on(self.rpc_client().genesis())
             .map_err(|e| Kind::Rpc.context(e))?
             .consensus_params)
     }
@@ -160,9 +158,8 @@ impl CosmosSDKChain {
             value: pk_buf,
         };
 
-        let acct_response = self
-            .block_on(query_account(self, key.account))?
-            .map_err(|e| Kind::Grpc.context(e))?;
+        let acct_response =
+            block_on(query_account(self, key.account)).map_err(|e| Kind::Grpc.context(e))?;
 
         let single = Single { mode: 1 };
         let sum_single = Some(Sum::Single(single));
@@ -218,9 +215,8 @@ impl CosmosSDKChain {
         let mut txraw_buf = Vec::new();
         prost::Message::encode(&tx_raw, &mut txraw_buf).unwrap();
 
-        let response = self
-            .block_on(broadcast_tx_commit(self, txraw_buf))?
-            .map_err(|e| Kind::Rpc.context(e))?;
+        let response =
+            block_on(broadcast_tx_commit(self, txraw_buf)).map_err(|e| Kind::Rpc.context(e))?;
 
         let res = tx_result_to_event(response)?;
 
@@ -313,8 +309,7 @@ impl Chain for CosmosSDKChain {
                 .into());
         }
 
-        let response =
-            self.block_on(abci_query(&self, path, data.to_string(), height, prove))??;
+        let response = block_on(abci_query(&self, path, data.to_string(), height, prove))?;
 
         // TODO - Verify response proof, if requested.
         if prove {}
@@ -356,9 +351,7 @@ impl Chain for CosmosSDKChain {
 
     /// Query the latest height the chain is at via a RPC query
     fn query_latest_height(&self) -> Result<ICSHeight, Error> {
-        let status = self
-            .block_on(self.rpc_client().status())?
-            .map_err(|e| Kind::Rpc.context(e))?;
+        let status = block_on(self.rpc_client().status()).map_err(|e| Kind::Rpc.context(e))?;
 
         if status.sync_info.catching_up {
             fail!(
@@ -531,8 +524,7 @@ impl Chain for CosmosSDKChain {
 
         let request = tonic::Request::new(request);
 
-        let response = self
-            .block_on(client.packet_commitments(request))?
+        let response = block_on(client.packet_commitments(request))
             .map_err(|e| Kind::Grpc.context(e))?
             .into_inner();
 
@@ -563,8 +555,7 @@ impl Chain for CosmosSDKChain {
 
         let request = tonic::Request::new(request);
 
-        let response = self
-            .block_on(client.unreceived_packets(request))?
+        let response = block_on(client.unreceived_packets(request))
             .map_err(|e| Kind::Grpc.context(e))?
             .into_inner();
 
@@ -587,8 +578,7 @@ impl Chain for CosmosSDKChain {
 
         let request = tonic::Request::new(request);
 
-        let response = self
-            .block_on(client.packet_acknowledgements(request))?
+        let response = block_on(client.packet_acknowledgements(request))
             .map_err(|e| Kind::Grpc.context(e))?
             .into_inner();
 
@@ -619,8 +609,7 @@ impl Chain for CosmosSDKChain {
 
         let request = tonic::Request::new(request);
 
-        let response = self
-            .block_on(client.unreceived_acks(request))?
+        let response = block_on(client.unreceived_acks(request))
             .map_err(|e| Kind::Grpc.context(e))?
             .into_inner();
 
@@ -638,16 +627,14 @@ impl Chain for CosmosSDKChain {
         let mut result: Vec<IBCEvent> = vec![];
         for seq in request.sequences.iter() {
             // query all Tx-es that include events related to packet with given port, channel and sequence
-            let response = self
-                .block_on(self.rpc_client.tx_search(
-                    packet_query(&request, seq)?,
-                    false,
-                    1,
-                    1,
-                    Order::Ascending,
-                ))
-                .unwrap()
-                .unwrap(); // todo
+            let response = block_on(self.rpc_client.tx_search(
+                packet_query(&request, seq)?,
+                false,
+                1,
+                1,
+                Order::Ascending,
+            ))
+            .unwrap(); // todo
 
             let mut events = packet_from_tx_search_response(&request, *seq, &response)?
                 .map_or(vec![], |v| vec![v]);

--- a/relayer/src/channel.rs
+++ b/relayer/src/channel.rs
@@ -216,11 +216,18 @@ impl Channel {
                     error!("Failed ChanTry {:?}: {}", self.config.b_end(), e);
                     continue;
                 }
-                Ok(result) => {
-                    self.config.b_config.channel_id = extract_channel_id(&result)?.clone();
-                    info!("{}  {} => {:?}\n", done, b_chain.id(), result);
-                    break;
-                }
+                Ok(result) => match result {
+                    IBCEvent::ChainError(e) => {
+                        info!("Failed ChanTry {:?}: {}", self.config.b_end(), e);
+                        continue;
+                    }
+
+                    _ => {
+                        self.config.b_config.channel_id = extract_channel_id(&result)?.clone();
+                        info!("{}  {} => {:?}\n", done, b_chain.id(), result);
+                        break;
+                    }
+                },
             }
         }
         debug!("elapsed time {:?}", now.elapsed().unwrap().as_secs());
@@ -472,14 +479,19 @@ pub fn build_chan_try(
     let dst_connection =
         dst_chain.query_connection(&opts.dst().connection_id().clone(), Height::default())?;
 
-    let ics_target_height = src_chain.query_latest_height()?;
+    let query_height = src_chain.query_latest_height()?;
+    let proofs = src_chain.build_channel_proofs(
+        &opts.src().port_id(),
+        &opts.src().channel_id(),
+        query_height,
+    )?;
 
-    // Build message to update client on destination
+    // Build message(s) to update client on destination
     let mut msgs = build_update_client(
         dst_chain.clone(),
         src_chain.clone(),
         &dst_connection.client_id(),
-        ics_target_height,
+        proofs.height(),
     )?;
 
     let counterparty = Counterparty::new(
@@ -506,11 +518,7 @@ pub fn build_chan_try(
         previous_channel_id: src_channel.counterparty().channel_id,
         channel,
         counterparty_version: src_chain.module_version(&opts.src().port_id())?,
-        proofs: src_chain.build_channel_proofs(
-            &opts.src().port_id(),
-            &opts.src().channel_id(),
-            ics_target_height,
-        )?,
+        proofs,
         signer,
     };
 
@@ -579,14 +587,19 @@ pub fn build_chan_ack(
     let dst_connection =
         dst_chain.query_connection(&opts.dst().connection_id().clone(), Height::default())?;
 
-    let ics_target_height = src_chain.query_latest_height()?;
+    let query_height = src_chain.query_latest_height()?;
+    let proofs = src_chain.build_channel_proofs(
+        &opts.src().port_id(),
+        &opts.src().channel_id(),
+        query_height,
+    )?;
 
-    // Build message to update client on destination
+    // Build message(s) to update client on destination
     let mut msgs = build_update_client(
         dst_chain.clone(),
         src_chain.clone(),
         &dst_connection.client_id(),
-        ics_target_height,
+        proofs.height(),
     )?;
 
     // Get signer
@@ -600,11 +613,7 @@ pub fn build_chan_ack(
         channel_id: opts.dst().channel_id().clone(),
         counterparty_channel_id: opts.src().channel_id().clone(),
         counterparty_version: src_chain.module_version(&opts.dst().port_id())?,
-        proofs: src_chain.build_channel_proofs(
-            &opts.src().port_id(),
-            &opts.src().channel_id(),
-            ics_target_height,
-        )?,
+        proofs,
         signer,
     };
 
@@ -677,14 +686,19 @@ pub fn build_chan_confirm(
     let dst_connection =
         dst_chain.query_connection(&opts.dst().connection_id().clone(), Height::default())?;
 
-    let ics_target_height = src_chain.query_latest_height()?;
+    let query_height = src_chain.query_latest_height()?;
+    let proofs = src_chain.build_channel_proofs(
+        &opts.src().port_id(),
+        &opts.src().channel_id(),
+        query_height,
+    )?;
 
-    // Build message to update client on destination
+    // Build message(s) to update client on destination
     let mut msgs = build_update_client(
         dst_chain.clone(),
         src_chain.clone(),
         &dst_connection.client_id(),
-        ics_target_height,
+        proofs.height(),
     )?;
 
     // Get signer
@@ -696,11 +710,7 @@ pub fn build_chan_confirm(
     let new_msg = MsgChannelOpenConfirm {
         port_id: opts.dst().port_id().clone(),
         channel_id: opts.dst().channel_id().clone(),
-        proofs: src_chain.build_channel_proofs(
-            &opts.src().port_id(),
-            &opts.src().channel_id(),
-            ics_target_height,
-        )?,
+        proofs,
         signer,
     };
 

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -218,7 +218,7 @@ impl Connection {
             counter += 1;
             match build_conn_try_and_send(b_chain.clone(), a_chain.clone(), &self.config) {
                 Err(e) => {
-                    error!("Failed ConnTry {:?}: {}", self.config.b_end(), e);
+                    info!("Failed ConnTry {:?}: {}", self.config.b_end(), e);
                     continue;
                 }
                 Ok(result) => {
@@ -480,21 +480,20 @@ pub fn build_conn_try(
     )?;
     src_chain.send_msgs(client_msgs)?;
 
-    // Build message(s) for updating client on destination
-    let ics_target_height = src_chain.query_latest_height()?;
-
-    let mut msgs = build_update_client(
-        dst_chain.clone(),
-        src_chain.clone(),
-        &opts.dst().client_id(),
-        ics_target_height,
-    )?;
-
+    let query_height = src_chain.query_latest_height()?;
     let (client_state, proofs) = src_chain.build_connection_proofs_and_client_state(
         ConnectionMsgType::OpenTry,
         &opts.src().connection_id().clone(),
         &opts.src().client_id(),
-        ics_target_height,
+        query_height,
+    )?;
+
+    // Build message(s) for updating client on destination
+    let mut msgs = build_update_client(
+        dst_chain.clone(),
+        src_chain.clone(),
+        &opts.dst().client_id(),
+        proofs.height(),
     )?;
 
     let counterparty_versions = if src_connection.versions().is_empty() {
@@ -598,21 +597,20 @@ pub fn build_conn_ack(
     )?;
     src_chain.send_msgs(client_msgs)?;
 
-    // Build message(s) for updating client on destination
-    let ics_target_height = src_chain.query_latest_height()?;
-
-    let mut msgs = build_update_client(
-        dst_chain.clone(),
-        src_chain.clone(),
-        &opts.dst().client_id(),
-        ics_target_height,
-    )?;
-
+    let query_height = src_chain.query_latest_height()?;
     let (client_state, proofs) = src_chain.build_connection_proofs_and_client_state(
         ConnectionMsgType::OpenAck,
         &opts.src().connection_id().clone(),
         &opts.src().client_id(),
-        ics_target_height,
+        query_height,
+    )?;
+
+    // Build message(s) for updating client on destination
+    let mut msgs = build_update_client(
+        dst_chain.clone(),
+        src_chain.clone(),
+        &opts.dst().client_id(),
+        proofs.height(),
     )?;
 
     // Get signer
@@ -682,10 +680,11 @@ pub fn build_conn_confirm(
         .context(e)
     })?;
 
+    let query_height = src_chain.query_latest_height()?;
     let _src_connection = src_chain
-        .query_connection(&opts.src().connection_id().clone(), ICSHeight::default())
+        .query_connection(&opts.src().connection_id().clone(), query_height)
         .map_err(|e| {
-            Kind::ConnOpenAck(
+            Kind::ConnOpenConfirm(
                 opts.src().connection_id().clone(),
                 "missing connection on source chain".to_string(),
             )
@@ -694,21 +693,19 @@ pub fn build_conn_confirm(
 
     // TODO - check that the src connection is consistent with the confirm options
 
-    // Build message(s) for updating client on destination
-    let ics_target_height = src_chain.query_latest_height()?;
-
-    let mut msgs = build_update_client(
-        dst_chain.clone(),
-        src_chain.clone(),
-        &opts.dst().client_id(),
-        ics_target_height,
-    )?;
-
     let (_, proofs) = src_chain.build_connection_proofs_and_client_state(
         ConnectionMsgType::OpenConfirm,
         &opts.src().connection_id().clone(),
         &opts.src().client_id(),
-        ics_target_height,
+        query_height,
+    )?;
+
+    // Build message(s) for updating client on destination
+    let mut msgs = build_update_client(
+        dst_chain.clone(),
+        src_chain.clone(),
+        &opts.dst().client_id(),
+        proofs.height(),
     )?;
 
     // Get signer

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -218,7 +218,7 @@ impl Connection {
             counter += 1;
             match build_conn_try_and_send(b_chain.clone(), a_chain.clone(), &self.config) {
                 Err(e) => {
-                    info!("Failed ConnTry {:?}: {}", self.config.b_end(), e);
+                    error!("Failed ConnTry {:?}: {}", self.config.b_end(), e);
                     continue;
                 }
                 Ok(result) => {

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -17,6 +17,7 @@ use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
 
 use crate::chain::handle::ChainHandle;
 use crate::error::{Error, Kind};
+use std::time::SystemTime;
 
 #[derive(Debug, Error)]
 pub enum ForeignClientError {
@@ -190,6 +191,10 @@ pub fn build_update_client(
     target_height: Height,
 ) -> Result<Vec<Any>, Error> {
     // Wait for source chain to reach `target_height`
+    info!("time start q height {:?}", SystemTime::now());
+    let _h = src_chain.query_latest_height()?;
+    info!("time end wait{:?}", SystemTime::now());
+
     while src_chain.query_latest_height()? < target_height {
         thread::sleep(Duration::from_millis(100))
     }
@@ -209,7 +214,10 @@ pub fn build_update_client(
         header,
         signer,
     };
-    info!("built update client msg for {:?} height {:?}", dst_client_id, target_height);
+    info!(
+        "built update client msg for {:?} height {:?}",
+        dst_client_id, target_height
+    );
 
     Ok(vec![new_msg.to_any::<RawMsgUpdateClient>()])
 }

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -1,4 +1,5 @@
 use prost_types::Any;
+use std::{thread, time::Duration};
 use thiserror::Error;
 use tracing::{error, info};
 
@@ -116,7 +117,7 @@ impl ForeignClient {
             ForeignClientError::ClientUpdate(format!("build_create_client_and_send {:?}", e))
         })?;
 
-        println!(
+        info!(
             "Client id {:?} on {:?} updated with return message {:?}\n",
             client_id,
             self.dst_chain.id(),
@@ -188,6 +189,11 @@ pub fn build_update_client(
     dst_client_id: &ClientId,
     target_height: Height,
 ) -> Result<Vec<Any>, Error> {
+    // Wait for source chain to reach `target_height`
+    while src_chain.query_latest_height()? < target_height {
+        thread::sleep(Duration::from_millis(40))
+    }
+
     // Get the latest trusted height from the client state on destination.
     let trusted_height = dst_chain
         .query_client_state(&dst_client_id, Height::default())?

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -191,7 +191,7 @@ pub fn build_update_client(
 ) -> Result<Vec<Any>, Error> {
     // Wait for source chain to reach `target_height`
     while src_chain.query_latest_height()? < target_height {
-        thread::sleep(Duration::from_millis(40))
+        thread::sleep(Duration::from_millis(100))
     }
 
     // Get the latest trusted height from the client state on destination.
@@ -209,6 +209,7 @@ pub fn build_update_client(
         header,
         signer,
     };
+    info!("built update client msg for {:?} height {:?}", dst_client_id, target_height);
 
     Ok(vec![new_msg.to_any::<RawMsgUpdateClient>()])
 }

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -17,7 +17,6 @@ use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
 
 use crate::chain::handle::ChainHandle;
 use crate::error::{Error, Kind};
-use std::time::SystemTime;
 
 #[derive(Debug, Error)]
 pub enum ForeignClientError {
@@ -191,10 +190,6 @@ pub fn build_update_client(
     target_height: Height,
 ) -> Result<Vec<Any>, Error> {
     // Wait for source chain to reach `target_height`
-    info!("time start q height {:?}", SystemTime::now());
-    let _h = src_chain.query_latest_height()?;
-    info!("time end wait{:?}", SystemTime::now());
-
     while src_chain.query_latest_height()? < target_height {
         thread::sleep(Duration::from_millis(100))
     }
@@ -214,10 +209,6 @@ pub fn build_update_client(
         header,
         signer,
     };
-    info!(
-        "built update client msg for {:?} height {:?}",
-        dst_client_id, target_height
-    );
 
     Ok(vec![new_msg.to_any::<RawMsgUpdateClient>()])
 }

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -393,226 +393,255 @@ fn build_ack_from_recv_event(
     build_ack_packet(dst_chain, src_chain, &event, event_height)
 }
 
-struct RecvPacketsAndTimeouts {
-    recv_msgs: Vec<Any>,
-    dst_query_height: Height,
-    timeouts: Vec<Any>,
-    src_query_height: Height,
+struct PacketMsgCollector {
+    packet_dst_chain: Box<dyn ChainHandle>,
+    packet_src_chain: Box<dyn ChainHandle>,
+    opts: PacketEnvelope,
+    recv_seqs: Vec<Sequence>,
+    ack_seqs: Vec<Sequence>,
+    src_query_height: Height, // proof height for recv packets
+    dst_msgs: Vec<Any>,       // recv packets to be send to destination chain
+    dst_query_height: Height, // proof height for acks and timeout
+    src_msgs: Vec<Any>,       // acks and/or timeouts to be sent to source chain
 }
 
-impl Default for RecvPacketsAndTimeouts {
-    fn default() -> Self {
-        RecvPacketsAndTimeouts {
-            recv_msgs: vec![],
+impl PacketMsgCollector {
+    fn new(
+        packet_dst_chain: Box<dyn ChainHandle>,
+        packet_src_chain: Box<dyn ChainHandle>,
+        opts: &PacketEnvelope,
+    ) -> Self {
+        PacketMsgCollector {
+            packet_src_chain,
+            packet_dst_chain,
+            opts: opts.clone(),
+            recv_seqs: vec![],
+            ack_seqs: vec![],
             dst_query_height: Default::default(),
-            timeouts: vec![],
+            src_msgs: vec![],
             src_query_height: Default::default(),
+            dst_msgs: vec![],
         }
     }
-}
 
-impl RecvPacketsAndTimeouts {
-    fn none() -> RecvPacketsAndTimeouts {
-        RecvPacketsAndTimeouts::default()
-    }
-}
-
-/// From each sequence it builds either a MsgRecvPacket or a MsgTimeout message
-/// MsgTimeout-s are sent to the source chain while MsgRecvPacket-s are sent to
-/// the destination chain
-fn build_recv_packet_and_timeout_msgs(
-    packet_src_chain: Box<dyn ChainHandle>,
-    packet_dst_chain: Box<dyn ChainHandle>,
-    opts: &PacketOptions,
-) -> Result<RecvPacketsAndTimeouts, Error> {
-    // Get the sequences of packets that have been sent on source chain but
-    // have not been received on destination chain (i.e. ack was not seen on source chain)
-    let (sequences, src_query_height) = target_height_and_sequences_of_recv_packets(
-        packet_src_chain.clone(),
-        packet_dst_chain.clone(),
-        opts,
-    )?;
-
-    if sequences.is_empty() {
-        return Ok(RecvPacketsAndTimeouts::none());
-    }
-
-    let mut events = packet_src_chain.query_txs(QueryPacketEventDataRequest {
-        event_id: IBCEventType::SendPacket,
-        source_port_id: opts.packet_src_port_id.clone(),
-        source_channel_id: opts.packet_src_channel_id.clone(),
-        sequences,
-        height: src_query_height,
-    })?;
-
-    let mut packet_sequences = vec![];
-    for event in events.iter() {
-        let send_event = downcast!(event => IBCEvent::SendPacketChannel)
-            .ok_or_else(|| Kind::Query.context("unexpected query tx response"))?;
-
-        packet_sequences.append(&mut vec![send_event.packet.sequence]);
-    }
-    info!("received from query_txs {:?}", packet_sequences);
-
-    let dst_query_height = packet_dst_chain.query_latest_height()?;
-    let mut result = RecvPacketsAndTimeouts::default();
-
-    for event in events.iter_mut() {
-        event.set_height(src_query_height);
-
-        let (recv, timeout) = handle_packet_event(
-            packet_dst_chain.clone(),
-            dst_query_height,
-            packet_src_chain.clone(),
-            event,
-        )?;
-        if let Some(recv) = recv {
-            result.recv_msgs.append(&mut vec![recv]);
+    fn target_height_and_sequences_of_recv_packets(&mut self) -> Result<(), Error> {
+        // Query packet commitments on packet's source chain (sent but not acknowledged)
+        let pc_request = QueryPacketCommitmentsRequest {
+            port_id: self.opts.packet_src_port_id.to_string(),
+            channel_id: self.opts.packet_src_channel_id.to_string(),
+            pagination: None,
+        };
+        let (packet_commitments, query_height) =
+            self.packet_src_chain.query_packet_commitments(pc_request)?;
+        if packet_commitments.is_empty() {
+            return Ok(());
         }
-        if let Some(timeout) = timeout {
-            result.timeouts.append(&mut vec![timeout]);
+        self.src_query_height = query_height;
+        let commit_sequences = packet_commitments.iter().map(|p| p.sequence).collect();
+        info!(
+            "packets that still have commitments on source {}: {:?}",
+            self.packet_src_chain.id(),
+            commit_sequences
+        );
+
+        // Get the packets that have not been received on destination chain
+        let request = QueryUnreceivedPacketsRequest {
+            port_id: self.opts.packet_dst_port_id.to_string(),
+            channel_id: self.opts.packet_dst_channel_id.to_string(),
+            packet_commitment_sequences: commit_sequences,
+        };
+
+        self.recv_seqs = self
+            .packet_dst_chain
+            .query_unreceived_packets(request)?
+            .into_iter()
+            .map(From::from)
+            .collect();
+        info!(
+            "packets to send out of the ones with commitments on source {:?}",
+            self.recv_seqs
+        );
+
+        Ok(())
+    }
+
+    fn target_height_and_sequences_of_ack_packets(&mut self) -> Result<(), Error> {
+        // Get the sequences of packets that have been acknowledged on destination
+        let pc_request = QueryPacketAcknowledgementsRequest {
+            port_id: self.opts.packet_dst_port_id.to_string(),
+            channel_id: self.opts.packet_dst_channel_id.to_string(),
+            pagination: None,
+        };
+        let (acks_on_destination, query_height) = self
+            .packet_dst_chain
+            .query_packet_acknowledgements(pc_request)?;
+
+        if acks_on_destination.is_empty() {
+            return Ok(());
         }
+
+        let acked_sequences = acks_on_destination.iter().map(|p| p.sequence).collect();
+        info!(
+            "packets that have acknowledgments on destination {} {:?}",
+            self.packet_dst_chain.id(),
+            acked_sequences
+        );
+
+        let request = QueryUnreceivedAcksRequest {
+            port_id: self.opts.packet_src_port_id.to_string(),
+            channel_id: self.opts.packet_src_channel_id.to_string(),
+            packet_ack_sequences: acked_sequences,
+        };
+
+        self.ack_seqs = self
+            .packet_src_chain
+            .query_unreceived_acknowledgement(request)?
+            .into_iter()
+            .map(From::from)
+            .collect();
+        info!(
+            "acks to send out to {} of the ones with acknowledgments on destination {}: {:?}",
+            self.packet_src_chain.id(),
+            self.packet_dst_chain.id(),
+            self.ack_seqs
+        );
+
+        self.dst_query_height = query_height;
+        Ok(())
     }
-    result.src_query_height = src_query_height;
-    result.dst_query_height = dst_query_height;
-    Ok(result)
-}
 
-fn build_packet_ack_msgs(
-    packet_src_chain: Box<dyn ChainHandle>,
-    packet_dst_chain: Box<dyn ChainHandle>,
-    opts: &PacketOptions,
-) -> Result<(Vec<Any>, Height), Error> {
-    // Get the sequences of packets that have been acknowledged on destination chain but still
-    // have commitments on source chain (i.e. ack was not seen on source chain)
-    let (sequences, dst_query_height) = target_height_and_sequences_of_ack_packets(
-        packet_src_chain.clone(),
-        packet_dst_chain.clone(),
-        opts,
-    )?;
+    fn build_recv_packet_and_timeout_msgs(&mut self) -> Result<(), Error> {
+        // Get the sequences of packets that have been sent on source chain but
+        // have not been received on destination chain (i.e. ack was not seen on source chain)
+        self.target_height_and_sequences_of_recv_packets()?;
 
-    if sequences.is_empty() {
-        return Ok((vec![], dst_query_height));
-    }
-
-    let mut events = packet_dst_chain.query_txs(QueryPacketEventDataRequest {
-        event_id: IBCEventType::WriteAck,
-        source_port_id: opts.packet_src_port_id.clone(),
-        source_channel_id: opts.packet_src_channel_id.clone(),
-        sequences,
-        height: dst_query_height,
-    })?;
-
-    let mut packet_sequences = vec![];
-    for event in events.iter() {
-        let write_ack_event = downcast!(event => IBCEvent::WriteAcknowledgementChannel)
-            .ok_or_else(|| Kind::Query.context("unexpected query tx response"))?;
-
-        packet_sequences.append(&mut vec![write_ack_event.packet.sequence]);
-    }
-    info!("received from query_txs {:?}", packet_sequences);
-
-    let mut msgs = vec![];
-    for event in events.iter_mut() {
-        event.set_height(dst_query_height);
-        if let (Some(new_msg), _) = handle_packet_event(
-            packet_src_chain.clone(),
-            packet_src_chain.query_latest_height()?,
-            packet_dst_chain.clone(),
-            event,
-        )? {
-            msgs.append(&mut vec![new_msg]);
+        if self.recv_seqs.is_empty() {
+            return Ok(());
         }
-    }
-    Ok((msgs, dst_query_height))
-}
 
-fn target_height_and_sequences_of_recv_packets(
-    packet_src_chain: Box<dyn ChainHandle>, // where timeout and acknowledgment is sent
-    packet_dst_chain: Box<dyn ChainHandle>, // where packet_recv is sent
-    opts: &PacketOptions,
-) -> Result<(Vec<Sequence>, Height), Error> {
-    // Query packet commitments on packet's source chain (sent but not acknowledged)
-    let pc_request = QueryPacketCommitmentsRequest {
-        port_id: opts.packet_src_port_id.to_string(),
-        channel_id: opts.packet_src_channel_id.to_string(),
-        pagination: None,
-    };
-    let (packet_commitments, query_height) =
-        packet_src_chain.query_packet_commitments(pc_request)?;
-    if packet_commitments.is_empty() {
-        return Ok((vec![], Height::zero()));
-    }
-    let commit_sequences = packet_commitments.iter().map(|p| p.sequence).collect();
-    info!(
-        "packets that still have commitments on source {}: {:?}",
-        packet_src_chain.id(),
-        commit_sequences
-    );
+        let mut events = self
+            .packet_src_chain
+            .query_txs(QueryPacketEventDataRequest {
+                event_id: IBCEventType::SendPacket,
+                source_port_id: self.opts.packet_src_port_id.clone(),
+                source_channel_id: self.opts.packet_src_channel_id.clone(),
+                sequences: self.recv_seqs.clone(),
+                height: self.src_query_height,
+            })?;
 
-    // Get the packets that have not been received on destination chain
-    let request = QueryUnreceivedPacketsRequest {
-        port_id: opts.packet_dst_port_id.to_string(),
-        channel_id: opts.packet_dst_channel_id.to_string(),
-        packet_commitment_sequences: commit_sequences,
-    };
-    let sequences_to_send = packet_dst_chain
-        .query_unreceived_packets(request)?
-        .into_iter()
-        .map(From::from)
-        .collect();
-    info!(
-        "packets to send out of the ones with commitments on source {:?}",
-        sequences_to_send
-    );
+        let mut packet_sequences = vec![];
+        for event in events.iter() {
+            let send_event = downcast!(event => IBCEvent::SendPacketChannel)
+                .ok_or_else(|| Kind::Query.context("unexpected query tx response"))?;
 
-    Ok((sequences_to_send, query_height))
-}
+            packet_sequences.append(&mut vec![send_event.packet.sequence]);
+        }
+        info!("received from query_txs {:?}", packet_sequences);
 
-fn target_height_and_sequences_of_ack_packets(
-    packet_src_chain: Box<dyn ChainHandle>,
-    packet_dst_chain: Box<dyn ChainHandle>,
-    opts: &PacketOptions,
-) -> Result<(Vec<Sequence>, Height), Error> {
-    // Get the sequences of packets that have been acknowledged on destination
-    let pc_request = QueryPacketAcknowledgementsRequest {
-        port_id: opts.packet_dst_port_id.to_string(),
-        channel_id: opts.packet_dst_channel_id.to_string(),
-        pagination: None,
-    };
-    let (acks_on_destination, query_height) =
-        packet_dst_chain.query_packet_acknowledgements(pc_request)?;
+        self.dst_query_height = self.packet_dst_chain.query_latest_height()?;
 
-    if acks_on_destination.is_empty() {
-        return Ok((vec![], Height::zero()));
+        for event in events.iter_mut() {
+            event.set_height(self.src_query_height);
+
+            let (recv, timeout) = handle_packet_event(
+                self.packet_dst_chain.clone(),
+                self.dst_query_height,
+                self.packet_src_chain.clone(),
+                event,
+            )?;
+            if let Some(recv) = recv {
+                self.dst_msgs.append(&mut vec![recv]);
+            }
+            if let Some(timeout) = timeout {
+                self.src_msgs.append(&mut vec![timeout]);
+            }
+        }
+        Ok(())
     }
 
-    let acked_sequences = acks_on_destination.iter().map(|p| p.sequence).collect();
-    info!(
-        "packets that have acknowledgments on destination {} {:?}",
-        packet_dst_chain.id(),
-        acked_sequences
-    );
+    fn build_packet_ack_msgs(&mut self) -> Result<(), Error> {
+        // Get the sequences of packets that have been acknowledged on destination chain but still
+        // have commitments on source chain (i.e. ack was not seen on source chain)
+        self.target_height_and_sequences_of_ack_packets()?;
 
-    let request = QueryUnreceivedAcksRequest {
-        port_id: opts.packet_src_port_id.to_string(),
-        channel_id: opts.packet_src_channel_id.to_string(),
-        packet_ack_sequences: acked_sequences,
-    };
+        if self.ack_seqs.is_empty() {
+            return Ok(());
+        }
 
-    let acks_to_send = packet_src_chain
-        .query_unreceived_acknowledgement(request)?
-        .into_iter()
-        .map(From::from)
-        .collect();
-    info!(
-        "acks to send out to {} of the ones with acknowledgments on destination {}: {:?}",
-        packet_src_chain.id(),
-        packet_dst_chain.id(),
-        acks_to_send
-    );
+        let mut events = self
+            .packet_dst_chain
+            .query_txs(QueryPacketEventDataRequest {
+                event_id: IBCEventType::WriteAck,
+                source_port_id: self.opts.packet_src_port_id.clone(),
+                source_channel_id: self.opts.packet_src_channel_id.clone(),
+                sequences: self.ack_seqs.clone(),
+                height: self.dst_query_height,
+            })?;
 
-    Ok((acks_to_send, query_height))
+        let mut packet_sequences = vec![];
+        for event in events.iter() {
+            let write_ack_event = downcast!(event => IBCEvent::WriteAcknowledgementChannel)
+                .ok_or_else(|| Kind::Query.context("unexpected query tx response"))?;
+
+            packet_sequences.append(&mut vec![write_ack_event.packet.sequence]);
+        }
+        info!("received from query_txs {:?}", packet_sequences);
+
+        self.src_query_height = self.packet_src_chain.query_latest_height()?;
+        for event in events.iter_mut() {
+            event.set_height(self.dst_query_height);
+            if let (Some(new_msg), _) = handle_packet_event(
+                self.packet_src_chain.clone(),
+                self.src_query_height,
+                self.packet_dst_chain.clone(),
+                event,
+            )? {
+                self.src_msgs.append(&mut vec![new_msg]);
+            }
+        }
+        Ok(())
+    }
+
+    fn build_client_updates(&mut self) -> Result<(), Error> {
+        if !self.dst_msgs.is_empty() {
+            // Check that the channel on the destination chain is Open
+            verify_channel_state(
+                self.packet_dst_chain.clone(),
+                &self.opts.packet_dst_port_id,
+                &self.opts.packet_dst_channel_id,
+            )?;
+
+            // Prepend client update and send all recv_packet messages
+            let mut dst_msgs = build_update_client(
+                self.packet_dst_chain.clone(),
+                self.packet_src_chain.clone(),
+                &self.opts.packet_dst_client_id,
+                self.src_query_height.increment(),
+            )?;
+            dst_msgs.append(&mut self.dst_msgs);
+            self.dst_msgs = dst_msgs;
+        }
+
+        if !self.src_msgs.is_empty() {
+            // Check the channel on source chain is Open
+            verify_channel_state(
+                self.packet_src_chain.clone(),
+                &self.opts.packet_src_port_id,
+                &self.opts.packet_src_channel_id,
+            )?;
+
+            // Prepend client update and send all ack and timeout messages
+            let mut src_msgs = build_update_client(
+                self.packet_src_chain.clone(),
+                self.packet_dst_chain.clone(),
+                &self.opts.packet_src_client_id.clone(),
+                self.dst_query_height.increment(),
+            )?;
+            src_msgs.append(&mut self.src_msgs);
+            self.src_msgs = src_msgs;
+        }
+        Ok(())
+    }
 }
 
 fn verify_channel_state(
@@ -646,52 +675,24 @@ pub fn build_and_send_recv_packet_messages(
     packet_dst_chain: Box<dyn ChainHandle>, // the chain where recv is sent and from where ack data and proofs are collected
     opts: &PacketOptions,
 ) -> Result<Vec<IBCEvent>, Error> {
-    let mut result = build_recv_packet_and_timeout_msgs(
-        packet_src_chain.clone(),
+    let mut msg_collector = PacketMsgCollector::new(
         packet_dst_chain.clone(),
-        opts,
-    )?;
+        packet_src_chain.clone(),
+        &opts.packet_envelope,
+    );
 
-    let mut tx_result = vec![];
+    msg_collector.build_recv_packet_and_timeout_msgs()?;
+    msg_collector.build_client_updates()?;
+    let mut result = vec![];
 
-    if !result.recv_msgs.is_empty() {
-        // Check the channel on destination chain is Open
-        verify_channel_state(
-            packet_dst_chain.clone(),
-            &opts.packet_dst_port_id,
-            &opts.packet_dst_channel_id,
-        )?;
-
-        // Prepend client update and send all recv_packet messages
-        let mut dst_msgs = build_update_client(
-            packet_dst_chain.clone(),
-            packet_src_chain.clone(),
-            &opts.packet_dst_client_id.clone(),
-            result.src_query_height.increment(),
-        )?;
-        dst_msgs.append(&mut result.recv_msgs);
-        tx_result.append(&mut packet_dst_chain.send_msgs(dst_msgs)?);
+    if !msg_collector.dst_msgs.is_empty() {
+        result.append(&mut packet_dst_chain.send_msgs(msg_collector.dst_msgs)?);
     }
 
-    if !result.timeouts.is_empty() {
-        // Check the channel on source chain is Open
-        verify_channel_state(
-            packet_src_chain.clone(),
-            &opts.packet_src_port_id,
-            &opts.packet_src_channel_id,
-        )?;
-
-        // Prepend client update and send all timeout messages
-        let mut src_msgs = build_update_client(
-            packet_src_chain.clone(),
-            packet_dst_chain.clone(),
-            &opts.packet_src_client_id.clone(),
-            result.dst_query_height.increment(),
-        )?;
-        src_msgs.append(&mut result.timeouts);
-        tx_result.append(&mut packet_src_chain.send_msgs(src_msgs)?);
+    if !msg_collector.src_msgs.is_empty() {
+        result.append(&mut packet_src_chain.send_msgs(msg_collector.src_msgs)?);
     }
-    Ok(tx_result)
+    Ok(result)
 }
 
 pub fn build_and_send_ack_packet_messages(
@@ -699,42 +700,35 @@ pub fn build_and_send_ack_packet_messages(
     packet_dst_chain: Box<dyn ChainHandle>, // the chain from where ack data and proofs are collected
     opts: &PacketOptions,
 ) -> Result<Vec<IBCEvent>, Error> {
+    let mut msg_colletcor = PacketMsgCollector::new(
+        packet_dst_chain.clone(),
+        packet_src_chain.clone(),
+        &opts.packet_envelope,
+    );
     // Construct the ack messages and get the height of their proofs
-    let (mut ack_msgs, proof_height) =
-        build_packet_ack_msgs(packet_src_chain.clone(), packet_dst_chain.clone(), opts)?;
-
+    msg_colletcor.build_packet_ack_msgs()?;
+    msg_colletcor.build_client_updates()?;
     let mut result = vec![];
 
-    if !ack_msgs.is_empty() {
-        // Check the channel on source chain is Open
-        verify_channel_state(
-            packet_src_chain.clone(),
-            &opts.packet_src_port_id,
-            &opts.packet_src_channel_id,
-        )?;
-
-        let mut src_msgs = build_update_client(
-            packet_src_chain.clone(),
-            packet_dst_chain.clone(),
-            &opts.packet_src_client_id.clone(),
-            proof_height.increment(),
-        )?;
-
-        src_msgs.append(&mut ack_msgs);
-        result.append(&mut packet_src_chain.send_msgs(src_msgs)?);
+    if !msg_colletcor.src_msgs.is_empty() {
+        result.append(&mut packet_src_chain.send_msgs(msg_colletcor.src_msgs)?);
     }
-
     Ok(result)
+}
+
+#[derive(Clone, Debug)]
+pub struct PacketEnvelope {
+    pub packet_src_client_id: ClientId,
+    pub packet_src_port_id: PortId,
+    pub packet_src_channel_id: ChannelId,
+    pub packet_dst_client_id: ClientId,
+    pub packet_dst_port_id: PortId,
+    pub packet_dst_channel_id: ChannelId,
 }
 
 #[derive(Clone, Debug)]
 pub struct PacketOptions {
     pub packet_src_chain_config: ChainConfig,
-    pub packet_src_client_id: ClientId,
-    pub packet_src_port_id: PortId,
-    pub packet_src_channel_id: ChannelId,
     pub packet_dst_chain_config: ChainConfig,
-    pub packet_dst_client_id: ClientId,
-    pub packet_dst_port_id: PortId,
-    pub packet_dst_channel_id: ChannelId,
+    pub packet_envelope: PacketEnvelope,
 }

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -700,18 +700,18 @@ pub fn build_and_send_ack_packet_messages(
     packet_dst_chain: Box<dyn ChainHandle>, // the chain from where ack data and proofs are collected
     opts: &PacketOptions,
 ) -> Result<Vec<IBCEvent>, Error> {
-    let mut msg_colletcor = PacketMsgCollector::new(
+    let mut msg_collector = PacketMsgCollector::new(
         packet_dst_chain.clone(),
         packet_src_chain.clone(),
         &opts.packet_envelope,
     );
     // Construct the ack messages and get the height of their proofs
-    msg_colletcor.build_packet_ack_msgs()?;
-    msg_colletcor.build_client_updates()?;
+    msg_collector.build_packet_ack_msgs()?;
+    msg_collector.build_client_updates()?;
     let mut result = vec![];
 
-    if !msg_colletcor.src_msgs.is_empty() {
-        result.append(&mut packet_src_chain.send_msgs(msg_colletcor.src_msgs)?);
+    if !msg_collector.src_msgs.is_empty() {
+        result.append(&mut packet_src_chain.send_msgs(msg_collector.src_msgs)?);
     }
     Ok(result)
 }

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -458,7 +458,7 @@ impl PacketMsgCollector {
             .map(From::from)
             .collect();
         info!(
-            "packets to send out of the ones with commitments on source {:?}",
+            "recv packets to send out of the ones with commitments on source {:?}",
             self.recv_seqs
         );
 
@@ -500,7 +500,7 @@ impl PacketMsgCollector {
             .map(From::from)
             .collect();
         info!(
-            "acks to send out to {} of the ones with acknowledgments on destination {}: {:?}",
+            "ack packets to send out to {} of the ones with acknowledgments on destination {}: {:?}",
             self.packet_src_chain.id(),
             self.packet_dst_chain.id(),
             self.ack_seqs
@@ -611,7 +611,7 @@ impl PacketMsgCollector {
                 &self.opts.packet_dst_channel_id,
             )?;
 
-            // Prepend client update and send all recv_packet messages
+            // Prepend client updates and send all recv_packet messages
             let mut dst_msgs = build_update_client(
                 self.packet_dst_chain.clone(),
                 self.packet_src_chain.clone(),
@@ -630,7 +630,7 @@ impl PacketMsgCollector {
                 &self.opts.packet_src_channel_id,
             )?;
 
-            // Prepend client update and send all ack and timeout messages
+            // Prepend client updates and send all ack and timeout messages
             let mut src_msgs = build_update_client(
                 self.packet_src_chain.clone(),
                 self.packet_dst_chain.clone(),
@@ -649,7 +649,7 @@ fn verify_channel_state(
     port_id: &PortId,
     channel_id: &ChannelId,
 ) -> Result<(), Error> {
-    // Check the packet's channel on source chain is Open
+    // Check that the packet's channel on source chain is Open
     let channel = chain
         .query_channel(port_id, channel_id, Height::default())
         .map_err(|e| {

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -409,12 +409,12 @@ impl PacketMsgCollector {
     fn new(
         packet_dst_chain: Box<dyn ChainHandle>,
         packet_src_chain: Box<dyn ChainHandle>,
-        opts: &PacketEnvelope,
+        opts: PacketEnvelope,
     ) -> Self {
         PacketMsgCollector {
             packet_src_chain,
             packet_dst_chain,
-            opts: opts.clone(),
+            opts,
             recv_seqs: vec![],
             ack_seqs: vec![],
             dst_query_height: Default::default(),
@@ -678,7 +678,7 @@ pub fn build_and_send_recv_packet_messages(
     let mut msg_collector = PacketMsgCollector::new(
         packet_dst_chain.clone(),
         packet_src_chain.clone(),
-        &opts.packet_envelope,
+        opts.packet_envelope.clone(),
     );
 
     msg_collector.build_recv_packet_and_timeout_msgs()?;
@@ -703,7 +703,7 @@ pub fn build_and_send_ack_packet_messages(
     let mut msg_collector = PacketMsgCollector::new(
         packet_dst_chain.clone(),
         packet_src_chain.clone(),
-        &opts.packet_envelope,
+        opts.packet_envelope.clone(),
     );
     // Construct the ack messages and get the height of their proofs
     msg_collector.build_packet_ack_msgs()?;


### PR DESCRIPTION
Closes: #514
Closes: #94

## Description
Main changes are:
- replaced `CosmosSDK` 's `block_on()` with util's `block_on()`
- added check in `build_update_client()` to wait for source chain to reach the `target_height`
- re-organized packet CLIs around `PacketMsgCollector` that is populated by the queries, with focus on correct query height versus proof and client update height.

Miscellaneous/ Cleanup: 
- added ack and timeout event extraction from Tx results
- removed `Msg` 's `validate_basic()`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.