### PR TITLE
Fix panic in conn open try when no connection id is provided

### DIFF
--- a/modules/src/ics03_connection/context.rs
+++ b/modules/src/ics03_connection/context.rs
@@ -72,14 +72,14 @@ pub trait ConnectionKeeper {
                 )?;
             }
             State::TryOpen => {
-                self.store_connection(
-                    &result.connection_id.clone().unwrap(),
-                    &result.connection_end,
-                )?;
+                let connection_id = result
+                    .connection_id
+                    .unwrap_or_else(|| self.next_connection_id());
+                self.store_connection(&connection_id, &result.connection_end)?;
                 // If this is the first time the handler processed this connection, associate the
                 // connection end to its client identifier.
                 self.store_connection_to_client(
-                    &result.connection_id.clone().unwrap(),
+                    &connection_id,
                     &result.connection_end.client_id(),
                 )?;
             }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description


Currently, a conn open try can only succeed if some `previous_connection_id` is provided in the `MsgConnectionOpenTry`:
https://github.com/informalsystems/ibc-rs/blob/b1b9dac6132a2fd2a86fa1c6f0179f47db3e3454/modules/src/ics03_connection/msgs/conn_open_try.rs#L26-L35
However, to have a valid `previous_connection_id`, one has to have a successful conn open try. This circular dependency makes it so that it's never possible to have successful conn open try.

This issue was found during the MBT work (#601). I tried to add a regression test but didn't find an easy way to do it. The best candidate was the `routing_module_and_keepers` test in `ics26_routing/handler.rs`: https://github.com/informalsystems/ibc-rs/blob/b1b9dac6132a2fd2a86fa1c6f0179f47db3e3454/modules/src/ics26_routing/handler.rs#L152-L316

There's a single chain here, which I think means it's not possible to have a successful conn open try. I've also noticed that the tests here don't check that the returned error matches the expected error. This is done in the `IBCTestExecutor` introduced in #601. Maybe at some point it will be possible to reuse this test executor to write these simple unit tests.


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.