### PR TITLE
Set allow_update_..flags in client state to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
-# Changelog
-
 ## Unreleased
 
+> [TODO: high level summary]
+
+### IMPROVEMENTS
+
+- [ibc-relayer]
+  - Change the default for client creation to allow governance recovery in case of expiration or misbehaviour. ([#785])
+
+### BREAKING CHANGES
+
 > Nothing yet.
+
+[#785]: https://github.com/informalsystems/ibc-rs/issues/785
 
 ## v0.2.0
 *April 14th, 2021*

--- a/e2e/e2e/client.py
+++ b/e2e/e2e/client.py
@@ -51,11 +51,14 @@ class TxUpdateClient(Cmd[ClientUpdated]):
 
 # -----------------------------------------------------------------------------
 
+@dataclass
+class AllowUpdate:
+    after_expiry: bool
+    after_misbehaviour: bool
+
 
 @dataclass
 class ClientState:
-    allow_update_after_expiry: bool
-    allow_update_after_misbehaviour: bool
     chain_id: ChainId
     frozen_height: Height
     latest_height: Height
@@ -64,6 +67,7 @@ class ClientState:
     trusting_period: Duration
     unbonding_period: Duration
     upgrade_path: List[str]
+    allow_update: AllowUpdate
 
 
 @dataclass

--- a/modules/src/ics02_client/handler/create_client.rs
+++ b/modules/src/ics02_client/handler/create_client.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::ics02_client::handler::{dispatch, ClientResult};
     use crate::ics02_client::msgs::create_client::MsgCreateAnyClient;
     use crate::ics02_client::msgs::ClientMsg;
-    use crate::ics07_tendermint::client_state::ClientState;
+    use crate::ics07_tendermint::client_state::{AllowUpdate, ClientState};
     use crate::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
     use crate::ics24_host::identifier::ClientId;
     use crate::mock::client_state::{MockClientState, MockConsensusState};
@@ -232,8 +232,10 @@ mod tests {
             max_clock_drift: Duration::from_millis(3000),
             latest_height: Height::new(0, u64::from(tm_header.height)),
             frozen_height: Height::zero(),
-            allow_update_after_expiry: false,
-            allow_update_after_misbehaviour: false,
+            allow_update: AllowUpdate {
+                after_expiry: false,
+                after_misbehaviour: false,
+            },
             upgrade_path: vec!["".to_string()],
         });
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -1173,12 +1173,12 @@ impl Chain for CosmosSdkChain {
             self.config.trust_threshold,
             self.config.trusting_period,
             self.unbonding_period()?,
-            Duration::from_millis(3000), // TODO - get it from src config when avail
+            self.config.clock_drift,
             height,
             ICSHeight::zero(),
             vec!["upgrade".to_string(), "upgradedIBCState".to_string()],
-            false,
-            false,
+            true,
+            true,
         )
         .map_err(|e| Kind::BuildClientStateFailure.context(e))?)
     }

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -31,7 +31,7 @@ use ibc::ics03_connection::connection::ConnectionEnd;
 use ibc::ics04_channel::channel::{ChannelEnd, QueryPacketEventDataRequest};
 use ibc::ics04_channel::events as ChannelEvents;
 use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
-use ibc::ics07_tendermint::client_state::ClientState;
+use ibc::ics07_tendermint::client_state::{AllowUpdate, ClientState};
 use ibc::ics07_tendermint::consensus_state::ConsensusState as TMConsensusState;
 use ibc::ics07_tendermint::header::Header as TmHeader;
 use ibc::ics23_commitment::commitment::CommitmentPrefix;
@@ -1168,7 +1168,7 @@ impl Chain for CosmosSdkChain {
 
     fn build_client_state(&self, height: ICSHeight) -> Result<Self::ClientState, Error> {
         // Build the client state.
-        Ok(ibc::ics07_tendermint::client_state::ClientState::new(
+        Ok(ClientState::new(
             self.id().clone(),
             self.config.trust_threshold,
             self.config.trusting_period,
@@ -1177,8 +1177,10 @@ impl Chain for CosmosSdkChain {
             height,
             ICSHeight::zero(),
             vec!["upgrade".to_string(), "upgradedIBCState".to_string()],
-            true,
-            true,
+            AllowUpdate {
+                after_expiry: true,
+                after_misbehaviour: true,
+            },
         )
         .map_err(|e| Kind::BuildClientStateFailure.context(e))?)
     }

--- a/relayer/src/chain/mock.rs
+++ b/relayer/src/chain/mock.rs
@@ -15,7 +15,7 @@ use ibc::ics02_client::client_state::AnyClientState;
 use ibc::ics03_connection::connection::ConnectionEnd;
 use ibc::ics04_channel::channel::ChannelEnd;
 use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
-use ibc::ics07_tendermint::client_state::ClientState as TendermintClientState;
+use ibc::ics07_tendermint::client_state::{AllowUpdate, ClientState as TendermintClientState};
 use ibc::ics07_tendermint::consensus_state::ConsensusState as TendermintConsensusState;
 use ibc::ics07_tendermint::header::Header as TendermintHeader;
 use ibc::ics18_relayer::context::Ics18Context;
@@ -282,7 +282,7 @@ impl Chain for MockChain {
     }
 
     fn build_client_state(&self, height: Height) -> Result<Self::ClientState, Error> {
-        let client_state = Self::ClientState::new(
+        let client_state = TendermintClientState::new(
             self.id().clone(),
             self.config.trust_threshold,
             self.config.trusting_period,
@@ -291,8 +291,10 @@ impl Chain for MockChain {
             height,
             Height::zero(),
             vec!["upgrade/upgradedClient".to_string()],
-            false,
-            false,
+            AllowUpdate {
+                after_expiry: false,
+                after_misbehaviour: false,
+            },
         )
         .map_err(|e| Kind::BuildClientStateFailure.context(e))?;
 


### PR DESCRIPTION
Get clock drift from configuration

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #785

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- set allow_update_..` flags in tendermint client state builder to `true`
- get the clock drift from config

Note: the `build_client_state()` should eventually become parameterized once we allow parameters in `hermes create client`. This will be done in another PR.
______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.