### PR TITLE
Fix communication with runtime for build_header and misbehaviour

### DIFF
--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -254,6 +254,8 @@ macro_rules! attribute {
 #[macro_export]
 macro_rules! some_attribute {
     ($a:ident, $b:literal) => {
-        $a.events.get($b).ok_or($b)?[$a.idx].parse().ok()
+        $a.events
+            .get($b)
+            .map_or_else(|| None, |tags| tags[$a.idx].parse().ok())
     };
 }

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -447,10 +447,10 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
     ) -> Result<(), Error> {
         let misbehaviour = self
             .light_client
-            .check_misbehaviour(update_event, &client_state)?;
+            .check_misbehaviour(update_event, &client_state);
 
         reply_to
-            .send(Ok(misbehaviour))
+            .send(misbehaviour)
             .map_err(|e| Kind::Channel.context(e))?;
 
         Ok(())

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -370,25 +370,27 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
         client_state: AnyClientState,
         reply_to: ReplyTo<AnyHeader>,
     ) -> Result<(), Error> {
-        let header = {
-            // Get the light block at trusted_height + 1 from chain.
-            //
-            // TODO: This is tendermint specific and needs to be refactored during
-            //       the relayer light client refactoring.
-            // NOTE: This is needed to get the next validator set. While there is a next validator set
-            //       in the light block at trusted height, the proposer is not known/set in this set.
-            let trusted_light_block = self.light_client.fetch(trusted_height.increment())?;
+        // Get the light block at trusted_height + 1 from chain.
+        //
+        // TODO: This is tendermint specific and needs to be refactored during
+        //       the relayer light client refactoring.
+        // NOTE: This is needed to get the next validator set. While there is a next validator set
+        //       in the light block at trusted height, the proposer is not known/set in this set.
+        let trusted_light_block = self.light_client.fetch(trusted_height.increment());
 
-            // Get the light block at target_height from chain.
-            let target_light_block =
-                self.light_client
-                    .verify(trusted_height, target_height, &client_state)?;
+        // Get the light block at target_height from chain.
+        let target_light_block =
+            self.light_client
+                .verify(trusted_height, target_height, &client_state);
 
-            let header =
-                self.chain
-                    .build_header(trusted_height, trusted_light_block, target_light_block)?;
-
-            Ok(header.wrap_any())
+        // Try to build the header, return first error encountered.
+        let header = match (trusted_light_block, target_light_block) {
+            (Err(eta), _) => Err(eta),
+            (_, Err(etr)) => Err(etr),
+            (Ok(trusted_light_block), Ok(target_light_block)) => self
+                .chain
+                .build_header(trusted_height, trusted_light_block, target_light_block)
+                .map_or_else(Err, |header| Ok(header.wrap_any())),
         };
 
         reply_to

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -40,7 +40,7 @@ pub enum ForeignClientError {
     #[error("failed while finding client {0}: expected chain_id in client state: {1}; actual chain_id: {2}")]
     ClientFind(ClientId, ChainId, ChainId),
 
-    #[error("error raised while submitting the misbehaviour evidence: {0}")]
+    #[error("error raised while checking for misbehaviour evidence: {0}")]
     Misbehaviour(String),
 
     #[error("failed while trying to upgrade client id {0} with error: {1}")]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
Fixes are included for the following issues:
- when errors are detected in the runtime they should be sent via the channel to the caller. This is generally the case with all our APIs, except:
  - `build_header()`
  - `check_misbehaviour()`
- the update client event is not properly decoded (e.g. by the `hermes listen` command) when header field is `None`
- `some_attribute` macro returns error when the field is not present (the intent is to return `None` when field is missing, `Some(obj)` if attribute parses ok, bubble up error otherwise)

These issues were discovered when @andynog was testing hermes on `akashnet-2` that is using an older SDK version (v0.41.3): no header in update client event, causing misbehavior check to return error (fine) that it is then improperly handled (bad).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.