### PR TITLE
Fixes to make hermes work with non-gaiad custom chains (e.g. starport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 - [ibc-relayer]
   - Replaced `rust-crypto` & `bitcoin-wallet` deprecated dependencies ([#352])
+  - Fix for hard-coded account number ([#752])
+  - Fix for chains that don't have `cosmos` account prefix ([#416])
 
 - [ibc-relayer-cli]
   - Hermes guide: improved installation guideline ([#672])
@@ -58,6 +60,7 @@
   - [nothing yet]
 
 [#352]: https://github.com/informalsystems/ibc-rs/issues/352
+[#416]: https://github.com/informalsystems/ibc-rs/issues/416
 [#561]: https://github.com/informalsystems/ibc-rs/issues/561
 [#599]: https://github.com/informalsystems/ibc-rs/issues/599
 [#630]: https://github.com/informalsystems/ibc-rs/issues/630
@@ -69,6 +72,7 @@
 [#700]: https://github.com/informalsystems/ibc-rs/pull/700
 [#702]: https://github.com/informalsystems/ibc-rs/issues/702
 [#740]: https://github.com/informalsystems/ibc-rs/issues/740
+[#752]: https://github.com/informalsystems/ibc-rs/issues/752
 
 ## v0.1.1
 *February 17, 2021*

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -159,6 +159,8 @@ impl CosmosSdkChain {
         let mut pk_buf = Vec::new();
         prost::Message::encode(&key.public_key.public_key.to_bytes(), &mut pk_buf).unwrap();
 
+        crate::time!("PK {:?}", hex::encode(key.public_key.public_key.to_bytes()));
+
         // Create a MsgSend proto Any message
         let pk_any = Any {
             type_url: "/cosmos.crypto.secp256k1.PubKey".to_string(),
@@ -181,7 +183,7 @@ impl CosmosSdkChain {
         // Gas Fee
         let coin = Coin {
             denom: "stake".to_string(),
-            amount: "1000".to_string(),
+            amount: "10000".to_string(),
         };
 
         let fee = Some(Fee {
@@ -204,7 +206,7 @@ impl CosmosSdkChain {
             body_bytes: body_buf.clone(),
             auth_info_bytes: auth_buf.clone(),
             chain_id: self.config.clone().id.to_string(),
-            account_number: 0,
+            account_number: acct_response.account_number,
         };
 
         // A protobuf serialization of a SignDoc
@@ -222,6 +224,8 @@ impl CosmosSdkChain {
 
         let mut txraw_buf = Vec::new();
         prost::Message::encode(&tx_raw, &mut txraw_buf).unwrap();
+
+        crate::time!("TxRAW {:?}", hex::encode(txraw_buf.clone()));
 
         let response = self
             .block_on(broadcast_tx_commit(self, txraw_buf))

--- a/relayer/src/keys/add.rs
+++ b/relayer/src/keys/add.rs
@@ -26,7 +26,9 @@ pub fn add_key(opts: KeysAddOptions) -> Result<String, Error> {
         .map_err(|_| Kind::KeyBase.context("error reading the key file"))?;
 
     // Check if it's a valid Key seed file
-    let key_entry = chain.keybase().key_from_seed_file(&key_contents);
+    let key_entry = chain
+        .keybase()
+        .key_from_seed_file(&key_contents, chain.config());
 
     match key_entry {
         Ok(k) => {


### PR DESCRIPTION
Closes: 

* #416 
* #752 

## Description

This PR implements fixes to allow hermes relay packets between two non-gaiad based chains.

These changes were tested against two `starport v0.15.0` (supports `cosmos-sdk v0.42.1`). These starport chains have custom account prefix addresses (not `cosmos`) such as `chainb1pnv0elanhs8qcq2sst0jssak8magjpj3ggq45x`

This PR also fixes an issue where the account number is not `0`. For example the starport chains have multiple accounts (e.g. `validator` and `bob`). So using `bob` account key in the relayer would make the transactions fail because that account number is `1` in the key store. After the fix, it works now because the account number is dynamically fetched from the chain using grpc (same logic that gets the account sequence to submit transaction).
_____

For contributor use:

- [X] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [X] Re-reviewed `Files changed` in the Github PR explorer.