### PR TITLE
JSON output for queries and txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@
 
 - Add support for streamlining releases ([#507])
 
+[relayer-cli]
+- JSON output for queries and txs ([#500])
+
+
 ### IMPROVEMENTS
 
 - Update to `tendermint-rs` v0.17.1 ([#517])
 
 
+[#500]: https://github.com/informalsystems/ibc-rs/issues/500
 [#507]: https://github.com/informalsystems/ibc-rs/issues/507
 [#511]: https://github.com/informalsystems/ibc-rs/pull/511
 [#517]: https://github.com/informalsystems/ibc-rs/issues/517

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -163,6 +163,7 @@ impl From<AnyHeader> for Any {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "AnyClientState")]
 pub enum AnyClientState {
     Tendermint(TendermintClientState),
 
@@ -259,6 +260,7 @@ impl ClientState for AnyClientState {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "AnyConsensusState")]
 pub enum AnyConsensusState {
     Tendermint(TendermintConsensusState),
 

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -1,9 +1,11 @@
-use prost_types::Any;
 use std::convert::TryFrom;
 
+use prost_types::Any;
+use serde::Serialize;
 use tendermint_proto::Protobuf;
 
 use crate::downcast;
+use crate::Height;
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::error::{Error, Kind};
 use crate::ics02_client::header::Header;
@@ -15,7 +17,6 @@ use crate::ics07_tendermint::consensus_state::ConsensusState as TendermintConsen
 use crate::ics07_tendermint::header::Header as TendermintHeader;
 use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofBytes, CommitmentRoot};
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
-use crate::Height;
 
 #[cfg(any(test, feature = "mocks"))]
 use crate::mock::{
@@ -161,7 +162,7 @@ impl From<AnyHeader> for Any {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum AnyClientState {
     Tendermint(TendermintClientState),
 
@@ -255,7 +256,7 @@ impl ClientState for AnyClientState {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum AnyConsensusState {
     Tendermint(TendermintConsensusState),
 
@@ -538,11 +539,13 @@ impl ClientDef for AnyClient {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
+
+    use prost_types::Any;
+
     use crate::ics02_client::client_def::AnyClientState;
     use crate::ics07_tendermint::client_state::test_util::get_dummy_tendermint_client_state;
     use crate::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
-    use prost_types::Any;
-    use std::convert::TryFrom;
 
     #[test]
     fn any_client_state_serialization() {

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use tendermint_proto::Protobuf;
 
 use crate::downcast;
-use crate::Height;
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::error::{Error, Kind};
 use crate::ics02_client::header::Header;
@@ -17,6 +16,7 @@ use crate::ics07_tendermint::consensus_state::ConsensusState as TendermintConsen
 use crate::ics07_tendermint::header::Header as TendermintHeader;
 use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofBytes, CommitmentRoot};
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
+use crate::Height;
 
 #[cfg(any(test, feature = "mocks"))]
 use crate::mock::{

--- a/modules/src/ics02_client/client_def.rs
+++ b/modules/src/ics02_client/client_def.rs
@@ -197,6 +197,8 @@ impl TryFrom<Any> for AnyClientState {
     // TODO Fix type urls: avoid having hardcoded values sprinkled around the whole codebase.
     fn try_from(raw: Any) -> Result<Self, Self::Error> {
         match raw.type_url.as_str() {
+            "" => Err(Kind::EmptyClientState.into()),
+
             TENDERMINT_CLIENT_STATE_TYPE_URL => Ok(AnyClientState::Tendermint(
                 TendermintClientState::decode_vec(&raw.value)
                     .map_err(|e| Kind::InvalidRawClientState.context(e))?,

--- a/modules/src/ics02_client/error.rs
+++ b/modules/src/ics02_client/error.rs
@@ -30,6 +30,9 @@ pub enum Kind {
     #[error("unknown client state type: {0}")]
     UnknownClientStateType(String),
 
+    #[error("empty client state")]
+    EmptyClientState,
+
     #[error("unknown client consensus state type: {0}")]
     UnknownConsensusStateType(String),
 

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -1,10 +1,12 @@
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
+use serde::Serialize;
+use tendermint_proto::Protobuf;
+
 use ibc_proto::ibc::core::connection::v1::{
     ConnectionEnd as RawConnectionEnd, Counterparty as RawCounterparty,
 };
-use tendermint_proto::Protobuf;
 
 use crate::ics03_connection::error::Kind;
 use crate::ics03_connection::version::Version;
@@ -12,7 +14,7 @@ use crate::ics23_commitment::commitment::CommitmentPrefix;
 use crate::ics24_host::error::ValidationError;
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ConnectionEnd {
     state: State,
     client_id: ClientId,
@@ -148,7 +150,7 @@ impl ConnectionEnd {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Counterparty {
     client_id: ClientId,
     connection_id: Option<ConnectionId>,
@@ -237,7 +239,7 @@ impl Counterparty {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub enum State {
     Uninitialized = 0,
     Init = 1,

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -15,6 +15,7 @@ use crate::ics24_host::error::ValidationError;
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "ConnectionEnd")]
 pub struct ConnectionEnd {
     state: State,
     client_id: ClientId,

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -53,7 +53,7 @@ pub enum Kind {
     #[error("invalid signer")]
     InvalidSigner,
 
-    #[error("no connection was found for the previous connection id provide {0}")]
+    #[error("no connection was found for the previous connection id provided {0}")]
     ConnectionNotFound(ConnectionId),
 
     #[error("invalid counterparty")]

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -53,8 +53,8 @@ pub enum Kind {
     #[error("invalid signer")]
     InvalidSigner,
 
-    #[error("queried for a non-existing connection")]
-    ConnectionNotFound,
+    #[error("no connection was found for the previous connection id provide {0}")]
+    ConnectionNotFound(ConnectionId),
 
     #[error("invalid counterparty")]
     InvalidCounterparty,

--- a/modules/src/ics03_connection/handler/conn_open_try.rs
+++ b/modules/src/ics03_connection/handler/conn_open_try.rs
@@ -23,7 +23,7 @@ pub(crate) fn process(
         Some(prev_id) => {
             let old_connection_end = ctx
                 .connection_end(prev_id)
-                .ok_or_else(|| Kind::ConnectionNotFound.context(prev_id.to_string()))?;
+                .ok_or_else(|| Kind::ConnectionNotFound(prev_id.clone()))?;
 
             // Validate that existing connection end matches with the one we're trying to establish.
             if old_connection_end.state_matches(&State::Init)

--- a/modules/src/ics03_connection/version.rs
+++ b/modules/src/ics03_connection/version.rs
@@ -1,12 +1,14 @@
 use std::convert::TryFrom;
 
-use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
+use serde::Serialize;
 use tendermint_proto::Protobuf;
+
+use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
 
 use crate::ics03_connection::error::Kind;
 
 /// Stores the identifier and the features supported by a version
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Version {
     /// unique version identifier
     identifier: String,
@@ -85,9 +87,11 @@ pub fn pick_version(
 
 #[cfg(test)]
 mod tests {
-    use crate::ics03_connection::version::{get_compatible_versions, pick_version, Version};
-    use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
     use std::convert::{TryFrom, TryInto};
+
+    use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
+
+    use crate::ics03_connection::version::{get_compatible_versions, pick_version, Version};
 
     fn good_versions() -> Vec<RawVersion> {
         vec![

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -1,19 +1,20 @@
-use crate::ics04_channel::error::{self, Error, Kind};
-use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
-
-use ibc_proto::ibc::core::channel::v1::Channel as RawChannel;
-use ibc_proto::ibc::core::channel::v1::Counterparty as RawCounterparty;
-
-use tendermint_proto::Protobuf;
-
-use crate::events::IBCEventType;
-use crate::ics02_client::height::Height;
-use crate::ics04_channel::packet::Sequence;
-use anomaly::fail;
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
-#[derive(Clone, Debug, PartialEq)]
+use anomaly::fail;
+use serde::Serialize;
+use tendermint_proto::Protobuf;
+
+use ibc_proto::ibc::core::channel::v1::{Channel as RawChannel,
+                                        Counterparty as RawCounterparty};
+
+use crate::events::IBCEventType;
+use crate::ics02_client::height::Height;
+use crate::ics04_channel::{error::{self, Error, Kind},
+                           packet::Sequence};
+use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ChannelEnd {
     state: State,
     ordering: Order,
@@ -150,7 +151,7 @@ impl ChannelEnd {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Counterparty {
     pub port_id: PortId,
     pub channel_id: Option<ChannelId>,
@@ -218,7 +219,7 @@ impl From<Counterparty> for RawCounterparty {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum Order {
     None = 0,
     Unordered,
@@ -265,7 +266,7 @@ impl FromStr for Order {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum State {
     Uninitialized = 0,
     Init = 1,
@@ -343,13 +344,13 @@ pub mod test_util {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
     use std::str::FromStr;
 
-    use crate::ics04_channel::channel::test_util::get_dummy_raw_channel_end;
-    use crate::ics04_channel::channel::ChannelEnd;
-
     use ibc_proto::ibc::core::channel::v1::Channel as RawChannel;
-    use std::convert::TryFrom;
+
+    use crate::ics04_channel::channel::ChannelEnd;
+    use crate::ics04_channel::channel::test_util::get_dummy_raw_channel_end;
 
     #[test]
     fn channel_end_try_from_raw() {

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -16,8 +16,9 @@ use crate::ics04_channel::{
 use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
-#[serde(tag = "ChannelEnd")]    // Internal tagging, to make the type explicit in JSON outputs.
-pub struct ChannelEnd {         // see https://serde.rs/enum-representations.html#internally-tagged
+#[serde(tag = "ChannelEnd")] // Internal tagging, to make the type explicit in JSON outputs.
+pub struct ChannelEnd {
+    // see https://serde.rs/enum-representations.html#internally-tagged
     state: State,
     ordering: Order,
     remote: Counterparty,

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -5,13 +5,14 @@ use anomaly::fail;
 use serde::Serialize;
 use tendermint_proto::Protobuf;
 
-use ibc_proto::ibc::core::channel::v1::{Channel as RawChannel,
-                                        Counterparty as RawCounterparty};
+use ibc_proto::ibc::core::channel::v1::{Channel as RawChannel, Counterparty as RawCounterparty};
 
 use crate::events::IBCEventType;
 use crate::ics02_client::height::Height;
-use crate::ics04_channel::{error::{self, Error, Kind},
-                           packet::Sequence};
+use crate::ics04_channel::{
+    error::{self, Error, Kind},
+    packet::Sequence,
+};
 use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -349,8 +350,8 @@ mod tests {
 
     use ibc_proto::ibc::core::channel::v1::Channel as RawChannel;
 
-    use crate::ics04_channel::channel::ChannelEnd;
     use crate::ics04_channel::channel::test_util::get_dummy_raw_channel_end;
+    use crate::ics04_channel::channel::ChannelEnd;
 
     #[test]
     fn channel_end_try_from_raw() {

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -16,7 +16,8 @@ use crate::ics04_channel::{
 use crate::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub struct ChannelEnd {
+#[serde(tag = "ChannelEnd")]    // Internal tagging, to make the type explicit in JSON outputs.
+pub struct ChannelEnd {         // see https://serde.rs/enum-representations.html#internally-tagged
     state: State,
     ordering: Order,
     remote: Counterparty,

--- a/modules/src/ics04_channel/packet.rs
+++ b/modules/src/ics04_channel/packet.rs
@@ -4,9 +4,9 @@ use serde_derive::{Deserialize, Serialize};
 
 use ibc_proto::ibc::core::channel::v1::Packet as RawPacket;
 
-use crate::Height;
 use crate::ics04_channel::error::Kind;
 use crate::ics24_host::identifier::{ChannelId, PortId};
+use crate::Height;
 
 /// Enumeration of proof carrying ICS3 message, helper for relayer.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -162,8 +162,8 @@ mod tests {
 
     use ibc_proto::ibc::core::channel::v1::Packet as RawPacket;
 
-    use crate::ics04_channel::packet::Packet;
     use crate::ics04_channel::packet::test_utils::get_dummy_raw_packet;
+    use crate::ics04_channel::packet::Packet;
 
     #[test]
     fn packet_try_from_raw() {

--- a/modules/src/ics04_channel/packet.rs
+++ b/modules/src/ics04_channel/packet.rs
@@ -1,11 +1,12 @@
-use serde_derive::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
+
+use serde_derive::{Deserialize, Serialize};
 
 use ibc_proto::ibc::core::channel::v1::Packet as RawPacket;
 
+use crate::Height;
 use crate::ics04_channel::error::Kind;
 use crate::ics24_host::identifier::{ChannelId, PortId};
-use crate::Height;
 
 /// Enumeration of proof carrying ICS3 message, helper for relayer.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -13,6 +14,16 @@ pub enum PacketMsgType {
     Recv,
     Ack,
     Timeout,
+}
+
+impl std::fmt::Display for PacketMsgType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PacketMsgType::Recv => write!(f, "(PacketMsgType::Recv)"),
+            PacketMsgType::Ack => write!(f, "(PacketMsgType::Ack)"),
+            PacketMsgType::Timeout => write!(f, "(PacketMsgType::Timeout)"),
+        }
+    }
 }
 
 /// The sequence number of a packet enforces ordering among packets from the same source.
@@ -151,8 +162,8 @@ mod tests {
 
     use ibc_proto::ibc::core::channel::v1::Packet as RawPacket;
 
-    use crate::ics04_channel::packet::test_utils::get_dummy_raw_packet;
     use crate::ics04_channel::packet::Packet;
+    use crate::ics04_channel::packet::test_utils::get_dummy_raw_packet;
 
     #[test]
     fn packet_try_from_raw() {

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -1,18 +1,20 @@
 use std::convert::{TryFrom, TryInto};
 use std::time::Duration;
 
-use ibc_proto::ibc::lightclients::tendermint::v1::{ClientState as RawClientState, Fraction};
+use serde::Serialize;
 use tendermint_light_client::types::TrustThreshold;
 use tendermint_proto::Protobuf;
 
+use ibc_proto::ibc::lightclients::tendermint::v1::{ClientState as RawClientState, Fraction};
+
+use crate::Height;
 use crate::ics02_client::client_def::AnyClientState;
 use crate::ics02_client::client_type::ClientType;
 use crate::ics07_tendermint::error::{Error, Kind};
 use crate::ics07_tendermint::header::Header;
 use crate::ics23_commitment::merkle::cosmos_specs;
-use crate::Height;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ClientState {
     pub chain_id: String,
     pub trust_level: TrustThreshold,
@@ -199,9 +201,9 @@ mod tests {
     use tendermint_light_client::types::TrustThreshold;
     use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
+    use crate::Height;
     use crate::ics07_tendermint::client_state::ClientState;
     use crate::test::test_serialization_roundtrip;
-    use crate::Height;
 
     #[test]
     fn serialization_roundtrip_no_proof() {
@@ -330,13 +332,14 @@ mod tests {
 
 #[cfg(any(test, feature = "mocks"))]
 pub mod test_util {
+    use std::time::Duration;
+
+    use tendermint::block::Header;
+
     use crate::ics02_client::client_def::AnyClientState;
     use crate::ics02_client::height::Height;
     use crate::ics07_tendermint::client_state::ClientState;
     use crate::ics24_host::identifier::ChainId;
-
-    use std::time::Duration;
-    use tendermint::block::Header;
 
     pub fn get_dummy_tendermint_client_state(tm_header: Header) -> AnyClientState {
         AnyClientState::Tendermint(

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -7,12 +7,12 @@ use tendermint_proto::Protobuf;
 
 use ibc_proto::ibc::lightclients::tendermint::v1::{ClientState as RawClientState, Fraction};
 
-use crate::Height;
 use crate::ics02_client::client_def::AnyClientState;
 use crate::ics02_client::client_type::ClientType;
 use crate::ics07_tendermint::error::{Error, Kind};
 use crate::ics07_tendermint::header::Header;
 use crate::ics23_commitment::merkle::cosmos_specs;
+use crate::Height;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ClientState {
@@ -201,9 +201,9 @@ mod tests {
     use tendermint_light_client::types::TrustThreshold;
     use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
-    use crate::Height;
     use crate::ics07_tendermint::client_state::ClientState;
     use crate::test::test_serialization_roundtrip;
+    use crate::Height;
 
     #[test]
     fn serialization_roundtrip_no_proof() {

--- a/modules/src/ics07_tendermint/consensus_state.rs
+++ b/modules/src/ics07_tendermint/consensus_state.rs
@@ -2,9 +2,7 @@ use std::convert::TryFrom;
 
 use chrono::{TimeZone, Utc};
 use serde::Serialize;
-use tendermint::{Hash,
-                 hash::Algorithm,
-                 time::Time};
+use tendermint::{hash::Algorithm, time::Time, Hash};
 use tendermint_proto::Protobuf;
 
 use ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState as RawConsensusState;

--- a/modules/src/ics07_tendermint/consensus_state.rs
+++ b/modules/src/ics07_tendermint/consensus_state.rs
@@ -1,19 +1,20 @@
-use chrono::{TimeZone, Utc};
 use std::convert::TryFrom;
 
-use ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState as RawConsensusState;
-
-use tendermint::time::Time;
-use tendermint::Hash;
+use chrono::{TimeZone, Utc};
+use serde::Serialize;
+use tendermint::{Hash,
+                 hash::Algorithm,
+                 time::Time};
 use tendermint_proto::Protobuf;
+
+use ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState as RawConsensusState;
 
 use crate::ics02_client::{client_def::AnyConsensusState, client_type::ClientType};
 use crate::ics07_tendermint::error::{Error, Kind};
 use crate::ics07_tendermint::header::Header;
 use crate::ics23_commitment::commitment::CommitmentRoot;
-use tendermint::hash::Algorithm;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ConsensusState {
     pub timestamp: Time,
     pub root: CommitmentRoot,
@@ -101,8 +102,9 @@ impl From<Header> for ConsensusState {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_serialization_roundtrip;
     use tendermint_rpc::endpoint::abci_query::AbciQuery;
+
+    use crate::test::test_serialization_roundtrip;
 
     #[test]
     fn serialization_roundtrip_no_proof() {

--- a/modules/src/ics23_commitment/commitment.rs
+++ b/modules/src/ics23_commitment/commitment.rs
@@ -26,7 +26,7 @@ impl From<Vec<u8>> for CommitmentRoot {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CommitmentPath;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct CommitmentProofBytes(Vec<u8>);
 
 impl CommitmentProofBytes {

--- a/modules/src/ics23_commitment/commitment.rs
+++ b/modules/src/ics23_commitment/commitment.rs
@@ -1,11 +1,13 @@
 use std::convert::TryFrom;
 use std::fmt;
 
+use serde::Serialize;
+
 use ibc_proto::ibc::core::commitment::v1::MerkleProof as RawMerkleProof;
 
 use crate::ics23_commitment::error::{Error, Kind};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct CommitmentRoot(pub Vec<u8>); // Todo: write constructor
 impl CommitmentRoot {
     pub fn from_bytes(bytes: &[u8]) -> Self {
@@ -72,7 +74,7 @@ impl TryFrom<CommitmentProofBytes> for RawMerkleProof {
 }
 
 // TODO: decent getter or Protobuf trait implementation
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Serialize)]
 pub struct CommitmentPrefix(pub Vec<u8>);
 
 impl CommitmentPrefix {

--- a/modules/src/mock/client_state.rs
+++ b/modules/src/mock/client_state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 
+use serde::Serialize;
 use tendermint_proto::Protobuf;
 
 use ibc_proto::ibc::mock::ClientState as RawMockClientState;
@@ -32,7 +33,7 @@ pub struct MockClientRecord {
 /// A mock of a client state. For an example of a real structure that this mocks, you can see
 /// `ClientState` of ics07_tendermint/client_state.rs.
 // TODO: `MockClientState` should evolve, at the very least needs a `is_frozen` boolean field.
-#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Serialize)]
 pub struct MockClientState(pub MockHeader);
 
 impl Protobuf<RawMockClientState> for MockClientState {}
@@ -96,7 +97,7 @@ impl From<MockConsensusState> for MockClientState {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct MockConsensusState(pub MockHeader);
 
 impl Protobuf<RawMockConsensusState> for MockConsensusState {}

--- a/modules/src/mock/header.rs
+++ b/modules/src/mock/header.rs
@@ -1,16 +1,18 @@
 use std::convert::{TryFrom, TryInto};
 
-use ibc_proto::ibc::mock::Header as RawMockHeader;
+use serde::Serialize;
 use tendermint_proto::Protobuf;
 
+use ibc_proto::ibc::mock::Header as RawMockHeader;
+
+use crate::Height;
 use crate::ics02_client::client_def::{AnyConsensusState, AnyHeader};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::error::{self, Error};
 use crate::ics02_client::header::Header;
 use crate::mock::client_state::MockConsensusState;
-use crate::Height;
 
-#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Serialize)]
 pub struct MockHeader(pub Height);
 
 impl Protobuf<RawMockHeader> for MockHeader {}

--- a/modules/src/mock/header.rs
+++ b/modules/src/mock/header.rs
@@ -5,12 +5,12 @@ use tendermint_proto::Protobuf;
 
 use ibc_proto::ibc::mock::Header as RawMockHeader;
 
-use crate::Height;
 use crate::ics02_client::client_def::{AnyConsensusState, AnyHeader};
 use crate::ics02_client::client_type::ClientType;
 use crate::ics02_client::error::{self, Error};
 use crate::ics02_client::header::Header;
 use crate::mock::client_state::MockConsensusState;
+use crate::Height;
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Serialize)]
 pub struct MockHeader(pub Height);

--- a/modules/src/proofs.rs
+++ b/modules/src/proofs.rs
@@ -1,10 +1,12 @@
+use serde::Serialize;
+
 use crate::ics23_commitment::commitment::CommitmentProofBytes;
 use crate::Height;
 
 /// Structure comprising proofs in a message. Proofs are typically present in messages for
 /// handshake protocols, e.g., ICS3 connection (open) handshake or ICS4 channel (open and close)
 /// handshake, as well as for ICS4 packets, timeouts, and acknowledgements.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct Proofs {
     object_proof: CommitmentProofBytes,
     client_proof: Option<CommitmentProofBytes>,
@@ -60,7 +62,7 @@ impl Proofs {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ConsensusProof {
     proof: CommitmentProofBytes,
     height: Height,

--- a/relayer-cli/src/commands/query.rs
+++ b/relayer-cli/src/commands/query.rs
@@ -67,18 +67,18 @@ pub enum QueryPacketCmds {
     Commitment(packet::QueryPacketCommitmentCmd),
 
     /// The `query unreceived packets` subcommand
-    #[options(help = "query unreceived packets")]
+    #[options(help = "query unreceived-packets")]
     UnreceivedPackets(packet::QueryUnreceivedPacketsCmd),
 
-    /// The `query packet commitments` subcommand
-    #[options(help = "query packet acknowledgements")]
+    /// The `query packet acknowledgments` subcommand
+    #[options(help = "query packet acks")]
     Acks(packet::QueryPacketAcknowledgementsCmd),
 
-    /// The `query packet commitment` subcommand
-    #[options(help = "query packet acknowledgment")]
+    /// The `query packet acknowledgement` subcommand
+    #[options(help = "query packet ack")]
     Ack(packet::QueryPacketAcknowledgmentCmd),
 
     /// The `query unreceived packets` subcommand
-    #[options(help = "query un-acknowledged packets")]
+    #[options(help = "query un-received acks")]
     UnreceivedAcks(packet::QueryUnreceivedAcknowledgementCmd),
 }

--- a/relayer-cli/src/commands/query/channel.rs
+++ b/relayer-cli/src/commands/query/channel.rs
@@ -7,8 +7,8 @@ use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::ics04_channel::channel::ChannelEnd;
 use ibc::ics24_host::error::ValidationError;
-use ibc::ics24_host::identifier::{ChannelId, PortId};
 use ibc::ics24_host::identifier::ChainId;
+use ibc::ics24_host::identifier::{ChannelId, PortId};
 use ibc::ics24_host::Path::ChannelEnds;
 use relayer::chain::{Chain, CosmosSDKChain};
 use relayer::config::{ChainConfig, Config};
@@ -86,9 +86,7 @@ impl Runnable for QueryChannelEndCmd {
 
         let (chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                return Output::with_error()
-                    .with_result(json!(err))
-                    .exit();
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -113,9 +111,7 @@ impl Runnable for QueryChannelEndCmd {
             });
 
         match res {
-            Ok(ce) => Output::with_success()
-                .with_result(json!(ce))
-                .exit(),
+            Ok(ce) => Output::with_success().with_result(json!(ce)).exit(),
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),

--- a/relayer-cli/src/commands/query/channel.rs
+++ b/relayer-cli/src/commands/query/channel.rs
@@ -1,18 +1,16 @@
 use std::sync::{Arc, Mutex};
 
 use abscissa_core::{Command, Options, Runnable};
+use tendermint_proto::Protobuf;
 use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::ics04_channel::channel::ChannelEnd;
 use ibc::ics24_host::error::ValidationError;
-use ibc::ics24_host::identifier::ChainId;
 use ibc::ics24_host::identifier::{ChannelId, PortId};
+use ibc::ics24_host::identifier::ChainId;
 use ibc::ics24_host::Path::ChannelEnds;
-
 use relayer::chain::{Chain, CosmosSDKChain};
 use relayer::config::{ChainConfig, Config};
-
-use tendermint_proto::Protobuf;
 
 use crate::error::{Error, Kind};
 use crate::prelude::*;
@@ -120,8 +118,9 @@ impl Runnable for QueryChannelEndCmd {
 
 #[cfg(test)]
 mod tests {
-    use crate::commands::query::channel::QueryChannelEndCmd;
     use relayer::config::parse;
+
+    use crate::commands::query::channel::QueryChannelEndCmd;
 
     #[test]
     fn parse_channel_query_end_parameters() {

--- a/relayer-cli/src/commands/query/connection.rs
+++ b/relayer-cli/src/commands/query/connection.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use abscissa_core::{Command, Options, Runnable};
+use serde_json::json;
 use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::ics03_connection::connection::ConnectionEnd;
@@ -11,6 +12,7 @@ use ibc::ics24_host::identifier::ConnectionId;
 use relayer::chain::{Chain, CosmosSDKChain};
 use relayer::config::{ChainConfig, Config};
 
+use crate::conclude::Output;
 use crate::error::{Error, Kind};
 use crate::prelude::*;
 
@@ -73,8 +75,7 @@ impl Runnable for QueryConnectionEndCmd {
 
         let (chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -90,8 +91,10 @@ impl Runnable for QueryConnectionEndCmd {
             .map_err(|e| Kind::Query.context(e).into());
 
         match res {
-            Ok(cs) => status_info!("connection query result: ", "{:?}", cs),
-            Err(e) => status_info!("connection query error", "{}", e),
+            Ok(ce) => Output::with_success().with_result(json!(ce)).exit(),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/connection.rs
+++ b/relayer-cli/src/commands/query/connection.rs
@@ -148,8 +148,7 @@ impl Runnable for QueryConnectionChannelsCmd {
 
         let (chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -168,8 +167,10 @@ impl Runnable for QueryConnectionChannelsCmd {
             .map_err(|e| Kind::Query.context(e).into());
 
         match res {
-            Ok(cs) => status_info!("connection channels query result: ", "{:?}", cs),
-            Err(e) => status_info!("connection channels query error", "{}", e),
+            Ok(cids) => Output::with_success().with_result(json!(cids)).exit(),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -158,12 +158,7 @@ impl Runnable for QueryPacketCommitmentCmd {
         );
 
         match res {
-            Ok(cs) => status_info!(
-                "Result for packet commitment query at height",
-                "{:?} {:#?}",
-                cs.0,
-                cs.1
-            ),
+            Ok(cs) => Output::with_success().with_result(json!(cs.1)).exit(),
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),
@@ -413,12 +408,7 @@ impl Runnable for QueryPacketAcknowledgmentCmd {
         );
 
         match res {
-            Ok(cs) => status_info!(
-                "Result for packet acknowledgment query at height",
-                "{:?} {:#?}",
-                cs.0,
-                cs.1
-            ),
+            Ok(out) => Output::with_success().with_result(json!(out)).exit(),
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -1,22 +1,22 @@
 use std::sync::{Arc, Mutex};
-use tokio::runtime::Runtime as TokioRuntime;
 
 use abscissa_core::{Command, Options, Runnable};
+use serde_json::json;
+use tokio::runtime::Runtime as TokioRuntime;
 
+use ibc::Height;
+use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
+use ibc::ics24_host::identifier::{ChannelId, PortId};
 use ibc_proto::ibc::core::channel::v1::{
     PacketState, QueryPacketAcknowledgementsRequest, QueryPacketCommitmentsRequest,
     QueryUnreceivedAcksRequest, QueryUnreceivedPacketsRequest,
 };
-
-use ibc::ics24_host::identifier::{ChannelId, PortId};
-use ibc::Height;
-
 use relayer::chain::{Chain, CosmosSDKChain, QueryPacketOptions};
 use relayer::config::{ChainConfig, Config};
 
+use crate::conclude::Output;
 use crate::error::{Error, Kind};
 use crate::prelude::*;
-use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct QueryPacketCommitmentsCmd {
@@ -59,8 +59,7 @@ impl Runnable for QueryPacketCommitmentsCmd {
 
         let (chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -86,10 +85,15 @@ impl Runnable for QueryPacketCommitmentsCmd {
                 cs.0,
                 cs.1
             ),
-            Err(e) => status_info!("Error encountered on packet commitments query:", "{}", e),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
+
+// Output::with_success().with_result(json!(cs.0))
+// .with_result(json!(cs.1)).exit(),
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct QueryPacketCommitmentCmd {
@@ -134,8 +138,7 @@ impl Runnable for QueryPacketCommitmentCmd {
 
         let (chain_config, opts, sequence) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -161,7 +164,9 @@ impl Runnable for QueryPacketCommitmentCmd {
                 cs.0,
                 cs.1
             ),
-            Err(e) => status_info!("Error encountered on packet commitment query:", "{}", e),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
@@ -220,8 +225,7 @@ impl Runnable for QueryUnreceivedPacketsCmd {
 
         let (dst_chain_config, src_chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -262,7 +266,9 @@ impl Runnable for QueryUnreceivedPacketsCmd {
 
         match res {
             Ok(cs) => status_info!("Result for unreceived packets query", "{:?}", cs),
-            Err(e) => status_info!("Error encountered on unreceived packets query:", "{}", e),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
@@ -308,8 +314,7 @@ impl Runnable for QueryPacketAcknowledgementsCmd {
 
         let (chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -335,11 +340,9 @@ impl Runnable for QueryPacketAcknowledgementsCmd {
                 cs.0,
                 cs.1
             ),
-            Err(e) => status_info!(
-                "Error encountered on packet acknowledgement query:",
-                "{}",
-                e
-            ),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
@@ -387,8 +390,7 @@ impl Runnable for QueryPacketAcknowledgmentCmd {
 
         let (chain_config, opts, sequence) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -414,7 +416,9 @@ impl Runnable for QueryPacketAcknowledgmentCmd {
                 cs.0,
                 cs.1
             ),
-            Err(e) => status_info!("Error encountered on packet acknowledgment query:", "{}", e),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
@@ -470,8 +474,7 @@ impl Runnable for QueryUnreceivedAcknowledgementCmd {
 
         let (dst_chain_config, src_chain_config, opts) = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -512,7 +515,9 @@ impl Runnable for QueryUnreceivedAcknowledgementCmd {
 
         match res {
             Ok(cs) => status_info!("Result for unreceived acks query", "{:?}", cs),
-            Err(e) => status_info!("Error encountered on unreceived acks query:", "{}", e),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -81,10 +81,13 @@ impl Runnable for QueryPacketCommitmentsCmd {
         match res {
             Ok(cs) => {
                 // Transform the raw packet commitm. state into the list of sequence numbers
-                let seqs: Vec<u64> = cs.0.iter().map(|ps| ps.sequence ).collect();
+                let seqs: Vec<u64> = cs.0.iter().map(|ps| ps.sequence).collect();
 
-                Output::with_success().with_result(json!(seqs)).with_result(json!(cs.1)).exit();
-            },
+                Output::with_success()
+                    .with_result(json!(seqs))
+                    .with_result(json!(cs.1))
+                    .exit();
+            }
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),
@@ -333,9 +336,12 @@ impl Runnable for QueryPacketAcknowledgementsCmd {
         match res {
             Ok(ps) => {
                 // Transform the raw packet state into the list of acks. sequence numbers
-                let seqs: Vec<u64> = ps.0.iter().map(|ps| ps.sequence ).collect();
+                let seqs: Vec<u64> = ps.0.iter().map(|ps| ps.sequence).collect();
 
-                Output::with_success().with_result(json!(seqs)).with_result(json!(ps.1)).exit();
+                Output::with_success()
+                    .with_result(json!(seqs))
+                    .with_result(json!(ps.1))
+                    .exit();
             }
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -79,21 +79,18 @@ impl Runnable for QueryPacketCommitmentsCmd {
             .map_err(|e| Kind::Query.context(e).into());
 
         match res {
-            Ok(cs) => status_info!(
-                "Result for packet commitments query at height",
-                "{:?} {:#?}",
-                cs.0,
-                cs.1
-            ),
+            Ok(cs) => {
+                // Transform the raw packet commitm. state into the list of sequence numbers
+                let seqs: Vec<u64> = cs.0.iter().map(|ps| ps.sequence ).collect();
+
+                Output::with_success().with_result(json!(seqs)).with_result(json!(cs.1)).exit();
+            },
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),
         }
     }
 }
-
-// Output::with_success().with_result(json!(cs.0))
-// .with_result(json!(cs.1)).exit(),
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct QueryPacketCommitmentCmd {
@@ -265,7 +262,7 @@ impl Runnable for QueryUnreceivedPacketsCmd {
         let res = dst_chain.query_unreceived_packets(request);
 
         match res {
-            Ok(cs) => status_info!("Result for unreceived packets query", "{:?}", cs),
+            Ok(seqs) => Output::with_success().with_result(json!(seqs)).exit(),
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),
@@ -334,12 +331,12 @@ impl Runnable for QueryPacketAcknowledgementsCmd {
             .map_err(|e| Kind::Query.context(e).into());
 
         match res {
-            Ok(cs) => status_info!(
-                "Result for packet acknowledgement query at height",
-                "{:?} {:#?}",
-                cs.0,
-                cs.1
-            ),
+            Ok(ps) => {
+                // Transform the raw packet state into the list of acks. sequence numbers
+                let seqs: Vec<u64> = ps.0.iter().map(|ps| ps.sequence ).collect();
+
+                Output::with_success().with_result(json!(seqs)).with_result(json!(ps.1)).exit();
+            }
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),
@@ -514,7 +511,7 @@ impl Runnable for QueryUnreceivedAcknowledgementCmd {
         let res = dst_chain.query_unreceived_acknowledgements(request);
 
         match res {
-            Ok(cs) => status_info!("Result for unreceived acks query", "{:?}", cs),
+            Ok(seqs) => Output::with_success().with_result(json!(seqs)).exit(),
             Err(e) => Output::with_error()
                 .with_result(json!(format!("{}", e)))
                 .exit(),

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -4,9 +4,9 @@ use abscissa_core::{Command, Options, Runnable};
 use serde_json::json;
 use tokio::runtime::Runtime as TokioRuntime;
 
-use ibc::Height;
 use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
 use ibc::ics24_host::identifier::{ChannelId, PortId};
+use ibc::Height;
 use ibc_proto::ibc::core::channel::v1::{
     PacketState, QueryPacketAcknowledgementsRequest, QueryPacketCommitmentsRequest,
     QueryUnreceivedAcksRequest, QueryUnreceivedPacketsRequest,

--- a/relayer-cli/src/commands/tx/channel.rs
+++ b/relayer-cli/src/commands/tx/channel.rs
@@ -1,19 +1,20 @@
-use crate::prelude::*;
-
 use abscissa_core::{Command, Options, Runnable};
+use serde_json::json;
+
 use ibc::events::IBCEvent;
 use ibc::ics04_channel::channel::Order;
 use ibc::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-
-use crate::error::{Error, Kind};
+use relayer::chain::{CosmosSDKChain,
+                     runtime::ChainRuntime};
 use relayer::channel::{
     build_chan_ack_and_send, build_chan_confirm_and_send, build_chan_init_and_send,
     build_chan_try_and_send,
 };
-
-use relayer::chain::runtime::ChainRuntime;
-use relayer::chain::CosmosSDKChain;
 use relayer::channel::{ChannelConfig, ChannelConfigSide};
+
+use crate::conclude::Output;
+use crate::error::{Error, Kind};
+use crate::prelude::*;
 
 macro_rules! chan_open_cmd {
     ($chan_open_cmd:ident, $dbg_string:literal, $func:ident) => {

--- a/relayer-cli/src/commands/tx/channel.rs
+++ b/relayer-cli/src/commands/tx/channel.rs
@@ -4,8 +4,7 @@ use serde_json::json;
 use ibc::events::IBCEvent;
 use ibc::ics04_channel::channel::Order;
 use ibc::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-use relayer::chain::{CosmosSDKChain,
-                     runtime::ChainRuntime};
+use relayer::chain::{runtime::ChainRuntime, CosmosSDKChain};
 use relayer::channel::{
     build_chan_ack_and_send, build_chan_confirm_and_send, build_chan_init_and_send,
     build_chan_try_and_send,
@@ -60,8 +59,11 @@ macro_rules! chan_open_cmd {
                 let (src_chain_config, dst_chain_config) = match (src_config, dst_config) {
                     (Ok(s), Ok(d)) => (s, d),
                     (_, _) => {
-                        status_err!("invalid options");
-                        return;
+                        return Output::with_error()
+                            .with_result(json!(
+                                "error occurred in finding the chains' configuration"
+                            ))
+                            .exit();
                     }
                 };
 
@@ -94,8 +96,10 @@ macro_rules! chan_open_cmd {
                     $func(dst_chain, src_chain, &opts).map_err(|e| Kind::Tx.context(e).into());
 
                 match res {
-                    Ok(receipt) => status_ok!("Ok: ", serde_json::to_string(&receipt).unwrap()),
-                    Err(e) => status_err!("Error: {}", e),
+                    Ok(receipt) => Output::with_success().with_result(json!(receipt)).exit(),
+                    Err(e) => Output::with_error()
+                        .with_result(json!(format!("{}", e)))
+                        .exit(),
                 }
             }
         }

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -1,15 +1,17 @@
 use abscissa_core::{Command, Options, Runnable};
+use serde_json::json;
 
 use ibc::events::IBCEvent;
 use ibc::ics24_host::identifier::ClientId;
+use relayer::chain::CosmosSDKChain;
+use relayer::chain::runtime::ChainRuntime;
+use relayer::config::ChainConfig;
+use relayer::foreign_client::{build_create_client_and_send, build_update_client_and_send};
 
 use crate::application::app_config;
 use crate::error::{Error, Kind};
 use crate::prelude::*;
-use relayer::chain::runtime::ChainRuntime;
-use relayer::chain::CosmosSDKChain;
-use relayer::config::ChainConfig;
-use relayer::foreign_client::{build_create_client_and_send, build_update_client_and_send};
+use crate::conclude::Output;
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct TxCreateClientCmd {

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -3,15 +3,15 @@ use serde_json::json;
 
 use ibc::events::IBCEvent;
 use ibc::ics24_host::identifier::ClientId;
-use relayer::chain::CosmosSDKChain;
 use relayer::chain::runtime::ChainRuntime;
+use relayer::chain::CosmosSDKChain;
 use relayer::config::ChainConfig;
 use relayer::foreign_client::{build_create_client_and_send, build_update_client_and_send};
 
 use crate::application::app_config;
+use crate::conclude::Output;
 use crate::error::{Error, Kind};
 use crate::prelude::*;
-use crate::conclude::Output;
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct TxCreateClientCmd {
@@ -28,8 +28,7 @@ impl Runnable for TxCreateClientCmd {
             match validate_common_options(&self.dst_chain_id, &self.src_chain_id) {
                 Ok(result) => result,
                 Err(err) => {
-                    status_err!("invalid options: {}", err);
-                    return;
+                    return Output::with_error().with_result(json!(err)).exit();
                 }
             };
 
@@ -47,8 +46,10 @@ impl Runnable for TxCreateClientCmd {
             .map_err(|e| Kind::Tx.context(e).into());
 
         match res {
-            Ok(receipt) => status_ok!("Ok: ", serde_json::to_string(&receipt).unwrap()),
-            Err(e) => status_err!("client create failed: {:?}", e),
+            Ok(receipt) => Output::with_success().with_result(json!(receipt)).exit(),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
@@ -75,8 +76,7 @@ impl Runnable for TxUpdateClientCmd {
         let (dst_chain_config, src_chain_config) = match opts {
             Ok(result) => result,
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
         };
 
@@ -96,8 +96,10 @@ impl Runnable for TxUpdateClientCmd {
                 .map_err(|e| Kind::Tx.context(e).into());
 
         match res {
-            Ok(receipt) => status_ok!("Ok: ", serde_json::to_string(&receipt).unwrap()),
-            Err(e) => status_err!("Error: {}", e),
+            Ok(receipt) => Output::with_success().with_result(json!(receipt)).exit(),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/tx/connection.rs
+++ b/relayer-cli/src/commands/tx/connection.rs
@@ -1,19 +1,18 @@
-use crate::prelude::*;
-
 use abscissa_core::{Command, Options, Runnable};
+use serde_json::json;
 
 use ibc::events::IBCEvent;
 use ibc::ics24_host::identifier::{ClientId, ConnectionId};
-
+use relayer::chain::{runtime::ChainRuntime, CosmosSDKChain};
 use relayer::connection::{
     build_conn_ack_and_send, build_conn_confirm_and_send, build_conn_init_and_send,
     build_conn_try_and_send,
 };
-
-use crate::error::{Error, Kind};
-use relayer::chain::runtime::ChainRuntime;
-use relayer::chain::CosmosSDKChain;
 use relayer::connection::{ConnectionConfig, ConnectionSideConfig};
+
+use crate::conclude::Output;
+use crate::error::{Error, Kind};
+use crate::prelude::*;
 
 macro_rules! conn_open_cmd {
     ($conn_open_cmd:ident, $dbg_string:literal, $func:ident) => {
@@ -53,8 +52,9 @@ macro_rules! conn_open_cmd {
                 let (src_chain_config, dst_chain_config) = match (src_config, dst_config) {
                     (Ok(s), Ok(d)) => (s, d),
                     (_, _) => {
-                        status_err!("invalid options");
-                        return;
+                        return Output::with_error()
+                            .with_result(json!("invalid options"))
+                            .exit();
                     }
                 };
 
@@ -82,8 +82,10 @@ macro_rules! conn_open_cmd {
                     $func(dst_chain, src_chain, &opts).map_err(|e| Kind::Tx.context(e).into());
 
                 match res {
-                    Ok(receipt) => status_ok!("Ok: ", serde_json::to_string(&receipt).unwrap()),
-                    Err(e) => status_err!("Error: {}", e),
+                    Ok(receipt) => Output::with_success().with_result(json!(receipt)).exit(),
+                    Err(e) => Output::with_error()
+                        .with_result(json!(format!("{}", e)))
+                        .exit(),
                 }
             }
         }

--- a/relayer-cli/src/commands/tx/packet.rs
+++ b/relayer-cli/src/commands/tx/packet.rs
@@ -1,16 +1,18 @@
-use crate::prelude::*;
-
 use abscissa_core::{Command, Options, Runnable};
-use relayer::config::Config;
+use serde_json::json;
 
-use crate::error::{Error, Kind};
 use ibc::events::IBCEvent;
 use ibc::ics24_host::identifier::{ChannelId, ClientId, PortId};
 use relayer::chain::runtime::ChainRuntime;
 use relayer::chain::CosmosSDKChain;
+use relayer::config::Config;
 use relayer::link::{
     build_and_send_ack_packet_messages, build_and_send_recv_packet_messages, PacketOptions,
 };
+
+use crate::conclude::Output;
+use crate::error::{Error, Kind};
+use crate::prelude::*;
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct TxRawPacketRecvCmd {
@@ -70,8 +72,7 @@ impl Runnable for TxRawPacketRecvCmd {
 
         let opts = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -87,8 +88,10 @@ impl Runnable for TxRawPacketRecvCmd {
                 .map_err(|e| Kind::Tx.context(e).into());
 
         match res {
-            Ok(ev) => status_info!("packet recv, result: ", "{:#?}", ev),
-            Err(e) => status_info!("packet recv failed, error: ", "{}", e),
+            Ok(ev) => Output::with_success().with_result(json!(ev)).exit(),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }
@@ -151,8 +154,7 @@ impl Runnable for TxRawPacketAckCmd {
 
         let opts = match self.validate_options(&config) {
             Err(err) => {
-                status_err!("invalid options: {}", err);
-                return;
+                return Output::with_error().with_result(json!(err)).exit();
             }
             Ok(result) => result,
         };
@@ -168,8 +170,10 @@ impl Runnable for TxRawPacketAckCmd {
                 .map_err(|e| Kind::Tx.context(e).into());
 
         match res {
-            Ok(ev) => status_info!("packet ack, result: ", "{:#?}", ev),
-            Err(e) => status_info!("packet ack failed, error: ", "{}", e),
+            Ok(ev) => Output::with_success().with_result(json!(ev)).exit(),
+            Err(e) => Output::with_error()
+                .with_result(json!(format!("{}", e)))
+                .exit(),
         }
     }
 }

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -88,14 +88,9 @@ impl Output {
 
     /// Builder-style method for attaching a result to an output object. Can be called multiple
     /// times, with each subsequent call appending the given `res` JSON object to the output.
-    pub fn with_result(self, res: serde_json::Value) -> Self {
-        let mut new_res = self.result.clone();
-        new_res.push(res);
-
-        Output {
-            result: new_res,
-            ..self
-        }
+    pub fn with_result(mut self, res: serde_json::Value) -> Self {
+        self.result.push(res);
+        self
     }
 
     /// Exits from the process with the current output. Convenience wrapper over `exit_with`.

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -6,9 +6,7 @@
 //!
 //! - Exit from a query/tx with a string error:
 //!
-//! ```
-//! use serde_json::json;
-//! use crate::conclude::Output;
+//! ```ignore
 //! let e = String::from("error message");
 //! Output::with_error().with_result(json!(e)).exit();
 //! // or as an alternative:
@@ -20,23 +18,24 @@
 //! better to simplify the output and only write out the chain of error sources, which we can
 //! achieve with `format!("{}", e)`. The complete solution is as follows:
 //!
-//! ```
-//! use crate::relayer_cli::error::{Error, Kind};
-//! use Output;
+//! ```ignore
 //! let e: Error = Kind::Query.into();
 //! Output::with_success().with_result(json!(format!("{}", e))).exit();
 //! ```
 //!
 //! - Exit from a query/tx with success:
 //!
-//! ```
+//! ```ignore
+//! let cs = ChannelEnd::default();
 //! Output::with_success().with_result(json!(cs)).exit();
 //! ```
 //!
 //! - Exit from a query/tx with success and multiple objects in the result:
 //!
-//! ```
-//! Output::with_success().with_result(json!(cs)).exit();
+//! ```ignore
+//! let h = Height::default();
+//! let end = ConnectionEnd::default();
+//! Output::with_success().with_result(json!(h)).with_result(end).exit();
 //! ```
 
 use serde::Serialize;

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -2,11 +2,14 @@
 //! from a CLI command. The main use-case for this module is to provide a consistent output for
 //! queries and transactions.
 //!
+//! The examples below rely on crate-private methods (for this reason, doctests do not compile.)
+//! They are intended for contributors to crate `relayer-cli`, and _not_ for users of this binary.
+//!
 //! ## Examples:
 //!
 //! - Exit from a query/tx with a string error:
 //!
-//! ```ignore
+//! ```compile_fail
 //! let e = String::from("error message");
 //! Output::with_error().with_result(json!(e)).exit();
 //! // or as an alternative:
@@ -18,21 +21,21 @@
 //! better to simplify the output and only write out the chain of error sources, which we can
 //! achieve with `format!("{}", e)`. The complete solution is as follows:
 //!
-//! ```ignore
+//! ```compile_fail
 //! let e: Error = Kind::Query.into();
 //! Output::with_success().with_result(json!(format!("{}", e))).exit();
 //! ```
 //!
 //! - Exit from a query/tx with success:
 //!
-//! ```ignore
+//! ```compile_fail
 //! let cs = ChannelEnd::default();
 //! Output::with_success().with_result(json!(cs)).exit();
 //! ```
 //!
 //! - Exit from a query/tx with success and multiple objects in the result:
 //!
-//! ```ignore
+//! ```compile_fail
 //! let h = Height::default();
 //! let end = ConnectionEnd::default();
 //! Output::with_success().with_result(json!(h)).with_result(end).exit();

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -1,0 +1,74 @@
+//! Custom-made solution to output a JSON return message and ensure a return code
+//! from a CLI command.
+
+use serde::Serialize;
+
+/// Functional-style method to exit a program.
+///
+/// ## Note: See `Output::exit()` for the preferred method of exiting a command.
+pub fn exit_with(out: Output) {
+    // Handle the output message
+    println!("{}", serde_json::to_string(&out).unwrap());
+
+    // The return code
+    if out.status == Status::Error {
+        std::process::exit(1);
+    } else {
+        std::process::exit(0);
+    }
+}
+
+/// A CLI output with support for JSON serialization. The only mandatory field is the `status`,
+/// which typically signals a success or an error. An optional `result` can be added to an output.
+#[derive(Serialize, Debug)]
+pub struct Output {
+    /// The return status
+    pub status: Status,
+
+    /// The result of a command, such as the output from a query or transaction.
+    /// An arbitrary strongly typed JSON object.
+    pub result: Option<serde_json::Value>,
+}
+
+impl Output {
+    /// Constructs a new `Output`.
+    pub fn new(status: Status) -> Self {
+        Output {
+            status,
+            result: None,
+        }
+    }
+
+    /// Quick-access to a constructor that returns a new `Output` having a `Success` status.
+    pub fn with_success() -> Self {
+        Output::new(Status::Success)
+    }
+
+    /// Quick-access to a constructor that returns a new `Output` having an `Error` status.
+    pub fn with_error() -> Self {
+        Output::new(Status::Error)
+    }
+
+    /// Builder-style method for attaching a result to an output object.
+    pub fn with_result(self, res: serde_json::Value) -> Self {
+        Output {
+            result: Some(res),
+            ..self
+        }
+    }
+
+    /// Exits from the process with the current output. Convenience wrapper over `exit_with`.
+    pub fn exit(self) {
+        exit_with(self);
+    }
+}
+
+/// Represents the exit status of any CLI command
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub enum Status {
+    #[serde(rename(serialize = "success"))]
+    Success,
+
+    #[serde(rename(serialize = "error"))]
+    Error,
+}

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -1,5 +1,31 @@
 //! Custom-made solution to output a JSON return message and ensure a return code
-//! from a CLI command.
+//! from a CLI command. The main use-case for this module is to provide a consistent output for
+//! queries and transactions.
+//!
+//! ## Examples:
+//! - Exit from a query/tx with a string error:
+//!
+//! ```
+//! use serde_json::json;
+//! use crate::conclude::Output;
+//! let e = String::from("error message");
+//! Output::with_error().with_result(json!(e)).exit();
+//! ```
+//!
+//! - Exit from a query/tx with an anomaly error:
+//!
+//! ```
+//! use crate::relayer_cli::error::{Error, Kind};
+//! use Output;
+//! let e: Error = Kind::Query.into();
+//! Output::with_success().with_result(json!(format!("{}", e))).exit();
+//! ```
+//!
+//! - Exit from a query/tx with success:
+//!
+//! ```
+//! Output::with_success().with_result(json!(cs)).exit();
+//! ```
 
 use serde::Serialize;
 

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -11,6 +11,8 @@
 //! use crate::conclude::Output;
 //! let e = String::from("error message");
 //! Output::with_error().with_result(json!(e)).exit();
+//! // or as an alternative:
+//! Output::with_error().with_result(json!("error occurred")).exit();
 //! ```
 //!
 //! - Exit from a query/tx with an error of type `anomaly`:

--- a/relayer-cli/src/lib.rs
+++ b/relayer-cli/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod application;
 pub mod commands;
+pub(crate) mod conclude;
 pub mod config;
 pub mod error;
 pub mod prelude;

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -154,7 +154,7 @@ pub trait Chain: Sized {
         height: ICSHeight,
     ) -> Result<ConnectionEnd, Error> {
         let res = self.query(Path::Connections(connection_id.clone()), height, false)?;
-        Ok(ConnectionEnd::decode_vec(&res.value).map_err(|e| Kind::Query.context(e))?)
+        Ok(ConnectionEnd::decode_vec(&res.value).map_err(|e| Kind::Query("connection".into()).context(e))?)
     }
 
     fn query_channel(
@@ -168,7 +168,7 @@ pub trait Chain: Sized {
             height,
             false,
         )?;
-        Ok(ChannelEnd::decode_vec(&res.value).map_err(|e| Kind::Query.context(e))?)
+        Ok(ChannelEnd::decode_vec(&res.value).map_err(|e| Kind::Query("channel".into()).context(e))?)
     }
 
     // Provable queries
@@ -186,14 +186,14 @@ pub trait Chain: Sized {
     ) -> Result<(ConnectionEnd, MerkleProof), Error> {
         let res = self
             .query(Path::Connections(connection_id.clone()), height, true)
-            .map_err(|e| Kind::Query.context(e))?;
+            .map_err(|e| Kind::Query("proven connection".into()).context(e))?;
         let connection_end =
-            ConnectionEnd::decode_vec(&res.value).map_err(|e| Kind::Query.context(e))?;
+            ConnectionEnd::decode_vec(&res.value).map_err(|e| Kind::Query("proven connection".into()).context(e))?;
 
         Ok((
             connection_end,
             res.proof
-                .ok_or_else(|| Kind::Query.context("empty proof".to_string()))?,
+                .ok_or_else(|| Kind::Query("proven connection".into()).context("empty proof".to_string()))?,
         ))
     }
 
@@ -216,14 +216,14 @@ pub trait Chain: Sized {
                 height,
                 true,
             )
-            .map_err(|e| Kind::Query.context(e))?;
+            .map_err(|e| Kind::Query("proven channel".into()).context(e))?;
 
-        let channel_end = ChannelEnd::decode_vec(&res.value).map_err(|e| Kind::Query.context(e))?;
+        let channel_end = ChannelEnd::decode_vec(&res.value).map_err(|e| Kind::Query("proven channel".into()).context(e))?;
 
         Ok((
             channel_end,
             res.proof
-                .ok_or_else(|| Kind::Query.context("empty proof".to_string()))?,
+                .ok_or_else(|| Kind::Query("proven channel".into()).context("empty proof".to_string()))?,
         ))
     }
 
@@ -372,12 +372,12 @@ pub trait Chain: Sized {
 
         let res = self
             .query(data, height, true)
-            .map_err(|e| Kind::Query.context(e))?;
+            .map_err(|e| Kind::Query(packet_type.to_string()).context(e))?;
 
         let proofs = Proofs::new(
             CommitmentProofBytes::from(
                 res.proof
-                    .ok_or_else(|| Kind::Query.context("empty proof".to_string()))?,
+                    .ok_or_else(|| Kind::Query(packet_type.to_string()).context("empty proof".to_string()))?,
             ),
             None,
             None,

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -154,7 +154,8 @@ pub trait Chain: Sized {
         height: ICSHeight,
     ) -> Result<ConnectionEnd, Error> {
         let res = self.query(Path::Connections(connection_id.clone()), height, false)?;
-        Ok(ConnectionEnd::decode_vec(&res.value).map_err(|e| Kind::Query("connection".into()).context(e))?)
+        Ok(ConnectionEnd::decode_vec(&res.value)
+            .map_err(|e| Kind::Query("connection".into()).context(e))?)
     }
 
     fn query_channel(
@@ -168,7 +169,8 @@ pub trait Chain: Sized {
             height,
             false,
         )?;
-        Ok(ChannelEnd::decode_vec(&res.value).map_err(|e| Kind::Query("channel".into()).context(e))?)
+        Ok(ChannelEnd::decode_vec(&res.value)
+            .map_err(|e| Kind::Query("channel".into()).context(e))?)
     }
 
     // Provable queries
@@ -187,13 +189,14 @@ pub trait Chain: Sized {
         let res = self
             .query(Path::Connections(connection_id.clone()), height, true)
             .map_err(|e| Kind::Query("proven connection".into()).context(e))?;
-        let connection_end =
-            ConnectionEnd::decode_vec(&res.value).map_err(|e| Kind::Query("proven connection".into()).context(e))?;
+        let connection_end = ConnectionEnd::decode_vec(&res.value)
+            .map_err(|e| Kind::Query("proven connection".into()).context(e))?;
 
         Ok((
             connection_end,
-            res.proof
-                .ok_or_else(|| Kind::Query("proven connection".into()).context("empty proof".to_string()))?,
+            res.proof.ok_or_else(|| {
+                Kind::Query("proven connection".into()).context("empty proof".to_string())
+            })?,
         ))
     }
 
@@ -218,12 +221,14 @@ pub trait Chain: Sized {
             )
             .map_err(|e| Kind::Query("proven channel".into()).context(e))?;
 
-        let channel_end = ChannelEnd::decode_vec(&res.value).map_err(|e| Kind::Query("proven channel".into()).context(e))?;
+        let channel_end = ChannelEnd::decode_vec(&res.value)
+            .map_err(|e| Kind::Query("proven channel".into()).context(e))?;
 
         Ok((
             channel_end,
-            res.proof
-                .ok_or_else(|| Kind::Query("proven channel".into()).context("empty proof".to_string()))?,
+            res.proof.ok_or_else(|| {
+                Kind::Query("proven channel".into()).context("empty proof".to_string())
+            })?,
         ))
     }
 
@@ -375,10 +380,9 @@ pub trait Chain: Sized {
             .map_err(|e| Kind::Query(packet_type.to_string()).context(e))?;
 
         let proofs = Proofs::new(
-            CommitmentProofBytes::from(
-                res.proof
-                    .ok_or_else(|| Kind::Query(packet_type.to_string()).context("empty proof".to_string()))?,
-            ),
+            CommitmentProofBytes::from(res.proof.ok_or_else(|| {
+                Kind::Query(packet_type.to_string()).context("empty proof".to_string())
+            })?),
             None,
             None,
             height.increment(),

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -384,10 +384,13 @@ impl Chain for CosmosSDKChain {
             .query(ClientStatePath(client_id.clone()), height, false)
             .map_err(|e| Kind::Query("client state".into()).context(e))
             .and_then(|v| {
-                AnyClientState::decode_vec(&v.value).map_err(|e| Kind::Query("client state".into()).context(e))
+                AnyClientState::decode_vec(&v.value)
+                    .map_err(|e| Kind::Query("client state".into()).context(e))
             })?;
-        let client_state = downcast!(client_state => AnyClientState::Tendermint)
-            .ok_or_else(|| Kind::Query("client state".into()).context("unexpected client state type"))?;
+        let client_state =
+            downcast!(client_state => AnyClientState::Tendermint).ok_or_else(|| {
+                Kind::Query("client state".into()).context("unexpected client state type")
+            })?;
         Ok(client_state)
     }
 
@@ -407,16 +410,19 @@ impl Chain for CosmosSDKChain {
             .query(ClientStatePath(client_id.clone()), height, true)
             .map_err(|e| Kind::Query("client state".into()).context(e))?;
 
-        let client_state =
-            AnyClientState::decode_vec(&res.value).map_err(|e| Kind::Query("client state".into()).context(e))?;
+        let client_state = AnyClientState::decode_vec(&res.value)
+            .map_err(|e| Kind::Query("client state".into()).context(e))?;
 
-        let client_state = downcast!(client_state => AnyClientState::Tendermint)
-            .ok_or_else(|| Kind::Query("client state".into()).context("unexpected client state type"))?;
+        let client_state =
+            downcast!(client_state => AnyClientState::Tendermint).ok_or_else(|| {
+                Kind::Query("client state".into()).context("unexpected client state type")
+            })?;
 
         Ok((
             client_state,
-            res.proof
-                .ok_or_else(|| Kind::Query("client state".into()).context("empty proof".to_string()))?,
+            res.proof.ok_or_else(|| {
+                Kind::Query("client state".into()).context("empty proof".to_string())
+            })?,
         ))
     }
 
@@ -438,16 +444,19 @@ impl Chain for CosmosSDKChain {
             )
             .map_err(|e| Kind::Query("client consensus".into()).context(e))?;
 
-        let consensus_state =
-            AnyConsensusState::decode_vec(&res.value).map_err(|e| Kind::Query("client consensus".into()).context(e))?;
+        let consensus_state = AnyConsensusState::decode_vec(&res.value)
+            .map_err(|e| Kind::Query("client consensus".into()).context(e))?;
 
         let consensus_state = downcast!(consensus_state => AnyConsensusState::Tendermint)
-            .ok_or_else(|| Kind::Query("client consensus".into()).context("unexpected client consensus type"))?;
+            .ok_or_else(|| {
+                Kind::Query("client consensus".into()).context("unexpected client consensus type")
+            })?;
 
         Ok((
             consensus_state,
-            res.proof
-                .ok_or_else(|| Kind::Query("client consensus".into()).context("empty proof".to_string()))?,
+            res.proof.ok_or_else(|| {
+                Kind::Query("client consensus".into()).context("empty proof".to_string())
+            })?,
         ))
     }
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -382,12 +382,12 @@ impl Chain for CosmosSDKChain {
     ) -> Result<Self::ClientState, Error> {
         let client_state = self
             .query(ClientStatePath(client_id.clone()), height, false)
-            .map_err(|e| Kind::Query.context(e))
+            .map_err(|e| Kind::Query("client state".into()).context(e))
             .and_then(|v| {
-                AnyClientState::decode_vec(&v.value).map_err(|e| Kind::Query.context(e))
+                AnyClientState::decode_vec(&v.value).map_err(|e| Kind::Query("client state".into()).context(e))
             })?;
         let client_state = downcast!(client_state => AnyClientState::Tendermint)
-            .ok_or_else(|| Kind::Query.context("unexpected client state type"))?;
+            .ok_or_else(|| Kind::Query("client state".into()).context("unexpected client state type"))?;
         Ok(client_state)
     }
 
@@ -405,18 +405,18 @@ impl Chain for CosmosSDKChain {
     ) -> Result<(Self::ClientState, MerkleProof), Error> {
         let res = self
             .query(ClientStatePath(client_id.clone()), height, true)
-            .map_err(|e| Kind::Query.context(e))?;
+            .map_err(|e| Kind::Query("client state".into()).context(e))?;
 
         let client_state =
-            AnyClientState::decode_vec(&res.value).map_err(|e| Kind::Query.context(e))?;
+            AnyClientState::decode_vec(&res.value).map_err(|e| Kind::Query("client state".into()).context(e))?;
 
         let client_state = downcast!(client_state => AnyClientState::Tendermint)
-            .ok_or_else(|| Kind::Query.context("unexpected client state type"))?;
+            .ok_or_else(|| Kind::Query("client state".into()).context("unexpected client state type"))?;
 
         Ok((
             client_state,
             res.proof
-                .ok_or_else(|| Kind::Query.context("empty proof".to_string()))?,
+                .ok_or_else(|| Kind::Query("client state".into()).context("empty proof".to_string()))?,
         ))
     }
 
@@ -436,18 +436,18 @@ impl Chain for CosmosSDKChain {
                 height,
                 true,
             )
-            .map_err(|e| Kind::Query.context(e))?;
+            .map_err(|e| Kind::Query("client consensus".into()).context(e))?;
 
         let consensus_state =
-            AnyConsensusState::decode_vec(&res.value).map_err(|e| Kind::Query.context(e))?;
+            AnyConsensusState::decode_vec(&res.value).map_err(|e| Kind::Query("client consensus".into()).context(e))?;
 
         let consensus_state = downcast!(consensus_state => AnyConsensusState::Tendermint)
-            .ok_or_else(|| Kind::Query.context("unexpected client consensus type"))?;
+            .ok_or_else(|| Kind::Query("client consensus".into()).context("unexpected client consensus type"))?;
 
         Ok((
             consensus_state,
             res.proof
-                .ok_or_else(|| Kind::Query.context("empty proof".to_string()))?,
+                .ok_or_else(|| Kind::Query("client consensus".into()).context("empty proof".to_string()))?,
         ))
     }
 

--- a/relayer/src/chain/mock.rs
+++ b/relayer/src/chain/mock.rs
@@ -174,8 +174,9 @@ impl Chain for MockChain {
             .context
             .query_client_full_state(client_id)
             .ok_or(Kind::EmptyResponseValue)?;
-        let client_state = downcast!(any_state => AnyClientState::Tendermint)
-            .ok_or_else(|| Kind::Query.context("unexpected client state type"))?;
+        let client_state = downcast!(any_state => AnyClientState::Tendermint).ok_or_else(|| {
+            Kind::Query("client state".into()).context("unexpected client state type")
+        })?;
         Ok(client_state)
     }
 

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -131,8 +131,8 @@ pub enum Kind {
     MessageTransaction(String),
 
     /// Failed query
-    #[error("Bad parameter")]
-    Query,
+    #[error("Query error occurred (failed to finish query for {0})")]
+    Query(String),
 
     /// Keybase related error
     #[error("Keybase error")]

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -422,7 +422,7 @@ fn build_recv_packet_and_timeout_msgs(
     let mut packet_sequences = vec![];
     for event in events.iter() {
         let send_event = downcast!(event => IBCEvent::SendPacketChannel)
-            .ok_or_else(|| Kind::Query.context("unexpected query tx response"))?;
+            .ok_or_else(|| Kind::Query("packet events".into()).context("unexpected query tx response"))?;
 
         packet_sequences.append(&mut vec![send_event.packet.sequence]);
     }
@@ -471,7 +471,7 @@ fn build_packet_ack_msgs(
     let mut packet_sequences = vec![];
     for event in events.iter() {
         let write_ack_event = downcast!(event => IBCEvent::WriteAcknowledgementChannel)
-            .ok_or_else(|| Kind::Query.context("unexpected query tx response"))?;
+            .ok_or_else(|| Kind::Query("packet events".into()).context("unexpected query tx response"))?;
 
         packet_sequences.append(&mut vec![write_ack_event.packet.sequence]);
     }

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -421,8 +421,9 @@ fn build_recv_packet_and_timeout_msgs(
 
     let mut packet_sequences = vec![];
     for event in events.iter() {
-        let send_event = downcast!(event => IBCEvent::SendPacketChannel)
-            .ok_or_else(|| Kind::Query("packet events".into()).context("unexpected query tx response"))?;
+        let send_event = downcast!(event => IBCEvent::SendPacketChannel).ok_or_else(|| {
+            Kind::Query("packet events".into()).context("unexpected query tx response")
+        })?;
 
         packet_sequences.append(&mut vec![send_event.packet.sequence]);
     }
@@ -471,7 +472,9 @@ fn build_packet_ack_msgs(
     let mut packet_sequences = vec![];
     for event in events.iter() {
         let write_ack_event = downcast!(event => IBCEvent::WriteAcknowledgementChannel)
-            .ok_or_else(|| Kind::Query("packet events".into()).context("unexpected query tx response"))?;
+            .ok_or_else(|| {
+                Kind::Query("packet events".into()).context("unexpected query tx response")
+            })?;
 
         packet_sequences.append(&mut vec![write_ack_event.packet.sequence]);
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #500 

## Description

List of outputs upon successful execution of all queries and txs:

#### client tx

> {"status":"success","result":[{"CreateClient":{"client_id":"07-tendermint-1","client_type":"Tendermint","consensus_height":{"revision_height":206,"revision_number":1},"height":"1"}}]}

> {"status":"success","result":[{"UpdateClient":{"client_id":"07-tendermint-1","client_type":"Tendermint","consensus_height":{"revision_height":346,"revision_number":0},"height":"1"}}]}

#### connection tx

> {"status":"success","result":[{"OpenInitConnection":{"client_id":"07-tendermint-1","connection_id":"connection-1","counterparty_client_id":"07-tendermint-1","counterparty_connection_id":null,"height":"1"}}]}

> {"status":"success","result":[{"OpenTryConnection":{"client_id":"07-tendermint-1","connection_id":"connection-2","counterparty_client_id":"07-tendermint-1","counterparty_connection_id":"connection-1","height":"1"}}]}

> {"status":"success","result":[{"OpenAckConnection":{"client_id":"07-tendermint-1","connection_id":"connection-2","counterparty_client_id":"07-tendermint-1","counterparty_connection_id":"connection-3","height":"1"}}]}

> {"status":"success","result":[{"OpenConfirmConnection":{"client_id":"07-tendermint-1","connection_id":"connection-3","counterparty_client_id":"07-tendermint-1","counterparty_connection_id":"connection-2","height":"1"}}]}


#### channel tx

> {"status":"success","result":[{"OpenInitChannel":{"channel_id":"channel-1","connection_id":"connection-3","counterparty_channel_id":null,"counterparty_port_id":"transfer","height":"1","port_id":"transfer"}}]}

> {"status":"success","result":[{"OpenTryChannel":{"channel_id":"channel-1","connection_id":"connection-2","counterparty_channel_id":"channel-1","counterparty_port_id":"transfer","height":"1","port_id":"transfer"}}]}

> {"status":"success","result":[{"OpenAckChannel":{"channel_id":"channel-1","connection_id":"connection-3","counterparty_channel_id":"channel-1","counterparty_port_id":"transfer","height":"1","port_id":"transfer"}}]}

> {"status":"success","result":[{"OpenConfirmChannel":{"channel_id":"channel-1","connection_id":"connection-2","counterparty_channel_id":"channel-1","counterparty_port_id":"transfer","height":"1","port_id":"transfer"}}]}

#### packet, transfer tx

> {"status":"success","result":[[{"SendPacketChannel":{"height":"1","packet":{"data":[123,34,97,109,111,117,110,116,34,58,34,49,48,48,48,48,34,44,34,100,101,110,111,109,34,58,34,115,97,109,111,108,101,97,110,115,34,44,34,114,101,99,101,105,118,101,114,34,58,34,99,111,115,109,111,115,49,106,107,54,118,115,99,108,119,117,97,122,101,116,117,57,107,102,118,118,117,112,50,51,50,122,51,52,104,101,52,116,101,110,104,121,115,99,107,34,44,34,115,101,110,100,101,114,34,58,34,99,111,115,109,111,115,49,50,110,101,119,48,97,120,110,97,112,109,114,117,116,110,122,103,52,104,117,115,120,122,117,103,110,122,119,114,122,101,57,100,50,48,51,53,56,34,125],"destination_channel":"channel-1","destination_port":"transfer","sequence":1,"source_channel":"channel-1","source_port":"transfer","timeout_height":{"revision_height":3798,"revision_number":1},"timeout_timestamp":0}}}]]}

__Note:__ TxRawPacketRecvCmd and TxRawPacketAckCmd: not clear how to test these

#### client queries

> {"status":"success","result":[{"AnyClientState":"Tendermint","allow_update_after_expiry":false,"allow_update_after_misbehaviour":false,"chain_id":"ibc-1","frozen_height":{"revision_height":0,"revision_number":0},"latest_height":{"revision_height":3536,"revision_number":1},"max_clock_drift":{"nanos":0,"secs":3},"trust_level":{"denominator":"3","numerator":"1"},"trusting_period":{"nanos":0,"secs":1209600},"unbonding_period":{"nanos":0,"secs":1814400},"upgrade_path":["upgrade","upgradedIBCState"]}]}

> {"status":"success","result":[{"AnyConsensusState":"Tendermint","next_validators_hash":"F340187B7E4860DE518F5B9F208EA243F9322BCE7D7D7693C4670B41E0057E22","root":[199,144,30,80,92,207,201,98,77,131,83,6,67,108,232,70,102,201,188,217,73,220,23,162,110,17,32,174,66,80,99,229],"timestamp":"2021-01-13T11:52:30.313428Z"}]}

> {"status":"success","result":[["connection-1","connection-2"]]}

#### connection queries:

{"status":"success","result":[{"ConnectionEnd":"ConnectionEnd","client_id":"07-tendermint-1","counterparty":{"client_id":"07-tendermint-1","connection_id":"connection-3","prefix":[105,98,99]},"delay_period":0,"state":"Open","versions":[{"features":["ORDER_ORDERED","ORDER_UNORDERED"],"identifier":"1"}]}]}


#### channel query: 

> {"status":"success","result":[{"ChannelEnd":"ChannelEnd","connection_hops":["connection-2"],"ordering":"Unordered","remote":{"channel_id":"channel-1","port_id":"transfer"},"state":"Open","version":"ics20-1"}]}

#### packet queries:

- for packet commitments:

> {"status":"success","result":[[1],{"revision_height":5641,"revision_number":0}]}

- for packet commitment:

> {"status":"success","result":[{"client_proof":null,"consensus_proof":null,"height":{"revision_height":1,"revision_number":0},"object_proof":[10,170,3,10,1....115]}]}

- for packet ack:

> {"status":"success","result":[[[],{"client_proof":null,"consensus_proof":null,"height":{"revision_height":1,"revision_number":0},"object_proof":[10,190,3,...45,107]}]]}

- for packet unreceived-packets:

> {"status":"success","result":[[1]]}

- for packet acks:

> {"status":"success","result":[[],{"revision_height":6993,"revision_number":0}]}

- for packet unreceived-acks:

> {"status":"success","result":[[]]}

##  Beside JSON output, this PR also improves on the following:

### Added derive serde `Serialize` annotation

Did this for several types, e.g., `AnyClientState`, which was necessary to be able to format these types into the JSON output format.

### Better error output in some error corner cases

For example, any Query error is now accompanied with the precise location (the query type) that failed, so that the chain of errors is explicit in the error output. Also, some query errors were misreported as _converting_ problems when the query result was empty (the problem was that the result was empty, not in converting the types). The output diff is as follows for `rrly -c loop_config.toml tx raw update-client ibc-1 ibc-0`:


```diff
- {"status":"error","result":["tx error: Bad parameter: error converting message type into domain type: unknown client state type: "]}
+ {"status":"error","result":["tx error: Query error occurred (failed to finish query for client state): error converting message type into domain type: empty client state"]}
```

### Output simplified for 'query packet commitments' command:

We used to output the [`RawPacketState`](https://github.com/informalsystems/ibc-rs/blob/db2be6f72fef647933f48d80b29a0f9f12c804d4/proto/src/prost/ibc.core.channel.v1.rs#L95) (to string) upon command `query packet commitments`. There is no associated domain type for this, and is not possible to annotate this raw type with a serde::Serialize derive macro. So instead of outputting the whole RawPacketState, we now output only the packet sequence numbers.

Here is how the output changed:

```diff
- Result for packet commitments query at height [PacketState { port_id: "transfer", channel_id: "channel-1", sequence: 1, data: [42, 195, 42, 106, 38, 32, 206, 55, 183, 248, 21, 191, 96, 95, 250, 161, 10, 105, 89, 6, 91, 122, 57, 205, 55, 167, 29, 101, 55, 32, 55, 127] }] Height {
-    revision_number: 0,
-    revision_height: 5187,
- }
+ {"status":"success","result":[[1],{"Height":"Height","revision_height":5702,"revision_number":0}]}
```

## Cases that are _not_ covered with JSON output:

The following is non-exhaustive list of commands that _do not have JSON_ output.
We'll fix these problems as they become important:

- client update with invalid client id: 
>$ rrly -c loop_config.toml tx raw update-client ibc-1 ibc-0 ddd
> error: invalid argument to option `dst_client_id`: identifier ddd has invalid length 3 must be between 9-64 characters

- conn-try with invalid connection id confuses success with error -- note the missing src_connection_id parameter:

> $ rrly -c loop_config.toml tx raw conn-try ibc-1 ibc-0 07-tendermint-1 07-tendermint-1 connection-1
> {"status":"success","result":[{"ChainError":"deliver_tx reports error: log=Log(\"failed to execute message; message index: 1: connection handshake open try failed: failed connection state verification for client (07-tendermint-1): chained membership proof contains nonexistence proof at index 0. If this is unexpected, please ensure that proof was queried from the height that contained the value in store and was queried with the correct key.: invalid proof\")"}]}

- ~~[`query packet commitment`](https://github.com/informalsystems/ibc-rs/blob/4feec430f08c7b1504916242b76282de54839083/relayer-cli/src/commands/query/packet.rs#L135) command does not output JSON upon success. Reason: it's not clear how this command will be used and what are the requirements on the output. Is the object proof going to be consumed by users/CI @ancazamfir @andynog? The same goes for `query packet ack`~~ this was addressed


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.