### PR TITLE
Fix for `chain_version` parsing when chain identifier has multiple dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Special thanks to external contributors:
+Jongwhan Lee (@leejw51crypto) ([#878]).
+
 > [TODO: high level summary]
 
 ### IMPROVEMENTS
@@ -12,6 +15,9 @@
   - Change the default for client creation to allow governance recovery in case of expiration or misbehaviour ([#785])
 
 ### BUG FIXES
+
+- [ibc]
+  - Fix parsing in `chain_version` when chain identifier has multiple dashes ([#878])
 
 - [ibc-relayer]
   - Fix pagination in gRPC query for clients ([#811])
@@ -35,6 +41,7 @@
 [#854]: https://github.com/informalsystems/ibc-rs/issues/854
 [#861]: https://github.com/informalsystems/ibc-rs/issues/861
 [#869]: https://github.com/informalsystems/ibc-rs/issues/869
+[#878]: https://github.com/informalsystems/ibc-rs/issues/878
 
 
 ## v0.2.0

--- a/modules/src/ics24_host/identifier.rs
+++ b/modules/src/ics24_host/identifier.rs
@@ -59,7 +59,7 @@ impl ChainId {
         }
 
         let split: Vec<_> = chain_id.split('-').collect();
-        split[1].parse().unwrap_or(0)
+        split.last().expect("get revision number from chain_id").parse().unwrap_or(0)
     }
 
     /// is_epoch_format() checks if a chain_id is in the format required for parsing epochs

--- a/modules/src/ics24_host/identifier.rs
+++ b/modules/src/ics24_host/identifier.rs
@@ -53,13 +53,25 @@ impl ChainId {
     }
 
     /// Extract the version from the given chain identifier.
+    /// ```
+    /// use ibc::ics24_host::identifier::ChainId;
+    ///
+    /// assert_eq!(ChainId::chain_version("chain--a-0"), 0);
+    /// assert_eq!(ChainId::chain_version("ibc-10"), 10);
+    /// assert_eq!(ChainId::chain_version("cosmos-hub-97"), 97);
+    /// assert_eq!(ChainId::chain_version("testnet-helloworld-2"), 2);
+    /// ```
     pub fn chain_version(chain_id: &str) -> u64 {
         if !ChainId::is_epoch_format(chain_id) {
             return 0;
         }
 
         let split: Vec<_> = chain_id.split('-').collect();
-        split.last().expect("get revision number from chain_id").parse().unwrap_or(0)
+        split
+            .last()
+            .expect("get revision number from chain_id")
+            .parse()
+            .unwrap_or(0)
     }
 
     /// is_epoch_format() checks if a chain_id is in the format required for parsing epochs


### PR DESCRIPTION

Co-authored-by: jongwhan lee.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This is the continuation of the work from https://github.com/informalsystems/ibc-rs/pull/879.
Closes: #878

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.