### PR TITLE
Explicit assumptions in packet_from_tx_search_response 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-[comment]: <> (## Unreleased Changes)
+## Unreleased Changes
+
+### BUG FIXES:
+
+- [relayer-cli]
+  - Fix wrong acks sent with `tx raw packet-ack` in a 3-chain setup ([#614])
+
+[#614]: https://github.com/informalsystems/ibc-rs/issues/614
 
 ## v0.1.0
 *February 4, 2021*

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -864,11 +864,9 @@ fn packet_from_tx_search_response(
 
         let mut matching = Vec::new();
         for e in r.tx_result.events {
-            assert_eq!(
-                e.type_str,
-                request.event_id.as_str(),
-                "packet_from_tx_search_response: unexpected event type"
-            );
+            if e.type_str != request.event_id.as_str() {
+                continue;
+            }
 
             let res = ChannelEvents::try_from_tx(&e);
             if res.is_none() {

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -841,12 +841,12 @@ fn packet_query(request: &QueryPacketEventDataRequest, seq: &Sequence) -> Result
 }
 
 // Extract the packet events from the query_txs RPC response. For any given
-// packet query, there is at most one Tx matching such query. However, a single
-// Tx may contain several events, and a single one must match the packet query.
+// packet query, there is at most one Tx matching such query. Moreover, a Tx may
+// contain several events, but a single one must match the packet query.
 // For example, if we're querying for the packet with sequence 3 and this packet
-// was committed a some Tx along with the packet with sequence 4, the response
-// will include both packets. For this reason, we iterate all packets in the Tx
-// until the one we're looking for is found.
+// was committed in some Tx along with the packet with sequence 4, the response
+// will include both packets. For this reason, we iterate all packets in the Tx,
+// searching for those that match (which must be a single one).
 fn packet_from_tx_search_response(
     request: &QueryPacketEventDataRequest,
     seq: Sequence,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

This PR makes the following two assumptions from `packet_from_tx_search_response` explicit:
- the number of returned transactions is at most 1
- if a transaction is returned, then there's exactly 1 transaction event matching the packet query

To make the second assumption explicit, it's required that we iterate all transactions events, which may come with a performance cost. To alleviate this, we're now only trying to parse channel events with `ChannelEvents::try_from_tx(&e)` instead of the more general `from_tx_response_event(e)`.

This is a follow-up to #613.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.