### PR TITLE
Allow spawning a supervisor per connection defined in the config

### DIFF
--- a/relayer-cli/src/cli_utils.rs
+++ b/relayer-cli/src/cli_utils.rs
@@ -1,13 +1,10 @@
-use abscissa_core::config;
 use ibc::ics24_host::identifier::ChainId;
+use ibc_relayer::chain::runtime::ChainRuntime;
 use ibc_relayer::chain::CosmosSdkChain;
-use ibc_relayer::{chain::handle::ChainHandle, config::StoreConfig};
-use ibc_relayer::{chain::runtime::ChainRuntime, config::ChainConfig};
+use ibc_relayer::config::{ChainConfig, StoreConfig};
+use ibc_relayer::{chain::handle::ChainHandle, config::Config};
 
-use crate::{
-    application::CliApp,
-    error::{Error, Kind},
-};
+use crate::error::{Error, Kind};
 
 #[derive(Clone, Debug)]
 /// Pair of chain handles that are used by most CLIs.
@@ -22,7 +19,7 @@ impl ChainHandlePair {
     /// Spawn the source and destination chain runtime from the configuration and chain identifiers,
     /// and return the pair of associated handles.
     pub fn spawn(
-        config: &config::Reader<CliApp>,
+        config: &Config,
         src_chain_id: &ChainId,
         dst_chain_id: &ChainId,
     ) -> Result<Self, Error> {
@@ -34,7 +31,7 @@ impl ChainHandlePair {
     /// is used to override each chain configuration before spawning its runtime.
     pub fn spawn_with(
         options: SpawnOptions,
-        config: &config::Reader<CliApp>,
+        config: &Config,
         src_chain_id: &ChainId,
         dst_chain_id: &ChainId,
     ) -> Result<Self, Error> {
@@ -49,7 +46,7 @@ impl ChainHandlePair {
 /// Returns the corresponding handle if successful.
 pub fn spawn_chain_runtime(
     spawn_options: SpawnOptions,
-    config: &config::Reader<CliApp>,
+    config: &Config,
     chain_id: &ChainId,
 ) -> Result<Box<dyn ChainHandle>, Error> {
     let mut chain_config = config

--- a/relayer-cli/src/commands.rs
+++ b/relayer-cli/src/commands.rs
@@ -64,7 +64,8 @@ pub enum CliCmd {
     Start(StartCmd),
 
     /// The `start-multi` subcommand
-    #[options(help = "Start the relayer in multi-channel mode")]
+    #[options(help = "Start the relayer in multi-channel mode. \
+                      Omit the options to pick up connections from the configuration.")]
     StartMulti(StartMultiCmd),
 
     /// The `channel` subcommand

--- a/relayer-cli/src/commands.rs
+++ b/relayer-cli/src/commands.rs
@@ -18,7 +18,6 @@ use self::{
 };
 
 mod channel;
-mod cli_utils;
 mod config;
 mod create;
 mod keys;

--- a/relayer-cli/src/commands/channel.rs
+++ b/relayer-cli/src/commands/channel.rs
@@ -7,7 +7,7 @@ use ibc_relayer::config::{RelayPath, StoreConfig};
 use ibc_relayer::relay::connect_with_new_channel;
 
 use crate::application::app_config;
-use crate::commands::cli_utils::{ChainHandlePair, SpawnOptions};
+use crate::cli_utils::{ChainHandlePair, SpawnOptions};
 use crate::conclude::Output;
 
 /// `channel` subcommand

--- a/relayer-cli/src/commands/create/connection.rs
+++ b/relayer-cli/src/commands/create/connection.rs
@@ -7,7 +7,7 @@ use ibc_relayer::config::StoreConfig;
 use ibc_relayer::connection::Connection;
 use ibc_relayer::foreign_client::ForeignClient;
 
-use crate::commands::cli_utils::{spawn_chain_runtime, ChainHandlePair, SpawnOptions};
+use crate::cli_utils::{spawn_chain_runtime, ChainHandlePair, SpawnOptions};
 use crate::conclude::{exit_with_unrecoverable_error, Output};
 use crate::prelude::*;
 

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -5,7 +5,7 @@ use ibc::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc_relayer::link::LinkParameters;
 use ibc_relayer::relay::{channel_relay, relay_on_new_link};
 
-use crate::commands::cli_utils::ChainHandlePair;
+use crate::cli_utils::ChainHandlePair;
 use crate::conclude::Output;
 use crate::prelude::*;
 

--- a/relayer-cli/src/commands/start_multi.rs
+++ b/relayer-cli/src/commands/start_multi.rs
@@ -9,32 +9,86 @@ use crate::{application::CliApp, commands::cli_utils::ChainHandlePair};
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct StartMultiCmd {
-    #[options(free, required, help = "identifier of the source chain")]
-    src_chain_id: ChainId,
+    #[options(free, help = "identifier of chain A")]
+    chain_a: Option<ChainId>,
 
-    #[options(free, required, help = "identifier of the destination chain")]
-    dst_chain_id: ChainId,
+    #[options(free, help = "identifier of chain B")]
+    chain_b: Option<ChainId>,
+}
+
+enum Opts<'a> {
+    AllConnections,
+    Specified {
+        chain_a: &'a ChainId,
+        chain_b: &'a ChainId,
+    },
+}
+
+impl StartMultiCmd {
+    fn validate_options(&self) -> Result<Opts<'_>, BoxError> {
+        match (&self.chain_a, &self.chain_b) {
+            (Some(chain_a), Some(chain_b)) => Ok(Opts::Specified { chain_a, chain_b }),
+            (None, None) => Ok(Opts::AllConnections),
+            _ => Err("invalid options: please specify both chain identifiers \
+                      or none at all to use the connections defined in the configuration"
+                .into()),
+        }
+    }
+
+    fn cmd(&self) -> Result<Output, BoxError> {
+        let options = self.validate_options()?;
+        let config = app_config();
+
+        match options {
+            Opts::Specified { chain_a, chain_b } => start_specified(&config, chain_a, chain_b),
+            Opts::AllConnections => start_all_connections(&config),
+        }
+    }
 }
 
 impl Runnable for StartMultiCmd {
     fn run(&self) {
-        let config = app_config();
-
-        match start_multi(&config, &self.src_chain_id, &self.dst_chain_id) {
+        match self.cmd() {
             Ok(output) => output.exit(),
             Err(e) => Output::error(format!("{}", e)).exit(),
         }
     }
 }
 
-fn start_multi(
+fn start_specified(
     config: &config::Reader<CliApp>,
     chain_a: &ChainId,
     chain_b: &ChainId,
 ) -> Result<Output, BoxError> {
+    eprintln!("spawning supervisor for chains {} and {}", chain_a, chain_b);
+
     let chains = ChainHandlePair::spawn(config, chain_a, chain_b)?;
     let supervisor = Supervisor::spawn(chains.src, chains.dst)?;
     supervisor.run()?;
+
+    Ok(Output::success("ok"))
+}
+
+fn start_all_connections(config: &config::Reader<CliApp>) -> Result<Output, BoxError> {
+    let connections = config
+        .connections
+        .as_ref()
+        .filter(|conns| !conns.is_empty())
+        .ok_or("no connections configured")?;
+
+    for conn in connections {
+        eprintln!(
+            "spawning supervisor for chains {} and {}",
+            conn.a_chain, conn.b_chain
+        );
+
+        let chains = ChainHandlePair::spawn(config, &conn.a_chain, &conn.b_chain)?;
+
+        std::thread::spawn(|| {
+            let supervisor = Supervisor::spawn(chains.src, chains.dst)?;
+            supervisor.run()
+        });
+    }
 
     Ok(Output::success("ok"))
 }

--- a/relayer-cli/src/commands/start_multi.rs
+++ b/relayer-cli/src/commands/start_multi.rs
@@ -1,15 +1,11 @@
-use std::collections::HashMap;
-
-use abscissa_core::{config, Command, Options, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 
 use ibc::ics24_host::identifier::ChainId;
-use ibc_relayer::{chain::handle::ChainHandle, supervisor::Supervisor};
+use ibc_relayer::{config::Config, supervisor::Supervisor};
 
 use crate::conclude::Output;
 use crate::prelude::*;
-use crate::{application::CliApp, commands::cli_utils::ChainHandlePair};
-
-use super::cli_utils::spawn_chain_runtime;
+use crate::registry::Registry;
 
 #[derive(Clone, Command, Debug, Options)]
 pub struct StartMultiCmd {
@@ -22,16 +18,13 @@ pub struct StartMultiCmd {
 
 enum Opts<'a> {
     AllConnections,
-    Specified {
-        chain_a: &'a ChainId,
-        chain_b: &'a ChainId,
-    },
+    Specified(&'a ChainId, &'a ChainId),
 }
 
 impl StartMultiCmd {
     fn validate_options(&self) -> Result<Opts<'_>, BoxError> {
         match (&self.chain_a, &self.chain_b) {
-            (Some(chain_a), Some(chain_b)) => Ok(Opts::Specified { chain_a, chain_b }),
+            (Some(chain_a), Some(chain_b)) => Ok(Opts::Specified(chain_a, chain_b)),
             (None, None) => Ok(Opts::AllConnections),
             _ => Err("invalid options: please specify both chain identifiers \
                       or none at all to use the connections defined in the configuration"
@@ -41,11 +34,11 @@ impl StartMultiCmd {
 
     fn cmd(&self) -> Result<Output, BoxError> {
         let options = self.validate_options()?;
-        let config = app_config();
+        let config = &*app_config();
 
         match options {
-            Opts::Specified { chain_a, chain_b } => start_specified(&config, chain_a, chain_b),
-            Opts::AllConnections => start_all_connections(&config),
+            Opts::Specified(chain_a, chain_b) => start_specified(config, chain_a, chain_b),
+            Opts::AllConnections => start_all_connections(config),
         }
     }
 }
@@ -60,36 +53,30 @@ impl Runnable for StartMultiCmd {
 }
 
 fn start_specified(
-    config: &config::Reader<CliApp>,
+    config: &Config,
     chain_a: &ChainId,
     chain_b: &ChainId,
 ) -> Result<Output, BoxError> {
     info!("spawning supervisor for chains {} and {}", chain_a, chain_b);
 
-    let chains = ChainHandlePair::spawn(config, chain_a, chain_b)?;
-    let supervisor = Supervisor::spawn(chains.src, chains.dst)?;
+    let mut registry = Registry::new(&config);
+    let chain_a = registry.get_or_spawn(chain_a)?;
+    let chain_b = registry.get_or_spawn(chain_b)?;
+
+    let supervisor = Supervisor::spawn(chain_a, chain_b)?;
     supervisor.run()?;
 
     Ok(Output::success("ok"))
 }
 
-fn start_all_connections(config: &config::Reader<CliApp>) -> Result<Output, BoxError> {
+fn start_all_connections(config: &Config) -> Result<Output, BoxError> {
     let connections = config
         .connections
         .as_ref()
         .filter(|conns| !conns.is_empty())
         .ok_or("no connections configured")?;
 
-    let mut handles = HashMap::new();
-    let mut get_handle = |id: &ChainId| -> Result<Box<dyn ChainHandle>, BoxError> {
-        if !handles.contains_key(id) {
-            let handle = spawn_chain_runtime(Default::default(), config, id)?;
-            handles.insert(id.clone(), handle);
-        }
-
-        let handle = handles.get(id).unwrap();
-        Ok(handle.clone())
-    };
+    let mut registry = Registry::new(config);
 
     for conn in connections {
         info!(
@@ -97,8 +84,8 @@ fn start_all_connections(config: &config::Reader<CliApp>) -> Result<Output, BoxE
             conn.a_chain, conn.b_chain
         );
 
-        let chain_a = get_handle(&conn.a_chain)?;
-        let chain_b = get_handle(&conn.b_chain)?;
+        let chain_a = registry.get_or_spawn(&conn.a_chain)?;
+        let chain_b = registry.get_or_spawn(&conn.b_chain)?;
 
         std::thread::spawn(|| {
             let supervisor = Supervisor::spawn(chain_a, chain_b)?;

--- a/relayer-cli/src/commands/tx/channel.rs
+++ b/relayer-cli/src/commands/tx/channel.rs
@@ -8,7 +8,7 @@ use ibc::Height;
 use ibc_relayer::channel::{Channel, ChannelSide};
 use ibc_relayer::config::StoreConfig;
 
-use crate::commands::cli_utils::{ChainHandlePair, SpawnOptions};
+use crate::cli_utils::{ChainHandlePair, SpawnOptions};
 use crate::conclude::Output;
 use crate::error::{Error, Kind};
 use crate::prelude::*;

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -6,7 +6,7 @@ use ibc_relayer::config::StoreConfig;
 use ibc_relayer::foreign_client::ForeignClient;
 
 use crate::application::app_config;
-use crate::commands::cli_utils::{ChainHandlePair, SpawnOptions};
+use crate::cli_utils::{ChainHandlePair, SpawnOptions};
 use crate::conclude::Output;
 use crate::error::{Error, Kind};
 

--- a/relayer-cli/src/commands/tx/connection.rs
+++ b/relayer-cli/src/commands/tx/connection.rs
@@ -5,7 +5,7 @@ use ibc::ics24_host::identifier::{ChainId, ClientId, ConnectionId};
 use ibc_relayer::config::StoreConfig;
 use ibc_relayer::connection::{Connection, ConnectionSide};
 
-use crate::commands::cli_utils::{ChainHandlePair, SpawnOptions};
+use crate::cli_utils::{ChainHandlePair, SpawnOptions};
 use crate::conclude::Output;
 use crate::error::{Error, Kind};
 use crate::prelude::*;

--- a/relayer-cli/src/commands/tx/packet.rs
+++ b/relayer-cli/src/commands/tx/packet.rs
@@ -5,7 +5,7 @@ use ibc::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc_relayer::config::StoreConfig;
 use ibc_relayer::link::{Link, LinkParameters};
 
-use crate::commands::cli_utils::{ChainHandlePair, SpawnOptions};
+use crate::cli_utils::{ChainHandlePair, SpawnOptions};
 use crate::conclude::Output;
 use crate::error::{Error, Kind};
 use crate::prelude::*;

--- a/relayer-cli/src/lib.rs
+++ b/relayer-cli/src/lib.rs
@@ -18,8 +18,11 @@
 
 pub mod application;
 pub mod commands;
-mod components;
-pub(crate) mod conclude;
 pub mod config;
 pub mod error;
 pub mod prelude;
+pub mod registry;
+
+pub(crate) mod cli_utils;
+pub(crate) mod components;
+pub(crate) mod conclude;

--- a/relayer-cli/src/registry.rs
+++ b/relayer-cli/src/registry.rs
@@ -1,0 +1,40 @@
+//! Registry for keeping track of [`ChainHandle`]s indexed by a `ChainId`.
+
+use std::collections::HashMap;
+
+use ibc::ics24_host::identifier::ChainId;
+use ibc_relayer::{chain::handle::ChainHandle, config::Config};
+
+use crate::{cli_utils::spawn_chain_runtime, error::Error};
+
+/// Registry for keeping track of [`ChainHandle`]s indexed by a `ChainId`.
+///
+/// The purpose of this type is to avoid spawning multiple runtimes for a single `ChainId`.
+pub struct Registry<'a> {
+    config: &'a Config,
+    handles: HashMap<ChainId, Box<dyn ChainHandle>>,
+}
+
+impl<'a> Registry<'a> {
+    /// Construct a new [`Registry`] using the provided [`Config`]
+    pub fn new(config: &'a Config) -> Self {
+        Self {
+            config,
+            handles: HashMap::new(),
+        }
+    }
+
+    /// Get the [`ChainHandle`] associated with the given [`ChainId`].
+    ///
+    /// If there is no handle yet, this will first spawn the runtime and then
+    /// return its handle.
+    pub fn get_or_spawn(&mut self, chain_id: &ChainId) -> Result<Box<dyn ChainHandle>, Error> {
+        if !self.handles.contains_key(chain_id) {
+            let handle = spawn_chain_runtime(Default::default(), &self.config, chain_id)?;
+            self.handles.insert(chain_id.clone(), handle);
+        }
+
+        let handle = self.handles.get(chain_id).unwrap();
+        Ok(handle.clone())
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

If the `start-multi` command is ran without options, spawn a supervisor per connection defined in the config.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.