### PR TITLE
Add MsgTimeoutOnClose and send it from packet-recv CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - [relayer]
   - Added retry mechanism, restructured relayer ([#519])
+  - Relay `MsgTimeoutOnClose` if counterparty channel state is `State::Closed`
+
+- [modules]
+  - Add `MsgTimeoutOnClose` message type ([#563])
 
 ### IMPROVEMENTS
 
@@ -67,6 +71,7 @@
 [#540]: https://github.com/informalsystems/ibc-rs/issues/540
 [#554]: https://github.com/informalsystems/ibc-rs/issues/554
 [#557]: https://github.com/informalsystems/ibc-rs/issues/557
+[#563]: https://github.com/informalsystems/ibc-rs/issues/563
 
 ## v0.0.6
 *December 23, 2020*

--- a/modules/src/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_ack.rs
@@ -133,6 +133,7 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
                 msg.proof_try.into(),
                 client_proof,
                 Option::from(consensus_proof_obj),
+                None,
                 proof_height,
             )
             .map_err(|e| Kind::InvalidProof.context(e))?,

--- a/modules/src/ics03_connection/msgs/conn_open_confirm.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_confirm.rs
@@ -68,7 +68,7 @@ impl TryFrom<RawMsgConnectionOpenConfirm> for MsgConnectionOpenConfirm {
                 .connection_id
                 .parse()
                 .map_err(|e| Kind::IdentifierError.context(e))?,
-            proofs: Proofs::new(msg.proof_ack.into(), None, None, proof_height)
+            proofs: Proofs::new(msg.proof_ack.into(), None, None, None, proof_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })

--- a/modules/src/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_try.rs
@@ -166,6 +166,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
                 msg.proof_init.into(),
                 client_proof,
                 Some(consensus_proof_obj),
+                None,
                 proof_height,
             )
             .map_err(|e| Kind::InvalidProof.context(e))?,

--- a/modules/src/ics04_channel/msgs.rs
+++ b/modules/src/ics04_channel/msgs.rs
@@ -20,6 +20,7 @@ pub mod chan_close_init;
 pub mod acknowledgement;
 pub mod recv_packet;
 pub mod timeout;
+pub mod timeout_on_close;
 
 /// Enumeration of all possible messages that the ICS4 protocol processes.
 #[derive(Clone, Debug, PartialEq)]

--- a/modules/src/ics04_channel/msgs/acknowledgement.rs
+++ b/modules/src/ics04_channel/msgs/acknowledgement.rs
@@ -68,6 +68,7 @@ impl TryFrom<RawMsgAcknowledgement> for MsgAcknowledgement {
             raw_msg.proof_acked.into(),
             None,
             None,
+            None,
             raw_msg
                 .proof_height
                 .ok_or(Kind::MissingHeight)?

--- a/modules/src/ics04_channel/msgs/chan_close_confirm.rs
+++ b/modules/src/ics04_channel/msgs/chan_close_confirm.rs
@@ -53,6 +53,7 @@ impl TryFrom<RawMsgChannelCloseConfirm> for MsgChannelCloseConfirm {
             raw_msg.proof_init.into(),
             None,
             None,
+            None,
             raw_msg
                 .proof_height
                 .ok_or(Kind::MissingHeight)?

--- a/modules/src/ics04_channel/msgs/chan_open_ack.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_ack.rs
@@ -54,6 +54,7 @@ impl TryFrom<RawMsgChannelOpenAck> for MsgChannelOpenAck {
             raw_msg.proof_try.into(),
             None,
             None,
+            None,
             raw_msg
                 .proof_height
                 .ok_or(Kind::MissingHeight)?

--- a/modules/src/ics04_channel/msgs/chan_open_confirm.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_confirm.rs
@@ -41,7 +41,7 @@ impl MsgChannelOpenConfirm {
             channel_id: channel_id
                 .parse()
                 .map_err(|e| Kind::IdentifierError.context(e))?,
-            proofs: Proofs::new(proof_ack, None, None, proofs_height)
+            proofs: Proofs::new(proof_ack, None, None, None, proofs_height)
                 .map_err(|e| Kind::InvalidProof.context(e))?,
             signer,
         })
@@ -75,6 +75,7 @@ impl TryFrom<RawMsgChannelOpenConfirm> for MsgChannelOpenConfirm {
 
         let proofs = Proofs::new(
             raw_msg.proof_ack.into(),
+            None,
             None,
             None,
             raw_msg

--- a/modules/src/ics04_channel/msgs/chan_open_try.rs
+++ b/modules/src/ics04_channel/msgs/chan_open_try.rs
@@ -84,6 +84,7 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
             raw_msg.proof_init.into(),
             None,
             None,
+            None,
             raw_msg
                 .proof_height
                 .ok_or(Kind::MissingHeight)?

--- a/modules/src/ics04_channel/msgs/recv_packet.rs
+++ b/modules/src/ics04_channel/msgs/recv_packet.rs
@@ -61,6 +61,7 @@ impl TryFrom<RawMsgRecvPacket> for MsgRecvPacket {
             raw_msg.proof_commitment.into(),
             None,
             None,
+            None,
             raw_msg
                 .proof_height
                 .ok_or(Kind::MissingHeight)?

--- a/modules/src/ics04_channel/msgs/timeout.rs
+++ b/modules/src/ics04_channel/msgs/timeout.rs
@@ -68,6 +68,7 @@ impl TryFrom<RawMsgTimeout> for MsgTimeout {
             raw_msg.proof_unreceived.into(),
             None,
             None,
+            None,
             raw_msg
                 .proof_height
                 .ok_or(Kind::MissingHeight)?

--- a/modules/src/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/ics04_channel/msgs/timeout_on_close.rs
@@ -1,0 +1,110 @@
+use std::convert::{TryFrom, TryInto};
+
+use tendermint::account::Id as AccountId;
+use tendermint_proto::Protobuf;
+
+use ibc_proto::ibc::core::channel::v1::MsgTimeoutOnClose as RawMsgTimeoutOnClose;
+
+use crate::address::{account_to_string, string_to_account};
+use crate::ics04_channel::error::{Error, Kind};
+use crate::ics04_channel::packet::{Packet, Sequence};
+use crate::{proofs::Proofs, tx_msg::Msg};
+
+pub const TYPE_URL: &str = "/ibc.core.channel.v1.MsgTimeoutOnClose";
+
+///
+/// Message definition for packet timeout domain type.
+///
+#[derive(Clone, Debug, PartialEq)]
+pub struct MsgTimeoutOnClose {
+    pub packet: Packet,
+    next_sequence_recv: Sequence,
+    proofs: Proofs,
+    signer: AccountId,
+}
+
+impl MsgTimeoutOnClose {
+    pub fn new(
+        packet: Packet,
+        next_sequence_recv: Sequence,
+        proofs: Proofs,
+        signer: AccountId,
+    ) -> Result<MsgTimeoutOnClose, Error> {
+        Ok(Self {
+            packet,
+            next_sequence_recv,
+            proofs,
+            signer,
+        })
+    }
+}
+
+impl Msg for MsgTimeoutOnClose {
+    type ValidationError = Error;
+
+    fn route(&self) -> String {
+        crate::keys::ROUTER_KEY.to_string()
+    }
+
+    fn type_url(&self) -> String {
+        TYPE_URL.to_string()
+    }
+
+    fn get_signers(&self) -> Vec<AccountId> {
+        vec![self.signer]
+    }
+}
+
+impl Protobuf<RawMsgTimeoutOnClose> for MsgTimeoutOnClose {}
+
+impl TryFrom<RawMsgTimeoutOnClose> for MsgTimeoutOnClose {
+    type Error = anomaly::Error<Kind>;
+
+    fn try_from(raw_msg: RawMsgTimeoutOnClose) -> Result<Self, Self::Error> {
+        let signer =
+            string_to_account(raw_msg.signer).map_err(|e| Kind::InvalidSigner.context(e))?;
+
+        let proofs = Proofs::new(
+            raw_msg.proof_unreceived.into(),
+            None,
+            None,
+            None,
+            raw_msg
+                .proof_height
+                .ok_or(Kind::MissingHeight)?
+                .try_into()
+                .map_err(|e| Kind::InvalidProof.context(e))?,
+        )
+        .map_err(|e| Kind::InvalidProof.context(e))?;
+
+        // TODO: Domain type verification for the next sequence: this should probably be > 0.
+
+        Ok(MsgTimeoutOnClose {
+            packet: raw_msg
+                .packet
+                .ok_or(Kind::MissingPacket)?
+                .try_into()
+                .map_err(|e| Kind::InvalidPacket.context(e))?,
+            next_sequence_recv: Sequence::from(raw_msg.next_sequence_recv),
+            signer,
+            proofs,
+        })
+    }
+}
+
+impl From<MsgTimeoutOnClose> for RawMsgTimeoutOnClose {
+    fn from(domain_msg: MsgTimeoutOnClose) -> Self {
+        RawMsgTimeoutOnClose {
+            packet: Some(domain_msg.packet.into()),
+            proof_unreceived: domain_msg.proofs.object_proof().clone().into(),
+            proof_close: domain_msg
+                .proofs
+                .other_proof
+                .clone()
+                .map_or_else(Vec::new, |v| v.into()),
+            proof_height: Some(domain_msg.proofs.height().into()),
+            next_sequence_recv: domain_msg.next_sequence_recv.into(),
+            signer: account_to_string(domain_msg.signer).unwrap(),
+        }
+    }
+}

--- a/modules/src/ics04_channel/packet.rs
+++ b/modules/src/ics04_channel/packet.rs
@@ -14,6 +14,7 @@ pub enum PacketMsgType {
     Recv,
     Ack,
     Timeout,
+    TimeoutOnClose,
 }
 
 impl std::fmt::Display for PacketMsgType {
@@ -22,6 +23,7 @@ impl std::fmt::Display for PacketMsgType {
             PacketMsgType::Recv => write!(f, "(PacketMsgType::Recv)"),
             PacketMsgType::Ack => write!(f, "(PacketMsgType::Ack)"),
             PacketMsgType::Timeout => write!(f, "(PacketMsgType::Timeout)"),
+            PacketMsgType::TimeoutOnClose => write!(f, "(PacketMsgType::TimeoutOnClose)"),
         }
     }
 }

--- a/modules/src/proofs.rs
+++ b/modules/src/proofs.rs
@@ -11,6 +11,8 @@ pub struct Proofs {
     object_proof: CommitmentProofBytes,
     client_proof: Option<CommitmentProofBytes>,
     consensus_proof: Option<ConsensusProof>,
+    /// Currently used for proof_close for MsgTimeoutOnCLose where object_proof is proof_unreceived
+    pub(crate) other_proof: Option<CommitmentProofBytes>,
     /// Height for the commitment root for proving the proofs above.
     /// When creating these proofs, the chain is queried at `height-1`.
     height: Height,
@@ -21,6 +23,7 @@ impl Proofs {
         object_proof: CommitmentProofBytes,
         client_proof: Option<CommitmentProofBytes>,
         consensus_proof: Option<ConsensusProof>,
+        other_proof: Option<CommitmentProofBytes>,
         height: Height,
     ) -> Result<Self, String> {
         if height.is_zero() {
@@ -35,6 +38,7 @@ impl Proofs {
             object_proof,
             client_proof,
             consensus_proof,
+            other_proof,
             height,
         })
     }

--- a/relayer-cli/relayer_operation_instructions.md
+++ b/relayer-cli/relayer_operation_instructions.md
@@ -242,11 +242,14 @@ make it work:
    - now `make build` and `make install` your local copy of gaia
 
 
-First transfer of 5555 samoleans from `ibc-1` to `ibc-0`. This results in a Tx to `ibc-1` for a `MsgTransfer` packet
+First transfer of 5555 samoleans from `ibc-1` to `ibc-0`. This results in a
+Tx to `ibc-1` for a `MsgTransfer` packet.
+Make sure you're not relaying this packet (the relayer should not be running on
+this path).
 
-    ```shell script
-    rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-1 5555 1000 -n 1 -d samoleans
-    ```
+```shell script
+rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-1 5555 1000 -n 1 -d samoleans
+```
   
 Starting with channel in open-open:
 

--- a/relayer-cli/relayer_operation_instructions.md
+++ b/relayer-cli/relayer_operation_instructions.md
@@ -33,11 +33,19 @@ rm -rf data/
 
 You can use the relayer CLIs, below are some examples.
 
-**Note:** These instructions below assume that the `relayer-cli` binary
+**Note 1:** These instructions below assume that the `relayer-cli` binary
 can be executed as `rrly`, eg. by using an shell alias:
 
 ```shell script
 alias rrly='cargo run --bin relayer --'
+```
+
+**Note 2:** In these instructions IDs `..-0` are used on `ibc-0` and `..-1` on `ibc-1`. You can control to some extent the ID generation by running some of these commands:
+```shell script
+rrly -c loop_config.toml tx raw create-client ibc-1 ibc-0
+rrly -c loop_config.toml tx raw conn-init ibc-1 ibc-0 07-tendermint-0 07-tendermint-0 dummyconnection dummyconnection
+rrly -c loop_config.toml tx raw chan-open-init ibc-1 ibc-0 connection-0 transfer transfer defaultChannel defaultChannel
+
 ```
 
 #### Client CLIs:
@@ -64,7 +72,7 @@ alias rrly='cargo run --bin relayer --'
 - init-none:
 
     ```shell script
-    rrly -c loop_config.toml tx raw conn-init ibc-0 ibc-1 07-tendermint-0 07-tendermint-0 dummyconnection dummyconnection
+    rrly -c loop_config.toml tx raw conn-init ibc-0 ibc-1 07-tendermint-0 07-tendermint-1 dummyconnection dummyconnection
     ```
 
     Take note of the ID allocated by the chain, e.g. `connection-0` on `ibc-0`. Use in the `conn-try` CLI
@@ -72,27 +80,27 @@ alias rrly='cargo run --bin relayer --'
 - init-try:
 
     ```shell script
-    rrly -c loop_config.toml tx raw conn-try ibc-1 ibc-0 07-tendermint-0 07-tendermint-0 dummyconnection connection-0
+    rrly -c loop_config.toml tx raw conn-try ibc-1 ibc-0 07-tendermint-1 07-tendermint-0 dummyconnection connection-0
     ```
 
-    Take note of the ID allocated by the chain, e.g. `connection-0` on `ibc-1`. Use in the `conn-ack` CLI
+    Take note of the ID allocated by the chain, e.g. `connection-1` on `ibc-1`. Use in the `conn-ack` CLI
 
 - open-try:
 
     ```shell script
-    rrly -c loop_config.toml tx raw conn-ack ibc-0 ibc-1 07-tendermint-0 07-tendermint-0 connection-0 connection-0
+    rrly -c loop_config.toml tx raw conn-ack ibc-0 ibc-1 07-tendermint-0 07-tendermint-1 connection-0 connection-1
     ```
 
 - open-open:
 
     ```shell script
-    rrly -c loop_config.toml tx raw conn-confirm ibc-1 ibc-0 07-tendermint-0 07-tendermint-0 connection-0 connection-0
+    rrly -c loop_config.toml tx raw conn-confirm ibc-1 ibc-0 07-tendermint-1 07-tendermint-0 connection-1 connection-0
     ```
 
 - verify that the two ends are in Open state:
 
     ```shell script
-    rrly -c loop_config.toml query connection end ibc-1 connection-0
+    rrly -c loop_config.toml query connection end ibc-1 connection-1
     rrly -c loop_config.toml query connection end ibc-0 connection-0
     ```
 
@@ -106,25 +114,25 @@ alias rrly='cargo run --bin relayer --'
 - init-try
 
     ```shell script
-    rrly -c loop_config.toml tx raw chan-open-try ibc-1 ibc-0 connection-0 transfer transfer defaultChannel channel-0
+    rrly -c loop_config.toml tx raw chan-open-try ibc-1 ibc-0 connection-1 transfer transfer defaultChannel channel-0
     ```
 
 - open-try
 
     ```shell script
-    rrly -c loop_config.toml tx raw chan-open-ack ibc-0 ibc-1 connection-0 transfer transfer channel-0 channel-0
+    rrly -c loop_config.toml tx raw chan-open-ack ibc-0 ibc-1 connection-0 transfer transfer channel-0 channel-1
     ```
 - open-open
 
     ```shell script
-    rrly -c loop_config.toml tx raw chan-open-confirm ibc-1 ibc-0 connection-0 transfer transfer channel-0 channel-0
+    rrly -c loop_config.toml tx raw chan-open-confirm ibc-1 ibc-0 connection-1 transfer transfer channel-1 channel-0
     ```
 
 - verify that the two ends are in Open state:
 
     ```shell script
     rrly -c loop_config.toml query channel end ibc-0 transfer channel-0
-    rrly -c loop_config.toml query channel end ibc-1 transfer channel-0
+    rrly -c loop_config.toml query channel end ibc-1 transfer channel-1
     ```
 
 #### Query balances:
@@ -153,6 +161,12 @@ First, we'll send 9999 samoleans from `ibc-0` to `ibc-1`.
     rrly -c loop_config.toml tx raw packet-send ibc-0 ibc-1 transfer channel-0 9999 1000 -n 1 -d samoleans
     ```
 
+- query packet commitments on ibc-0
+
+    ```shell script
+    rrly -c loop_config.toml query packet commitments ibc-0 transfer channel-0
+    ```
+
 - query unreceived packets on ibc-1
 
     ```shell script
@@ -168,13 +182,13 @@ First, we'll send 9999 samoleans from `ibc-0` to `ibc-1`.
 - query unreceived acks on ibc-0
 
     ```shell script
-    rrly -c loop_config.toml query packet unreceived-acks ibc-0 ibc-1 transfer channel-0
+    rrly -c loop_config.toml query packet unreceived-acks ibc-0 ibc-1 transfer channel-1
     ```
 
 - send acknowledgement to ibc-0
 
     ```shell script
-    rrly -c loop_config.toml tx raw packet-ack  ibc-0 ibc-1 transfer channel-0
+    rrly -c loop_config.toml tx raw packet-ack  ibc-0 ibc-1 transfer channel-1
     ```
 
 - send 1 packet with low timeout height offset to ibc-0
@@ -192,12 +206,12 @@ First, we'll send 9999 samoleans from `ibc-0` to `ibc-1`.
 Send those samoleans back, from `ibc-1` to `ibc-1`.
 
 ```shell script
-rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-0 9999 1000 -n 1 -d ibc/27A6394C3F9FF9C9DCF5DFFADF9BB5FE9A37C7E92B006199894CF1824DF9AC7C
-rrly -c loop_config.toml tx raw packet-recv ibc-0 ibc-1 transfer channel-0
+rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-1 9999 1000 -n 1 -d ibc/C1840BD16FCFA8F421DAA0DAAB08B9C323FC7685D0D7951DC37B3F9ECB08A199
+rrly -c loop_config.toml tx raw packet-recv ibc-0 ibc-1 transfer channel-1
 rrly -c loop_config.toml tx raw packet-ack  ibc-1 ibc-0 transfer channel-0
 ```
 
-The `ibc/27A6394C3F9FF9C9DCF5DFFADF9BB5FE9A37C7E92B006199894CF1824DF9AC7C` denominator above can be obtained by querying the balance at `ibc-1` after the transfer from `ibc-0` to `ibc-1` is concluded.
+The `ibc/C1840BD16FCFA8F421DAA0DAAB08B9C323FC7685D0D7951DC37B3F9ECB08A199` denominator above can be obtained by querying the balance at `ibc-1` after the transfer from `ibc-0` to `ibc-1` is concluded.
 
 #### Channel Close CLIs:
 
@@ -227,25 +241,38 @@ make it work:
 
    - now `make build` and `make install` your local copy of gaia
 
+
+First transfer of 5555 samoleans from `ibc-1` to `ibc-0`. This results in a Tx to `ibc-1` for a `MsgTransfer` packet
+
+    ```shell script
+    rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-1 5555 1000 -n 1 -d samoleans
+    ```
+  
 Starting with channel in open-open:
 
 - close-open
 
     ```shell script
-    rrly -c loop_config.toml tx raw chan-close-init ibc-0 ibc-1 connection-0 transfer transfer channel-0 channel-0
+    rrly -c loop_config.toml tx raw chan-close-init ibc-0 ibc-1 connection-0 transfer transfer channel-0 channel-1
+    ```
+
+- trigger timeout on close to ibc-1
+
+    ```shell script
+    rrly -c loop_config.toml tx raw packet-recv ibc-0 ibc-1 transfer channel-1
     ```
 
 - close-close
 
     ```shell script
-    rrly -c loop_config.toml tx raw chan-close-confirm ibc-1 ibc-0 connection-0 transfer transfer channel-0 channel-0
+    rrly -c loop_config.toml tx raw chan-close-confirm ibc-1 ibc-0 connection-1 transfer transfer channel-1 channel-0
     ```
 
 - verify that the two ends are in Close state:
 
   ```shell script
   rrly -c loop_config.toml query channel end ibc-0 transfer channel-0
-  rrly -c loop_config.toml query channel end ibc-1 transfer channel-0
+  rrly -c loop_config.toml query channel end ibc-1 transfer channel-1
   ```
 
 ### Relayer loop:
@@ -284,10 +311,10 @@ the relayer `v0` loop.
     ```shell script
     rrly -c loop_config.toml tx raw packet-send ibc-0 ibc-1 transfer channel-0 9999 1000 -n 2
     ```
-- use the CLI to send 2 packets to ibc0 chain:
+- use the CLI to send 2 packets to ibc1 chain:
 
     ```shell script
-    rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-0 9999 1000 -n 2
+    rrly -c loop_config.toml tx raw packet-send ibc-1 ibc-0 transfer channel-1 9999 1000 -n 2
     ```
 
 - observe the output on the relayer terminal, verify that the send events are processed and the recv_packets are sent out.
@@ -296,8 +323,8 @@ the relayer `v0` loop.
 
     ```shell script
     rrly -c loop_config.toml query packet unreceived-packets ibc-1 ibc-0  transfer channel-0
-    rrly -c loop_config.toml query packet unreceived-acks ibc-0 ibc-1 transfer channel-0
-    rrly -c loop_config.toml query packet unreceived-packets ibc-0 ibc-1  transfer channel-0
+    rrly -c loop_config.toml query packet unreceived-acks ibc-0 ibc-1 transfer channel-1
+    rrly -c loop_config.toml query packet unreceived-packets ibc-0 ibc-1  transfer channel-1
     rrly -c loop_config.toml query packet unreceived-acks ibc-1 ibc-0 transfer channel-0
     ```
 

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -185,14 +185,14 @@ pub struct QueryUnreceivedPacketsCmd {
         required,
         help = "identifier of the port to query on source chain"
     )]
-    port_id: PortId,
+    src_port_id: PortId,
 
     #[options(
         free,
         required,
         help = "identifier of the channel to query on source chain"
     )]
-    channel_id: ChannelId,
+    src_channel_id: ChannelId,
 }
 
 impl QueryUnreceivedPacketsCmd {
@@ -209,8 +209,8 @@ impl QueryUnreceivedPacketsCmd {
             .ok_or_else(|| format!("missing configuration for chain ({}) ", self.dst_chain_id))?;
 
         let opts = QueryPacketOptions {
-            port_id: self.port_id.clone(),
-            channel_id: self.channel_id.clone(),
+            port_id: self.src_port_id.clone(),
+            channel_id: self.src_channel_id.clone(),
             height: 0_u64,
         };
 
@@ -483,14 +483,14 @@ pub struct QueryUnreceivedAcknowledgementCmd {
         required,
         help = "identifier of the port to query on source chain"
     )]
-    port_id: PortId,
+    src_port_id: PortId,
 
     #[options(
         free,
         required,
         help = "identifier of the channel to query on source chain"
     )]
-    channel_id: ChannelId,
+    src_channel_id: ChannelId,
 }
 
 impl QueryUnreceivedAcknowledgementCmd {
@@ -507,8 +507,8 @@ impl QueryUnreceivedAcknowledgementCmd {
             .ok_or_else(|| format!("missing configuration for chain ({}) ", self.dst_chain_id))?;
 
         let opts = QueryPacketOptions {
-            port_id: self.port_id.clone(),
-            channel_id: self.channel_id.clone(),
+            port_id: self.src_port_id.clone(),
+            channel_id: self.src_channel_id.clone(),
             height: 0_u64,
         };
 

--- a/relayer-cli/src/commands/tx/packet.rs
+++ b/relayer-cli/src/commands/tx/packet.rs
@@ -11,11 +11,11 @@ use crate::prelude::*;
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct TxRawPacketRecvCmd {
-    #[options(free, required, help = "identifier of the source chain")]
-    src_chain_id: ChainId,
-
     #[options(free, required, help = "identifier of the destination chain")]
     dst_chain_id: ChainId,
+
+    #[options(free, required, help = "identifier of the source chain")]
+    src_chain_id: ChainId,
 
     #[options(free, required, help = "identifier of the source port")]
     src_port_id: PortId,
@@ -55,11 +55,11 @@ impl Runnable for TxRawPacketRecvCmd {
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct TxRawPacketAckCmd {
-    #[options(free, required, help = "identifier of the source chain")]
-    src_chain_id: ChainId,
-
     #[options(free, required, help = "identifier of the destination chain")]
     dst_chain_id: ChainId,
+
+    #[options(free, required, help = "identifier of the source chain")]
+    src_chain_id: ChainId,
 
     #[options(free, required, help = "identifier of the source port")]
     src_port_id: PortId,

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -586,7 +586,7 @@ impl Chain for CosmosSDKChain {
         Ok((pc, height))
     }
 
-    /// Queries the packet commitment hashes associated with a channel.
+    /// Queries the unreceived packet sequences associated with a channel.
     fn query_unreceived_packets(
         &self,
         request: QueryUnreceivedPacketsRequest,
@@ -644,7 +644,7 @@ impl Chain for CosmosSDKChain {
         Ok((pc, height))
     }
 
-    /// Queries the packet commitment hashes associated with a channel.
+    /// Queries the unreceived acknowledgements sequences associated with a channel.
     fn query_unreceived_acknowledgements(
         &self,
         request: QueryUnreceivedAcksRequest,


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #563

## Description
- Added `MsgTimeoutOnClose`
- Check destination channel state in `link.rs` and send `MsgTimeoutOnClose` to source instead of `MsgRecvPacket` to destination
- Fixed parameter order in `packet-recv` and `packet-ack`
- Updated relayer operation instructions to to use different IDs for the different chains so it is more clear which ID goes in which pozition.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.