### PR TITLE
Add `--coin-type` option to `keys restore` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-stream"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+checksum = "0a26cb53174ddd320edfff199a853f93d571f48eeb4dde75e67a9a3dbb7b7e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+checksum = "db134ba52475c060f3329a8ef0f8786d6b872ed01515d4b79c162e5798da1340"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -173,9 +173,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "78ed203b9ba68b242c62b3fb7480f589dd49829be1edb3fe8fc8b4ffda2dcb8d"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -1077,15 +1077,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.6"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+checksum = "4a1ce40d6fc9764887c2fdc7305c3dcc429ba11ff981c1509416afd5697e4437"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "humantime"
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1302,9 +1302,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1392,9 +1392,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1405,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "lock_api"
@@ -1706,18 +1706,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2032,9 +2032,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64",
  "log",
@@ -2319,9 +2319,9 @@ checksum = "cc47a29ce97772ca5c927f75bac34866b16d64e07f330c3248e2d7226623901b"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "sled"
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2999,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "utf-8"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -3011,9 +3011,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"
@@ -3191,18 +3191,18 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -25,7 +25,7 @@ ibc-relayer = { version = "0.2.0", path = "../relayer" }
 ibc-proto   = { version = "0.8.0", path = "../proto" }
 
 anomaly = "0.2.0"
-gumdrop = "0.7"
+gumdrop = { version = "0.7", features = ["default_expr"] }
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 tokio = { version = "1.0", features = ["full"] }

--- a/relayer-cli/src/commands/keys/restore.rs
+++ b/relayer-cli/src/commands/keys/restore.rs
@@ -17,12 +17,16 @@ pub struct KeyRestoreCmd {
 
     #[options(short = "m", required, help = "mnemonic to restore the key from")]
     mnemonic: String,
+
+    #[options(short = "t", help = "coin-type to restore the key from")]
+    coin_type: Option<String>,
 }
 
 #[derive(Clone, Debug)]
 pub struct KeysRestoreOptions {
     pub mnemonic: String,
     pub config: ChainConfig,
+    pub coin_type: Option<String>,
 }
 
 impl KeyRestoreCmd {
@@ -34,6 +38,7 @@ impl KeyRestoreCmd {
         Ok(KeysRestoreOptions {
             mnemonic: self.mnemonic.clone(),
             config: chain_config.clone(),
+            coin_type: self.coin_type.clone(),
         })
     }
 }
@@ -49,7 +54,7 @@ impl Runnable for KeyRestoreCmd {
 
         let key_name = opts.config.key_name.clone();
         let chain_id = opts.config.id.clone();
-        let key = restore_key(&opts.mnemonic, opts.config);
+        let key = restore_key(&opts.mnemonic, &opts.coin_type.as_deref(), opts.config);
 
         match key {
             Ok(key) => Output::success_msg(format!(
@@ -62,9 +67,9 @@ impl Runnable for KeyRestoreCmd {
     }
 }
 
-pub fn restore_key(mnemonic: &str, config: ChainConfig) -> Result<KeyEntry, BoxError> {
+pub fn restore_key(mnemonic: &str, coin_type: &Option<&str>, config: ChainConfig) -> Result<KeyEntry, BoxError> {
     let mut keyring = KeyRing::new(Store::Test, config)?;
-    let key_entry = keyring.key_from_mnemonic(mnemonic)?;
+    let key_entry = keyring.key_from_mnemonic(mnemonic, coin_type)?;
     keyring.add_key(key_entry.clone())?;
 
     Ok(key_entry)

--- a/relayer-cli/src/commands/keys/restore.rs
+++ b/relayer-cli/src/commands/keys/restore.rs
@@ -1,10 +1,10 @@
 use abscissa_core::{Command, Options, Runnable};
-
 use anomaly::BoxError;
+
 use ibc::ics24_host::identifier::ChainId;
 use ibc_relayer::{
     config::{ChainConfig, Config},
-    keyring::{KeyEntry, KeyRing, Store},
+    keyring::{CoinType, KeyEntry, KeyRing, Store},
 };
 
 use crate::application::app_config;
@@ -18,15 +18,19 @@ pub struct KeyRestoreCmd {
     #[options(short = "m", required, help = "mnemonic to restore the key from")]
     mnemonic: String,
 
-    #[options(short = "t", help = "coin-type to restore the key from")]
-    coin_type: Option<String>,
+    #[options(
+        short = "t",
+        help = "coin type of the key to restore, default: 118 (Atom)",
+        default_expr = "CoinType::ATOM"
+    )]
+    coin_type: CoinType,
 }
 
 #[derive(Clone, Debug)]
 pub struct KeysRestoreOptions {
     pub mnemonic: String,
     pub config: ChainConfig,
-    pub coin_type: Option<String>,
+    pub coin_type: CoinType,
 }
 
 impl KeyRestoreCmd {
@@ -38,7 +42,7 @@ impl KeyRestoreCmd {
         Ok(KeysRestoreOptions {
             mnemonic: self.mnemonic.clone(),
             config: chain_config.clone(),
-            coin_type: self.coin_type.clone(),
+            coin_type: self.coin_type,
         })
     }
 }
@@ -54,7 +58,7 @@ impl Runnable for KeyRestoreCmd {
 
         let key_name = opts.config.key_name.clone();
         let chain_id = opts.config.id.clone();
-        let key = restore_key(&opts.mnemonic, &opts.coin_type.as_deref(), opts.config);
+        let key = restore_key(&opts.mnemonic, opts.coin_type, opts.config);
 
         match key {
             Ok(key) => Output::success_msg(format!(
@@ -67,7 +71,11 @@ impl Runnable for KeyRestoreCmd {
     }
 }
 
-pub fn restore_key(mnemonic: &str, coin_type: &Option<&str>, config: ChainConfig) -> Result<KeyEntry, BoxError> {
+pub fn restore_key(
+    mnemonic: &str,
+    coin_type: CoinType,
+    config: ChainConfig,
+) -> Result<KeyEntry, BoxError> {
     let mut keyring = KeyRing::new(Store::Test, config)?;
     let key_entry = keyring.key_from_mnemonic(mnemonic, coin_type)?;
     keyring.add_key(key_entry.clone())?;

--- a/relayer/src/keyring.rs
+++ b/relayer/src/keyring.rs
@@ -342,8 +342,10 @@ fn private_key_from_mnemonic(
     let seed = Seed::new(&mnemonic, "");
 
     // Get Private Key from seed and standard derivation path
-    let hd_path =
-        StandardHDPath::try_from(format!("m/44'/{}'/0'/0/0", coin_type.num()).as_str()).unwrap();
+    let hd_path_format = format!("m/44'/{}'/0'/0/0", coin_type.num());
+    let hd_path = StandardHDPath::try_from(hd_path_format.as_str())
+        .map_err(|_| Kind::InvalidHdPath(hd_path_format))?;
+
     let private_key = ExtendedPrivKey::new_master(Network::Bitcoin, seed.as_bytes())
         .and_then(|k| k.derive_priv(&Secp256k1::new(), &DerivationPath::from(hd_path)))
         .map_err(|e| Kind::PrivateKey.context(e))?;

--- a/relayer/src/keyring/errors.rs
+++ b/relayer/src/keyring/errors.rs
@@ -31,6 +31,9 @@ pub enum Kind {
 
     #[error("key store error")]
     KeyStore,
+
+    #[error("invalid HD path: {0}")]
+    InvalidHdPath(String),
 }
 
 impl Kind {


### PR DESCRIPTION
Original PR by @allthatjazzleo: #848 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #847

## Description
The key cannot be properly restored for chain with coin-type other than cosmos 118

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.