### PR TITLE
Process ChanCloseInit in relayer loop (start command)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,53 @@
 # Changelog
 
-[comment]: <> (## Unreleased Changes)
+## Unreleased Changes
 
 ### FEATURES
 
 - <high level summary>
 
-- [modules]
+- [ibc]
   -
 
-- [relayer]
+- [ibc-relayer]
   - Listen to channel close initialization event and perform the close handshake ([#560])
 
-- [relayer-cli]
+- [ibc-relayer-cli]
   -
 
 ### IMPROVEMENTS
 
 - <high level summary>
 
-- [modules]
+- [ibc]
   -
 
-- [relayer]
+- [ibc-relayer]
   -
 
-- [relayer-cli]
+- [ibc-relayer-cli]
   -
 
 ### BUG FIXES:
 
-- [modules]
+- [ibc]
   -
 
-- [relayer]
+- [ibc-relayer]
   -
 
-- [relayer-cli]
+- [ibc-relayer-cli]
   -
 
 ### BREAKING CHANGES:
 
-- [modules]
+- [ibc]
   -
 
-- [relayer]
+- [ibc-relayer]
   -
 
-- [relayer-cli]
+- [ibc-relayer-cli]
 
 [#593]: https://github.com/informalsystems/ibc-rs/issues/560
 
@@ -70,7 +70,7 @@ Noteworthy changes in this release include:
 - Continous Integration (CI) end-to-end (e2e) testing with gaia v4 ([#32], [#582], [#602])
 - Add support for streamlining releases ([#507])
 
-- [relayer-cli]
+- [ibc-relayer-cli]
   - Implement command to query the channels associated with a connection ([#505])
   - JSON output for queries and txs ([#500])
   - Added 'required' annotation for CLIs queries & txs; better error display ([#555])
@@ -82,11 +82,11 @@ Noteworthy changes in this release include:
   - Added a relayer binary guide ([#542])
   - Split the dev-env script in `setup_chains` and `init_clients` ([#577])
 
-- [relayer]
+- [ibc-relayer]
   - Added retry mechanism, restructured relayer ([#519])
   - Relay `MsgTimeoutOnClose` if counterparty channel state is `State::Closed`
 
-- [modules]
+- [ibc]
   - Add `MsgTimeoutOnClose` message type ([#563])
   - Implement `MsgChannelOpenTry` message handler ([#543])
 
@@ -95,31 +95,31 @@ Noteworthy changes in this release include:
 - Update to `tendermint-rs` v0.18.0 ([#517], [#583])
 - Update to `tokio` 1.0, `prost` 0.7 and `tonic` 0.4 ([#527])
 
-- [relayer-cli]
+- [ibc-relayer-cli]
   - Replace `ChannelConfig` in `Channel::new` ([#511])
   - Add `packet-send` CLI ([#470])
   - UX improvements for relayer txs ([#536], [#540], [#554])
   - Allow running standalone commands concurrently to the main relayer loop ([#501])
   - Remove the simd-based integration tests ([#593])
 
-- [relayer]
+- [ibc-relayer]
   - Performance improvements ([#514], [#537])
   - Fix for mismatching `bitcoin` dep ([#525])
 
-- [modules]
+- [ibc]
   - Clean the `validate_basic` method ([#94])
   - `MsgConnectionOpenAck` testing improvements ([#306])
 
 ### BUG FIXES:
-- [relayer-cli]
+- [ibc-relayer-cli]
   - Help and usage commands show 'hermes' for executable name ([#590])
 
-- [modules]
+- [ibc]
   - Fix for storing `ClientType` upon 'create-client' ([#513])
 
 ### BREAKING CHANGES:
 
-- [modules]
+- [ibc]
   - The `ibc::handler::Event` is removed and handlers now produce `ibc::events::IBCEvent`s ([#535])
 
 [#32]: https://github.com/informalsystems/ibc-rs/issues/32
@@ -169,14 +169,14 @@ the latest cosmos proto versions from `v0.40.0-rc5` (sometimes called 'stargate-
 - Update to tendermint-rs version `0.17` ([#451])
 - Update to cosmos-sdk IBC proto version `v0.40.0-rc5` ([#451])
 
-- [relayer]
+- [ibc-relayer]
  
-- [relayer-cli]
+- [ibc-relayer-cli]
   - Packet CLIs for recv_packet ([#443])
   - Packet CLIs for acknowledging packets ([#468])
 
 ### IMPROVEMENTS
-- [relayer]
+- [ibc-relayer]
   - Mock chain (implementing IBC handlers) and integration against CLI ([#158])
   - Relayer tests for client update (ping pong) against MockChain ([#381])
   - Relayer refactor to improve testing and add semantic dependencies ([#447]) 
@@ -199,7 +199,7 @@ We also consolidated our TLA+ specs into an "IBC Core TLA+ specification," and a
 
 Special thanks to external contributors for this release: @CharlyCst ([#347], [#419]).
 
-- [relayer-cli]
+- [ibc-relayer-cli]
   - Add `--all` option to `light rm` command to remove all peers for a given chain ([#431])
 
 [#431]: https://github.com/informalsystems/ibc-rs/issues/431
@@ -208,18 +208,18 @@ Special thanks to external contributors for this release: @CharlyCst ([#347], [#
 
 - Update to tendermint-rs version `0.17-RC3` ([#403])
 - [changelog] Added "unreleased" section in `CHANGELOG.MD` to help streamline releases ([#274])
-- [modules]
+- [ibc]
     - Implement flexible connection id selection ([#332])
     - ICS 4 Domain Types for channel handshakes and packets ([#315], [#95])
     - Introduce LightBlock support for MockContext ([#389])
-- [relayer]
+- [ibc-relayer]
     - Retrieve account sequence information from a chain using a GRPC client (#337)
     - Implementation of chain runtime for v0 ([#330])
-    - Integrate relayer spike into relayer crate ([#335])
+    - Integrate relayer spike into ibc-relayer crate ([#335])
     - Implement `query_header_at_height` via plain RPC queries (no light client verification) ([#336])
     - Implement the relayer logic for connection handshake messages ([#358], [#359], [#360])
     - Implement the relayer logic for channel handshake messages ([#371], [#372], [#373], [#374])
-- [relayer-cli]
+- [ibc-relayer-cli]
     - Merge light clients config in relayer config and add commands to add/remove light clients ([#348])
     - CLI for client update message ([#277])
     - Implement the relayer CLI for connection handshake messages ([#358], [#359], [#360])
@@ -231,18 +231,18 @@ Special thanks to external contributors for this release: @CharlyCst ([#347], [#
     - Refactor and allow specifying a commit at which the Cosmos SDK should be checked out ([#366])
     - Add a `--tag` option to the `clone-sdk` command to check out a tag instead of a commit ([#369])
     - Fix `--out` command line parameter (instead of `--path`) ([#419])
-- [spec/relayer]
+- [ibc/relayer-spec]
     - ICS 020 spec in TLA+ ([#386])
     - Prepare IBC Core TLA+ specs ([#404])
 
 ### IMPROVEMENTS
 
-- [relayer]
+- [ibc-relayer]
     - Pin chain runtime against Tokio 0.2 by downgrading for 0.3 to avoid dependency hell ([#415], follow up to [#402])
-- [relayer-cli]
+- [ibc-relayer-cli]
     - Split tasks spawned by CLI commands into their own modules ([#331])
     - V0 command implementation ([#346])
-- [modules]
+- [ibc]
     - Split `msgs.rs` of ICS002 in separate modules ([#367])
     - Fixed inconsistent versioning for ICS003 and ICS004 ([#97])
     - Fixed `get_sign_bytes` method for messages ([#98])
@@ -303,41 +303,41 @@ Additional highlights:
 - Also added support for packet handling in the relayer algorithm specifications.
 
 ### BREAKING CHANGES:
-- [relayer] & [modules] Alignment with ecosystem updates:
+- [ibc-relayer] & [ibc] Alignment with ecosystem updates:
     - Compatibility with the latest protobuf (Gaia stargate-3 and stargate-4) ([#191], [#272], [#273], [#278]) 
     - Adaptations to tendermint 0.17 ([#286], [#293], [#300], [#302], [#308])
-- [relayer] UX improvement: Remove proof option from client connections command ([#205])
+- [ibc-relayer] UX improvement: Remove proof option from client connections command ([#205])
 
 ### FEATURES:
-- [modules/ics03] ICS03 Ack and Confirm message processors ([#223])
-- [relayer-cli]
+- [ibc/ics03] ICS03 Ack and Confirm message processors ([#223])
+- [ibc-relayer-cli]
     - Relayer CLIs for client messages ([#207])
     - Relayer CLIs for connection-open-init ([#206])
     - Queries for consensus state and client state ([#149], [#150])
-- [modules] Routing module minimal implementation for MVP ([#159], [#232])
-- [spec/relayer] Relayer specification for packet handling ([#229], [#234], [#237])
-- [spec/relayer] Basic packet handling in TLA+([#124])
-- [modules] Basic relayer functionality: a test with ClientUpdate ping-pong between two mocked chains ([#276])
+- [ibc] Routing module minimal implementation for MVP ([#159], [#232])
+- [ibc/relayer-spec] Relayer specification for packet handling ([#229], [#234], [#237])
+- [ibc/relayer-spec] Basic packet handling in TLA+([#124])
+- [ibc] Basic relayer functionality: a test with ClientUpdate ping-pong between two mocked chains ([#276])
 
 ### IMPROVEMENTS:
-- [modules] Implemented the `DomainType` trait for IBC proto structures ([#245], [#249]).
-- [modules] & [ibc-proto] Several improvements to message processors, among which ([#218]):
+- [ibc] Implemented the `DomainType` trait for IBC proto structures ([#245], [#249]).
+- [ibc] & [ibc-proto] Several improvements to message processors, among which ([#218]):
     - ICS03 connection handshake protocol initial implementation and tests ([#160])
     - Add capability to decode from protobuf Any* type into Tendermint and Mock client states 
     - Cleanup Any* client wrappers related code
     - Migrate handlers to newer protobuf definitions ([#226])
     - Extend client context mock ([#221])
     - Context mock simplifications and cleanup ([#269], [#295], [#296], [#297])
-- [modules/ics03] Split `msgs.rs` in multiple files, implement `From` for all messages ([#253])
+- [ibc/ics03] Split `msgs.rs` in multiple files, implement `From` for all messages ([#253])
 - [ibc-proto]
     - Move ibc-proto source code into ibc-rs ([#142]) and fixed code deduplication ([#282], [#284])
     - Consolidate proto-compiler logic [#241]
-- [spec/relayer] Add support for APALACHE to the Relayer TLA+ spec ([#165])
-- [relayer] Update to tendermint v.0.16 and integrate with the new light client implementation ([#90], [#243])
+- [ibc/relayer-spec] Add support for APALACHE to the Relayer TLA+ spec ([#165])
+- [ibc-relayer] Update to tendermint v.0.16 and integrate with the new light client implementation ([#90], [#243])
 
 ### BUG FIXES:
-- [modules] Removed "Uninitialized" state from connection ([#217])
-- [relayer-cli] Fix for client query subcommands ([#231])
+- [ibc] Removed "Uninitialized" state from connection ([#217])
+- [ibc-relayer-cli] Fix for client query subcommands ([#231])
 - [disclosure-log] & [spec/connection-handshake] Disclosed bugs in ICS3 version negotiation and proposed a fix ([#209], [#213])
 
 [#90]: https://github.com/informalsystems/ibc-rs/issues/90
@@ -387,7 +387,7 @@ Additional highlights:
 [ibc-proto]: https://github.com/informalsystems/ibc-rs/tree/master/proto
 [disclosure-log]: https://github.com/informalsystems/ibc-rs/blob/master/docs/disclosure-log.md
 [spec/connection-handshake]: https://github.com/informalsystems/ibc-rs/tree/master/docs/spec/connection-handshake
-[relayer]: https://github.com/informalsystems/ibc-rs/tree/master/relayer
+[ibc-relayer]: https://github.com/informalsystems/ibc-rs/tree/master/relayer
 
 ## v0.0.3
 *September 1, 2020*
@@ -396,53 +396,53 @@ This release focuses on the IBC message processor framework and initial
 implementations in ICS02 and ICS07. It also introduces an initial specification for the relayer algorithm.
 
 Other highlights:
-- The modules crate is published as [ibc](https://crates.io/crates/ibc) in crates.io
+- The ibc crate is published as [ibc](https://crates.io/crates/ibc) in crates.io
 - ADR-001 and ADR-003 are complete. 🎉
 
 ### BREAKING CHANGES:
-- [modules] Renamed `modules` crate to `ibc` crate. Version number for the new crate is not reset. ([#198])
-- [modules/ics02] `ConnectionId`s are now decoded to `Vec<ConnectionId>` and validated instead of `Vec<String>` ([#185])
-- [modules/ics03] Removed `Connection` and `ConnectionCounterparty` traits ([#193])
-- [modules/ics04] Removed `Channel` and `ChannelCounterparty` traits ([#192])
+- [ibc] Renamed `modules` crate to `ibc` crate. Version number for the new crate is not reset. ([#198])
+- [ibc/ics02] `ConnectionId`s are now decoded to `Vec<ConnectionId>` and validated instead of `Vec<String>` ([#185])
+- [ibc/ics03] Removed `Connection` and `ConnectionCounterparty` traits ([#193])
+- [ibc/ics04] Removed `Channel` and `ChannelCounterparty` traits ([#192])
 
 ### FEATURES:
-- [modules/ics02] partial implementation of message handler ([#119], [#194])
-- [modules/ics07] partial implementation of message handler ([#119], [#194])
+- [ibc/ics02] partial implementation of message handler ([#119], [#194])
+- [ibc/ics07] partial implementation of message handler ([#119], [#194])
 - [architecture/ADR-003] Proposal for IBC handler (message processor) architecture ([#119], [#194])
-- [spec/relayer] Detailed technical specification of the relayer algorithm with focus on client update ([#84])
+- [ibc/relayer-spec] Detailed technical specification of the relayer algorithm with focus on client update ([#84])
 - [architecture/ADR-001] Documentation for the repository structure ([#1])
 - [architecture/FSM-1] Connection Handshake FSM English description ([#122])
 
 ### IMPROVEMENTS:
 - [contributing] Updated CONTRIBUTING.md. Please read before opening PRs ([#195])
-- [relayer-cli] Refactor ConnectionId decoding in `query client` ([#185])
+- [ibc-relayer-cli] Refactor ConnectionId decoding in `query client` ([#185])
 
 ### BUG FIXES:
-- [modules/ics24] Identifiers limit update according to ICS specs ([#168])
+- [ibc/ics24] Identifiers limit update according to ICS specs ([#168])
 
-[spec/relayer]: https://github.com/informalsystems/ibc-rs/blob/master/docs/spec/relayer/Relayer.md
+[ibc/relayer-spec]: https://github.com/informalsystems/ibc-rs/blob/master/docs/spec/relayer/Relayer.md
 [#84]: https://github.com/informalsystems/ibc-rs/issues/84
 [architecture/ADR-001]: https://github.com/informalsystems/ibc-rs/blob/master/docs/architecture/adr-001-repo.md
 [#1]: https://github.com/informalsystems/ibc-rs/issues/1
 [contributing]: https://github.com/informalsystems/ibc-rs/blob/master/CONTRIBUTING.md
 [#195]: https://github.com/informalsystems/ibc-rs/pull/195
-[modules]: https://github.com/informalsystems/ibc-rs/tree/master/modules
+[ibc]: https://github.com/informalsystems/ibc-rs/tree/master/modules
 [#198]: https://github.com/informalsystems/ibc-rs/issues/198
-[modules/ics02]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics02_client
+[ibc/ics02]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics02_client
 [#185]: https://github.com/informalsystems/ibc-rs/issues/185
-[modules/ics03]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics03_connection
+[ibc/ics03]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics03_connection
 [#193]: https://github.com/informalsystems/ibc-rs/issues/193
-[modules/ics04]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics04_channel
+[ibc/ics04]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics04_channel
 [#192]: https://github.com/informalsystems/ibc-rs/issues/192
-[relayer-cli]: https://github.com/informalsystems/ibc-rs/tree/master/relayer-cli
+[ibc-relayer-cli]: https://github.com/informalsystems/ibc-rs/tree/master/relayer-cli
 [architecture/FSM-1]: https://github.com/informalsystems/ibc-rs/blob/master/docs/architecture/fsm-async-connection.md
 [#122]: https://github.com/informalsystems/ibc-rs/issues/122
 [architecture/ADR-003]: https://github.com/informalsystems/ibc-rs/blob/master/docs/architecture/adr-003-handler-implementation.md
 [#119]: https://github.com/informalsystems/ibc-rs/issues/119
 [#194]: https://github.com/informalsystems/ibc-rs/issues/194
-[modules/ics24]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics24_host
+[ibc/ics24]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics24_host
 [#168]: https://github.com/informalsystems/ibc-rs/issues/168
-[modules/ics07]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics07_tendermint
+[ibc/ics07]: https://github.com/informalsystems/ibc-rs/tree/master/modules/src/ics07_tendermint
 
 ## v0.0.2
 
@@ -457,7 +457,7 @@ the latest state of development towards the Cosmos-SDK Stargate release.
 
 ### BREAKING CHANGES:
 
-- [modules|relayer] Refactor queries, paths, and Chain trait to reduce code and use
+- [ibc|ibc-relayer] Refactor queries, paths, and Chain trait to reduce code and use
   protobuf instead of Amino.
         [\#152](https://github.com/informalsystems/ibc-rs/pull/152),
         [\#174](https://github.com/informalsystems/ibc-rs/pull/174),
@@ -466,9 +466,9 @@ the latest state of development towards the Cosmos-SDK Stargate release.
   
 ### FEATURES:
 
-- [relayer] Query connections given client id. [\#169](https://github.com/informalsystems/ibc-rs/pull/169)
-- [relayer] Query connection given connection id. [\#136](https://github.com/informalsystems/ibc-rs/pull/136)
-- [relayer] Query channel given channel id and port [\#163](https://github.com/informalsystems/ibc-rs/pull/163)
+- [ibc-relayer] Query connections given client id. [\#169](https://github.com/informalsystems/ibc-rs/pull/169)
+- [ibc-relayer] Query connection given connection id. [\#136](https://github.com/informalsystems/ibc-rs/pull/136)
+- [ibc-relayer] Query channel given channel id and port [\#163](https://github.com/informalsystems/ibc-rs/pull/163)
 - [spec] Channel closing datagrams in TLA+ [\#141](https://github.com/informalsystems/ibc-rs/pull/141)
 
 ### IMPROVEMENTS:
@@ -477,14 +477,14 @@ the latest state of development towards the Cosmos-SDK Stargate release.
     the Cosmos-SDK's `simd` binary with prepopulated IBC state in the genesis
         [\#140](https://github.com/informalsystems/ibc-rs/pull/140),
         [\#184](https://github.com/informalsystems/ibc-rs/pull/184)
-- [relayer|modules] Implemented better Raw type handling. [\#156](https://github.com/informalsystems/ibc-rs/pull/156)
+- [ibc-relayer|ibc] Implemented better Raw type handling. [\#156](https://github.com/informalsystems/ibc-rs/pull/156)
 - [repo] Add rust-toolchain file. [\#154](https://github.com/informalsystems/ibc-rs/pull/154)
    
 ### BUG FIXES:
 
-- [modules] Fixed the identifiers limits according to updated ics spec. [\#189](https://github.com/informalsystems/ibc-rs/pull/189)
-- [modules/relayer] Remove some warnings triggered during compilation due to dependency specification. [\#132](https://github.com/informalsystems/ibc-rs/pull/132)
-- [modules] Fix nightly runs. [\#161](https://github.com/informalsystems/ibc-rs/pull/161)
+- [ibc] Fixed the identifiers limits according to updated ics spec. [\#189](https://github.com/informalsystems/ibc-rs/pull/189)
+- [ibc/relayer] Remove some warnings triggered during compilation due to dependency specification. [\#132](https://github.com/informalsystems/ibc-rs/pull/132)
+- [ibc] Fix nightly runs. [\#161](https://github.com/informalsystems/ibc-rs/pull/161)
 - [repo] Fix for incomplete licence terms. [\#153](https://github.com/informalsystems/ibc-rs/pull/153)
   
 ## 0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 [comment]: <> (## Unreleased Changes)
 
+### FEATURES
+
+- <high level summary>
+
+- [modules]
+  -
+
+- [relayer]
+  - Listen to channel close initialization event and perform the close handshake ([#560])
+
+- [relayer-cli]
+  -
+
+### IMPROVEMENTS
+
+- <high level summary>
+
+- [modules]
+  -
+
+- [relayer]
+  -
+
+- [relayer-cli]
+  -
+
+### BUG FIXES:
+
+- [modules]
+  -
+
+- [relayer]
+  -
+
+- [relayer-cli]
+  -
+
+### BREAKING CHANGES:
+
+- [modules]
+  -
+
+- [relayer]
+  -
+
+- [relayer-cli]
+
+[#593]: https://github.com/informalsystems/ibc-rs/issues/560
+
 ## v0.1.0
 *February 4, 2021*
 

--- a/e2e/e2e/packet.py
+++ b/e2e/e2e/packet.py
@@ -32,7 +32,7 @@ class TxPacketSend(Cmd[TxPacketSendRes]):
         return [self.src_chain_id, self.dst_chain_id, self.src_port, self.src_channel, "9999", "1000"]
 
     def process(self, result: Any) -> TxPacketSendRes:
-        entry = find_entry(result, 'SendPacketChannel')
+        entry = find_entry(result, 'SendPacket')
         return from_dict(TxPacketSendRes, entry)
 
 # -----------------------------------------------------------------------------
@@ -57,7 +57,7 @@ class TxPacketRecv(Cmd[TxPacketRecvRes]):
         return [self.dst_chain_id, self.src_chain_id, self.src_port, self.src_channel]
 
     def process(self, result: Any) -> TxPacketRecvRes:
-        entry = find_entry(result, 'WriteAcknowledgementChannel')
+        entry = find_entry(result, 'WriteAcknowledgement')
         return from_dict(TxPacketRecvRes, entry)
 
 # -----------------------------------------------------------------------------
@@ -81,7 +81,7 @@ class TxPacketAck(Cmd[TxPacketAckRes]):
         return [self.dst_chain_id, self.src_chain_id, self.src_port, self.src_channel]
 
     def process(self, result: Any) -> TxPacketAckRes:
-        entry = find_entry(result, 'AcknowledgePacketChannel')
+        entry = find_entry(result, 'AcknowledgePacket')
         return from_dict(TxPacketAckRes, entry)
 
 # =============================================================================

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -54,11 +54,11 @@ pub enum IBCEvent {
     CloseInitChannel(ChannelEvents::CloseInit),
     CloseConfirmChannel(ChannelEvents::CloseConfirm),
 
-    SendPacketChannel(ChannelEvents::SendPacket),
-    ReceivePacketChannel(ChannelEvents::ReceivePacket),
-    WriteAcknowledgementChannel(ChannelEvents::WriteAcknowledgement),
-    AcknowledgePacketChannel(ChannelEvents::AcknowledgePacket),
-    TimeoutPacketChannel(ChannelEvents::TimeoutPacket),
+    SendPacket(ChannelEvents::SendPacket),
+    ReceivePacket(ChannelEvents::ReceivePacket),
+    WriteAcknowledgement(ChannelEvents::WriteAcknowledgement),
+    AcknowledgePacket(ChannelEvents::AcknowledgePacket),
+    TimeoutPacket(ChannelEvents::TimeoutPacket),
 
     TimeoutTransfer(TransferEvents::Timeout),
     PacketTransfer(TransferEvents::Packet),
@@ -87,15 +87,17 @@ impl IBCEvent {
         serde_json::to_string(self).unwrap()
     }
 
-    pub fn height(&self) -> Height {
+    // TODO - change to ICSHeight
+    pub fn height(&self) -> &Height {
         match self {
-            IBCEvent::NewBlock(bl) => bl.height,
-            IBCEvent::UpdateClient(uc) => *uc.height(),
-            IBCEvent::SendPacketChannel(ev) => ev.height,
-            IBCEvent::ReceivePacketChannel(ev) => ev.height,
-            IBCEvent::WriteAcknowledgementChannel(ev) => ev.height,
-            IBCEvent::AcknowledgePacketChannel(ev) => ev.height,
-            IBCEvent::TimeoutPacketChannel(ev) => ev.height,
+            IBCEvent::NewBlock(ev) => &ev.height,
+            IBCEvent::UpdateClient(ev) => ev.height(),
+            IBCEvent::SendPacket(ev) => &ev.height,
+            IBCEvent::ReceivePacket(ev) => &ev.height,
+            IBCEvent::WriteAcknowledgement(ev) => &ev.height,
+            IBCEvent::AcknowledgePacket(ev) => &ev.height,
+            IBCEvent::TimeoutPacket(ev) => &ev.height,
+            IBCEvent::CloseInitChannel(ev) => ev.height(),
 
             _ => unimplemented!(),
         }
@@ -103,19 +105,19 @@ impl IBCEvent {
 
     pub fn set_height(&mut self, height: ICSHeight) {
         match self {
-            IBCEvent::SendPacketChannel(ev) => {
+            IBCEvent::SendPacket(ev) => {
                 ev.height = Height::try_from(height.revision_height).unwrap()
             }
-            IBCEvent::ReceivePacketChannel(ev) => {
+            IBCEvent::ReceivePacket(ev) => {
                 ev.height = Height::try_from(height.revision_height).unwrap()
             }
-            IBCEvent::WriteAcknowledgementChannel(ev) => {
+            IBCEvent::WriteAcknowledgement(ev) => {
                 ev.height = Height::try_from(height.revision_height).unwrap()
             }
-            IBCEvent::AcknowledgePacketChannel(ev) => {
+            IBCEvent::AcknowledgePacket(ev) => {
                 ev.height = Height::try_from(height.revision_height).unwrap()
             }
-            IBCEvent::TimeoutPacketChannel(ev) => {
+            IBCEvent::TimeoutPacket(ev) => {
                 ev.height = Height::try_from(height.revision_height).unwrap()
             }
             _ => unimplemented!(),

--- a/modules/src/ics02_client/msgs/create_client.rs
+++ b/modules/src/ics02_client/msgs/create_client.rs
@@ -86,13 +86,13 @@ impl TryFrom<RawMsgCreateClient> for MsgCreateAnyClient {
 
         let signer = string_to_account(raw.signer).map_err(|e| Kind::InvalidAddress.context(e))?;
 
-        Ok(MsgCreateAnyClient::new(
+        MsgCreateAnyClient::new(
             AnyClientState::try_from(raw_client_state)
                 .map_err(|e| Kind::InvalidRawClientState.context(e))?,
             AnyConsensusState::try_from(raw_consensus_state)
                 .map_err(|e| Kind::InvalidRawConsensusState.context(e))?,
             signer,
-        )?)
+        )
     }
 }
 

--- a/modules/src/ics04_channel/events.rs
+++ b/modules/src/ics04_channel/events.rs
@@ -65,7 +65,7 @@ pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IBCEvent> {
             let (packet, write_ack) = extract_packet_and_write_ack_from_tx(event);
             // This event should not have a write ack.
             assert!(write_ack.is_none());
-            Some(IBCEvent::SendPacketChannel(SendPacket {
+            Some(IBCEvent::SendPacket(SendPacket {
                 height: Default::default(),
                 packet,
             }))
@@ -74,19 +74,17 @@ pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IBCEvent> {
             let (packet, write_ack) = extract_packet_and_write_ack_from_tx(event);
             // This event should have a write ack.
             let write_ack = write_ack.unwrap();
-            Some(IBCEvent::WriteAcknowledgementChannel(
-                WriteAcknowledgement {
-                    height: Default::default(),
-                    packet,
-                    ack: write_ack,
-                },
-            ))
+            Some(IBCEvent::WriteAcknowledgement(WriteAcknowledgement {
+                height: Default::default(),
+                packet,
+                ack: write_ack,
+            }))
         }
         ACK_PACKET => {
             let (packet, write_ack) = extract_packet_and_write_ack_from_tx(event);
             // This event should not have a write ack.
             assert!(write_ack.is_none());
-            Some(IBCEvent::AcknowledgePacketChannel(AcknowledgePacket {
+            Some(IBCEvent::AcknowledgePacket(AcknowledgePacket {
                 height: Default::default(),
                 packet,
             }))
@@ -95,7 +93,7 @@ pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IBCEvent> {
             let (packet, write_ack) = extract_packet_and_write_ack_from_tx(event);
             // This event should not have a write ack.
             assert!(write_ack.is_none());
-            Some(IBCEvent::TimeoutPacketChannel(TimeoutPacket {
+            Some(IBCEvent::TimeoutPacket(TimeoutPacket {
                 height: Default::default(),
                 packet,
             }))
@@ -334,6 +332,12 @@ impl CloseInit {
     pub fn channel_id(&self) -> &Option<ChannelId> {
         &self.0.channel_id
     }
+    pub fn height(&self) -> &block::Height {
+        &self.0.height
+    }
+    pub fn port_id(&self) -> &PortId {
+        &self.0.port_id
+    }
 }
 
 impl From<Attributes> for CloseInit {
@@ -362,6 +366,18 @@ impl TryFrom<RawObject> for CloseInit {
 impl From<CloseInit> for IBCEvent {
     fn from(v: CloseInit) -> Self {
         IBCEvent::CloseInitChannel(v)
+    }
+}
+
+impl std::fmt::Display for CloseInit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "{:?} {} {:?}",
+            self.height(),
+            CLOSE_INIT_EVENT_TYPE,
+            self.0
+        )
     }
 }
 
@@ -448,7 +464,7 @@ impl TryFrom<RawObject> for SendPacket {
 
 impl From<SendPacket> for IBCEvent {
     fn from(v: SendPacket) -> Self {
-        IBCEvent::SendPacketChannel(v)
+        IBCEvent::SendPacket(v)
     }
 }
 
@@ -477,7 +493,7 @@ impl TryFrom<RawObject> for ReceivePacket {
 
 impl From<ReceivePacket> for IBCEvent {
     fn from(v: ReceivePacket) -> Self {
-        IBCEvent::ReceivePacketChannel(v)
+        IBCEvent::ReceivePacket(v)
     }
 }
 
@@ -513,7 +529,7 @@ impl TryFrom<RawObject> for WriteAcknowledgement {
 
 impl From<WriteAcknowledgement> for IBCEvent {
     fn from(v: WriteAcknowledgement) -> Self {
-        IBCEvent::WriteAcknowledgementChannel(v)
+        IBCEvent::WriteAcknowledgement(v)
     }
 }
 
@@ -540,7 +556,7 @@ impl TryFrom<RawObject> for AcknowledgePacket {
 
 impl From<AcknowledgePacket> for IBCEvent {
     fn from(v: AcknowledgePacket) -> Self {
-        IBCEvent::AcknowledgePacketChannel(v)
+        IBCEvent::AcknowledgePacket(v)
     }
 }
 
@@ -568,7 +584,7 @@ impl TryFrom<RawObject> for TimeoutPacket {
 
 impl From<TimeoutPacket> for IBCEvent {
     fn from(v: TimeoutPacket) -> Self {
-        IBCEvent::TimeoutPacketChannel(v)
+        IBCEvent::TimeoutPacket(v)
     }
 }
 

--- a/modules/src/ics04_channel/events.rs
+++ b/modules/src/ics04_channel/events.rs
@@ -29,6 +29,7 @@ const RECV_PACKET: &str = "recv_packet";
 const WRITE_ACK: &str = "write_acknowledgement";
 const ACK_PACKET: &str = "acknowledge_packet";
 const TIMEOUT: &str = "timeout_packet";
+const TIMEOUT_ON_CLOSE: &str = "timeout_on_close_packet";
 
 /// Packet event attribute keys
 const PKT_SEQ_ATTRIBUTE_KEY: &str = "packet_sequence";
@@ -338,6 +339,9 @@ impl CloseInit {
     pub fn port_id(&self) -> &PortId {
         &self.0.port_id
     }
+    pub fn set_height(&mut self, height: block::Height) {
+        self.0.height = height;
+    }
 }
 
 impl From<Attributes> for CloseInit {
@@ -591,5 +595,33 @@ impl From<TimeoutPacket> for IBCEvent {
 impl std::fmt::Display for TimeoutPacket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{} {} {}", self.height, TIMEOUT, self.packet)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TimeoutOnClosePacket {
+    pub height: block::Height,
+    pub packet: Packet,
+}
+
+impl TryFrom<RawObject> for TimeoutOnClosePacket {
+    type Error = BoxError;
+    fn try_from(obj: RawObject) -> Result<Self, Self::Error> {
+        Ok(TimeoutOnClosePacket {
+            height: obj.height,
+            packet: Packet::try_from(obj)?,
+        })
+    }
+}
+
+impl From<TimeoutOnClosePacket> for IBCEvent {
+    fn from(v: TimeoutOnClosePacket) -> Self {
+        IBCEvent::TimeoutOnClosePacket(v)
+    }
+}
+
+impl std::fmt::Display for TimeoutOnClosePacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{} {} {}", self.height, TIMEOUT_ON_CLOSE, self.packet)
     }
 }

--- a/modules/src/mock/context.rs
+++ b/modules/src/mock/context.rs
@@ -440,19 +440,10 @@ impl ChannelKeeper for MockContext {
         cid: &ConnectionId,
         port_channel_id: &(PortId, ChannelId),
     ) -> Result<(), ICS4Error> {
-        match self.connection_channels.get(cid) {
-            Some(v) => {
-                let mut modv = v.clone();
-                modv.push(port_channel_id.clone());
-                self.connection_channels.remove(cid);
-                self.connection_channels.insert(cid.clone(), modv);
-            }
-            None => {
-                let mut modv = Vec::new();
-                modv.push(port_channel_id.clone());
-                self.connection_channels.insert(cid.clone(), modv);
-            }
-        }
+        self.connection_channels
+            .entry(cid.clone())
+            .or_insert_with(Vec::new)
+            .push(port_channel_id.clone());
         Ok(())
     }
 }

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -680,7 +680,7 @@ impl Chain for CosmosSDKChain {
             // query all Tx-es that include events related to packet with given port, channel and sequence
             let response = self
                 .block_on(self.rpc_client.tx_search(
-                    packet_query(&request, seq)?,
+                    packet_query(&request, seq),
                     false,
                     1,
                     1,
@@ -688,7 +688,7 @@ impl Chain for CosmosSDKChain {
                 ))
                 .unwrap(); // todo
 
-            let mut events = packet_from_tx_search_response(&request, *seq, &response)?
+            let mut events = packet_from_tx_search_response(&request, *seq, &response)
                 .map_or(vec![], |v| vec![v]);
             result.append(&mut events);
         }
@@ -816,8 +816,8 @@ impl Chain for CosmosSDKChain {
     }
 }
 
-fn packet_query(request: &QueryPacketEventDataRequest, seq: &Sequence) -> Result<Query, Error> {
-    Ok(tendermint_rpc::query::Query::eq(
+fn packet_query(request: &QueryPacketEventDataRequest, seq: &Sequence) -> Query {
+    tendermint_rpc::query::Query::eq(
         format!("{}.packet_src_channel", request.event_id.as_str()),
         request.source_channel_id.to_string(),
     )
@@ -836,7 +836,7 @@ fn packet_query(request: &QueryPacketEventDataRequest, seq: &Sequence) -> Result
     .and_eq(
         format!("{}.packet_sequence", request.event_id.as_str()),
         seq.to_string(),
-    ))
+    )
 }
 
 // Extract the packet events from the query_tx RPC response. The response includes the full set of events
@@ -847,7 +847,7 @@ fn packet_from_tx_search_response(
     request: &QueryPacketEventDataRequest,
     seq: Sequence,
     response: &tendermint_rpc::endpoint::tx_search::Response,
-) -> Result<Option<IBCEvent>, Error> {
+) -> Option<IBCEvent> {
     // TODO: remove loop as `response.txs.len() <= 1`
     for r in response.txs.iter() {
         let height = r.height;
@@ -885,10 +885,10 @@ fn packet_from_tx_search_response(
                 continue;
             }
 
-            return Ok(Some(event));
+            return Some(event);
         }
     }
-    Ok(None)
+    None
 }
 
 /// Perform a generic `abci_query`, and return the corresponding deserialized response data.

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -866,8 +866,8 @@ fn packet_from_tx_search_response(
             }
             let event = res.unwrap();
             let packet = match &event {
-                IBCEvent::SendPacketChannel(send_ev) => Some(&send_ev.packet),
-                IBCEvent::WriteAcknowledgementChannel(ack_ev) => Some(&ack_ev.packet),
+                IBCEvent::SendPacket(send_ev) => Some(&send_ev.packet),
+                IBCEvent::WriteAcknowledgement(ack_ev) => Some(&ack_ev.packet),
                 _ => None,
             };
 

--- a/relayer/src/channel.rs
+++ b/relayer/src/channel.rs
@@ -506,10 +506,7 @@ impl Channel {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgChannelOpenTry>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgChannelOpenTry>());
         Ok(msgs)
     }
 
@@ -598,10 +595,7 @@ impl Channel {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgChannelOpenAck>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgChannelOpenAck>());
         Ok(msgs)
     }
 
@@ -678,10 +672,7 @@ impl Channel {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgChannelOpenConfirm>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgChannelOpenConfirm>());
         Ok(msgs)
     }
 
@@ -807,10 +798,7 @@ impl Channel {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgChannelCloseConfirm>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgChannelCloseConfirm>());
         Ok(msgs)
     }
 

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -477,10 +477,7 @@ impl Connection {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgConnectionOpenTry>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgConnectionOpenTry>());
         Ok(msgs)
     }
 
@@ -576,10 +573,7 @@ impl Connection {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgConnectionOpenAck>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgConnectionOpenAck>());
         Ok(msgs)
     }
 
@@ -666,10 +660,7 @@ impl Connection {
             signer,
         };
 
-        let mut new_msgs = vec![new_msg.to_any::<RawMsgConnectionOpenConfirm>()];
-
-        msgs.append(&mut new_msgs);
-
+        msgs.push(new_msg.to_any::<RawMsgConnectionOpenConfirm>());
         Ok(msgs)
     }
 

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -981,7 +981,7 @@ impl Link {
                 b_channel_id,
             ),
         };
-        Ok(Link::new(channel)?)
+        Link::new(channel)
     }
 
     pub fn build_and_send_recv_packet_messages(&mut self) -> Result<Vec<IBCEvent>, LinkError> {

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -500,7 +500,7 @@ impl RelayPath {
         for event in self.all_events.iter() {
             let send_event = downcast!(event => IBCEvent::SendPacket)
                 .ok_or_else(|| LinkError::Failed("unexpected query tx response".into()))?;
-            packet_sequences.append(&mut vec![send_event.packet.sequence]);
+            packet_sequences.push(send_event.packet.sequence);
         }
         info!("received from query_txs {:?}", packet_sequences);
 
@@ -573,7 +573,7 @@ impl RelayPath {
         for event in self.all_events.iter() {
             let write_ack_event = downcast!(event => IBCEvent::WriteAcknowledgement)
                 .ok_or_else(|| LinkError::Failed("unexpected query tx response".into()))?;
-            packet_sequences.append(&mut vec![write_ack_event.packet.sequence]);
+            packet_sequences.push(write_ack_event.packet.sequence);
         }
         info!("received from query_txs {:?}", packet_sequences);
         Ok(())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #560

## Description

- collect `CloseInitChannel` event (`collect_events()`) and handle it in `build_msg_from_event()`
- handle the race condition where client updates are sent on destination for heights higher than event height:
   - added a new function `adjust_events_height()` that checks:
       - if latest consensus height <= event_height (no change) or
       - if a client consensus of height `event_height + 1` exists (no adjustment) or
       - one at height `> event_height + 1` (change events height to latest client consensus height - 1)
   - the race condition can be reproduce this way:
       - start the realyer loop on an open channel (`hermes start ibc-0 ibc-1 -p transfer -c channel-0`)
       - from one terminal send tens of packets to `ibc-0` (`hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-0 9999 1000 -n 30`) 
       - from a different terminal send a `chan-close-init` to `ibc-1` (`hermes tx raw chan-close-init ibc-1 ibc-0 connection-0 transfer transfer -d channel-1 -s channel-0`)
       - before the `CloseInitChannel` event with some height `X` from `ibc-1` is processed, the `SendPacket` events processing results in `MsgTimeoutOnClose` packets to be sent to `ibc-0` prepended by a `MsgClientUpdate` at some height > `X`. This causes the subsequent `chan-close-init` event processing to fail.
    - there are probably many other ways to cause the race

Minor changes:
- added `timeout_on_close_packet` event decoder, with some awkwardness because `message.action` is `timeout_on_close_packet ` while the event name (prefix of tags) is `timeout_packet`. Needs more digging in cosmos-sdk, maybe ask them to make the changes.
- changed the channel event names (removed `Channel` suffix) 
 
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.