### PR TITLE
Added hermes docker image

### DIFF
--- a/ci/hermes.Dockerfile
+++ b/ci/hermes.Dockerfile
@@ -1,0 +1,23 @@
+# informaldev/hermes image
+#
+# Used for running hermes in docker containers
+
+FROM rust:1.51 AS build-env
+LABEL maintainer="hello@informal.systems"
+
+ARG TAG
+WORKDIR /root
+
+RUN git clone https://github.com/informalsystems/ibc-rs
+RUN cd ibc-rs && git checkout $TAG && cargo build --release
+
+
+FROM debian:buster-slim
+LABEL maintainer="hello@informal.systems"
+
+RUN apt update && apt install -y vim jq && useradd -m hermes -s /bin/bash
+WORKDIR /home/hermes
+USER hermes:hermes
+ENTRYPOINT /usr/bin/hermes
+
+COPY --chown=0:0 --from=build-env /root/ibc-rs/target/release/hermes /usr/bin/hermes


### PR DESCRIPTION
Closes: #787

## Description
The added Dockerfile is deployed under `informaldev/hermes` and it's used for internal testing in our Cephalopod infrastructure.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [X] Re-reviewed `Files changed` in the Github PR explorer.