### PR TITLE
Add option to specify which events to listen for in `listen` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Added `client-upgrade` CLI ([#357])
   - Update gaia to version 4.1.0 for e2e tests on CI ([#702])
   - Add `start-multi` command to relay on all paths defined in the configuration ([#748])
+  - Add option to specify which events to listen for in `listen` command ([#550])
 
 ### IMPROVEMENTS
 
@@ -71,6 +72,7 @@
 [#357]: https://github.com/informalsystems/ibc-rs/issues/357
 [#416]: https://github.com/informalsystems/ibc-rs/issues/416
 [#561]: https://github.com/informalsystems/ibc-rs/issues/561
+[#550]: https://github.com/informalsystems/ibc-rs/issues/550
 [#599]: https://github.com/informalsystems/ibc-rs/issues/599
 [#630]: https://github.com/informalsystems/ibc-rs/issues/630
 [#672]: https://github.com/informalsystems/ibc-rs/issues/672


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #550

## Description


```
USAGE:
    hermes listen <OPTIONS>

DESCRIPTION:
    Listen to and display IBC events emitted by a chain

POSITIONAL ARGUMENTS:
    chain_id                  Identifier of the chain to listen for events from

FLAGS:
    -e, --event EVENT         Add an event type to listen for, can be repeated. Listen for all events by default (available: Tx, NewBlock)
```

---

**Listen for default events:**

```
$ hermes listen ibc-0
[info ] Listening for events `NewBlock, Tx` on 'ibc-0'...
```

**Listen for `NewBlock` event only:**

```
$ hermes listen ibc-0 -e NewBlock
[info ] Listening for events `NewBlock` on 'ibc-0'...
```

**Listen for `NewBlock` and `Tx` events:**

```
$ hermes listen ibc-0 -e NewBlock -e Tx
[info ] Listening for events `NewBlock, Tx` on 'ibc-0'...
```


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.