### PR TITLE
Unambiguous packet query

### DIFF
--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -324,6 +324,8 @@ pub struct QueryPacketEventDataRequest {
     pub event_id: IBCEventType,
     pub source_channel_id: ChannelId,
     pub source_port_id: PortId,
+    pub destination_channel_id: ChannelId,
+    pub destination_port_id: PortId,
     pub sequences: Vec<Sequence>,
     pub height: Height,
 }

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -826,6 +826,14 @@ fn packet_query(request: &QueryPacketEventDataRequest, seq: &Sequence) -> Result
         request.source_port_id.to_string(),
     )
     .and_eq(
+        format!("{}.packet_dst_channel", request.event_id.as_str()),
+        request.destination_channel_id.to_string(),
+    )
+    .and_eq(
+        format!("{}.packet_dst_port", request.event_id.as_str()),
+        request.destination_port_id.to_string(),
+    )
+    .and_eq(
         format!("{}.packet_sequence", request.event_id.as_str()),
         seq.to_string(),
     ))
@@ -840,6 +848,7 @@ fn packet_from_tx_search_response(
     seq: Sequence,
     response: &tendermint_rpc::endpoint::tx_search::Response,
 ) -> Result<Option<IBCEvent>, Error> {
+    // TODO: remove loop as `response.txs.len() <= 1`
     for r in response.txs.iter() {
         let height = r.height;
         if height.value() > request.height.revision_height {
@@ -869,6 +878,8 @@ fn packet_from_tx_search_response(
             let packet = packet.unwrap();
             if packet.source_port != request.source_port_id
                 || packet.source_channel != request.source_channel_id
+                || packet.destination_port != request.destination_port_id
+                || packet.destination_channel != request.destination_channel_id
                 || packet.sequence != seq
             {
                 continue;

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -372,6 +372,8 @@ impl RelayPath {
             event_id: IBCEventType::SendPacket,
             source_port_id: self.src_port_id().clone(),
             source_channel_id: self.src_channel_id().clone(),
+            destination_port_id: self.dst_port_id().clone(),
+            destination_channel_id: self.dst_channel_id().clone(),
             sequences,
             height: self.src_height,
         })?;
@@ -442,6 +444,8 @@ impl RelayPath {
                 event_id: IBCEventType::WriteAck,
                 source_port_id: self.dst_port_id().clone(),
                 source_channel_id: self.dst_channel_id().clone(),
+                destination_port_id: self.src_port_id().clone(),
+                destination_channel_id: self.src_channel_id().clone(),
                 sequences,
                 height: query_height,
             })


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #614

## Description

Before, a `query_txs` for a packet on a given chain would filter only by the packet source port, source channel and sequence.
With 2 chains, there can be at most a single packet matching such filter, and this fact was assumed in the code.

However, this assumption does not hold with more than 2 chains. To understand why, consider the following example with chains `ibc-0`, `ibc-1` and `ibc-2`:
- a channel handshake occurs between `ibc-0` and `ibc-1`; the channel identifiers are `channel-0` on both ends
- a channel handshake occurs between `ibc-1` and `ibc-2`; the channel identifier on `ibc-1` is `channel-1` and on `ibc-2` is `channel-0`

If now both `ibc-0` and `ibc-2` send packets to `ibc-1` and we do a packet query filtering only by the source, such query will return
packets from both `ibc-0` and `ibc-1` (as both have `channel-0` as the source channel in their packets).

In this commit, we start filtering also by the destination port and destination channel. This makes the packet query unambiguous.

Thanks @ancazamfir for the help debugging this issue. It was a fun one!

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.