### PR TITLE
Update supported Rust version to 1.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@
 [![End to End testing][e2e-image]][e2e-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![Rust Stable][rustc-image]
-![Rust 1.49+][rustc-version]
+![Rust 1.51+][rustc-version]
 
 Rust implementation of the Inter-Blockchain Communication (IBC) protocol.
 
 This project comprises primarily four crates:
- 
-- The [`ibc`][ibc-crate-link] crate defines the main data structures and 
+
+- The [`ibc`][ibc-crate-link] crate defines the main data structures and
   on-chain logic for the IBC protocol.
-- The [`ibc-relayer`][relayer-crate-link] crate provides an implementation 
+- The [`ibc-relayer`][relayer-crate-link] crate provides an implementation
   of an IBC relayer, as a _library_.
-- The [`ibc-relayer-cli`][relayer-cli-crate-link] is a CLI (a wrapper 
-  over the `ibc-relayer` library), comprising the 
+- The [`ibc-relayer-cli`][relayer-cli-crate-link] is a CLI (a wrapper
+  over the `ibc-relayer` library), comprising the
   [`hermes`](https://hermes.informal.systems) binary.
-- The [`ibc-proto`][ibc-proto-crate-link] is a library with proto definitions 
+- The [`ibc-proto`][ibc-proto-crate-link] is a library with proto definitions
   necessary for interacting with Cosmos SDK
   [IBC structs](https://github.com/cosmos/cosmos-sdk/tree/master/proto/ibc).
 
@@ -33,9 +33,9 @@ Includes [TLA+ specifications](/docs/spec).
 | [ibc-proto](./proto)  | lib |  [![IBC Proto Crate][ibc-proto-crate-image]][ibc-proto-crate-link]      |  [![IBC Proto Docs][ibc-proto-docs-image]][ibc-proto-docs-link] |
 
 
-## Requirements 
+## Requirements
 
-Developed with the latest stable version of Rust: `1.49.0`. 
+Developed with the latest stable version of Rust: `1.51.0`.
 (May work with older versions.)
 
 ## Hermes Guide
@@ -56,7 +56,7 @@ See also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Versioning
 
-We follow [Semantic Versioning](https://semver.org/), though APIs are still 
+We follow [Semantic Versioning](https://semver.org/), though APIs are still
 under active development.
 
 ## Resources
@@ -100,4 +100,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-blue.svg
 [license-link]: https://github.com/informalsystems/ibc-rs/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-stable-blue.svg
-[rustc-version]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-version]: https://img.shields.io/badge/rustc-1.51+-blue.svg

--- a/guide/src/pre_requisites.md
+++ b/guide/src/pre_requisites.md
@@ -12,14 +12,14 @@ The provided instructions will install all the Rust toolchain including `rustc`,
 
 ### Version requirements
 
-Hermes is developed and tested using the latest version of Rust, `1.49` at 
+Hermes is developed and tested using the latest version of Rust, `1.51` at
 the moment. To check that your toolchain is up-to-date run:
 
 ```shell
 rustc --version
 ```
 
-In case you already had installed the Rust toolchain in the past, you can 
+In case you already had installed the Rust toolchain in the past, you can
 update your installation by running `rustup update`.
 
 ### Testing the installation

--- a/modules/README.md
+++ b/modules/README.md
@@ -6,7 +6,7 @@
 [![End to End testing][e2e-image]][e2e-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![Rust Stable][rustc-image]
-![Rust 1.49+][rustc-version]
+![Rust 1.51+][rustc-version]
 
 
 See the [ibc-rs] repo root for more detailed information on how this crate can be used.
@@ -43,7 +43,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/informalsystems/ibc-rs/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-stable-blue.svg
-[rustc-version]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-version]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 
 [//]: # (general links)
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -6,7 +6,7 @@
 [![End to End testing][e2e-image]][e2e-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![Rust Stable][rustc-image]
-![Rust 1.49+][rustc-version]
+![Rust 1.51+][rustc-version]
 
 Rust crate for interacting with Cosmos SDK
 [IBC structs](https://github.com/cosmos/cosmos-sdk/tree/master/proto/ibc).
@@ -15,7 +15,7 @@ Rust crate for interacting with Cosmos SDK
 
 ## Requirements
 
-- Rust 1.49+
+- Rust 1.51+
 - `make`, `curl`
 - Cosmos SDK (downloaded automatically if you are using `make`)
 
@@ -50,7 +50,7 @@ limitations under the License.
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/informalsystems/ibc-rs/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-stable-blue.svg
-[rustc-version]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-version]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 
 [//]: # (general links)
 

--- a/relayer-cli/README.md
+++ b/relayer-cli/README.md
@@ -6,7 +6,7 @@
 [![End to End testing][e2e-image]][e2e-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![Rust Stable][rustc-image]
-![Rust 1.49+][rustc-version]
+![Rust 1.51+][rustc-version]
 
 This is the repository for the CLI of the IBC Relayer built in Rust, called 
 `hermes`.
@@ -40,4 +40,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/informalsystems/ibc-rs/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-stable-blue.svg
-[rustc-version]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-version]: https://img.shields.io/badge/rustc-1.51+-blue.svg

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -6,7 +6,7 @@
 [![End to End testing][e2e-image]][e2e-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
 ![Rust Stable][rustc-image]
-![Rust 1.49+][rustc-version]
+![Rust 1.51+][rustc-version]
 
 This is the repository for the IBC Relayer built in Rust, as a library.
 
@@ -37,4 +37,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/informalsystems/ibc-rs/blob/master/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-stable-blue.svg
-[rustc-version]: https://img.shields.io/badge/rustc-1.49+-blue.svg
+[rustc-version]: https://img.shields.io/badge/rustc-1.51+-blue.svg


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Supersedes: #859

## Description

On Rust 1.49, `cargo build` yields:

```
  --> relayer-cli/src/components.rs:92:10
   |
92 |         .reduce(|a, b| format!("{},{}", a, b))
   |          ^^^^^^ method not found in `std::iter::Map<std::slice::Iter<'_, &str>, [closure@relayer-cli/src/components.rs:91:14: 91:49]>`
```


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.