### PR TITLE
Fix crash during initialization of event monitor when node is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Jongwhan Lee (@leejw51crypto) ([#878]).
   - Fix pagination in gRPC query for clients ([#811])
   - Fix relayer crash when hermes starts in the same time as packets are being sent ([#851])
   - Fix missing port information in `hermes query channels` ([#840])
+  - Fix crash during initialization of event monitor when node is down ([#863])
 
 - [ibc-relayer-cli]
   - Fix for `ft-transfer` mismatching arguments ([#869])
@@ -46,6 +47,7 @@ Jongwhan Lee (@leejw51crypto) ([#878]).
 [#851]: https://github.com/informalsystems/ibc-rs/issues/851
 [#854]: https://github.com/informalsystems/ibc-rs/issues/854
 [#861]: https://github.com/informalsystems/ibc-rs/issues/861
+[#863]: https://github.com/informalsystems/ibc-rs/issues/863
 [#869]: https://github.com/informalsystems/ibc-rs/issues/869
 [#878]: https://github.com/informalsystems/ibc-rs/issues/878
 

--- a/relayer-cli/src/commands/start_multi.rs
+++ b/relayer-cli/src/commands/start_multi.rs
@@ -89,6 +89,7 @@ fn start_all_connections(config: &Config) -> Result<Output, BoxError> {
             let chain_b = registry.get_or_spawn(&conn.b_chain);
 
             let (chain_a, chain_b) = match (chain_a, chain_b) {
+                (Ok(a), Ok(b)) => (a, b),
                 (Err(err), _) => {
                     error!(
                         "failed to initialize runtime for chain '{}': {}",
@@ -99,11 +100,10 @@ fn start_all_connections(config: &Config) -> Result<Output, BoxError> {
                 (_, Err(err)) => {
                     error!(
                         "failed to initialize runtime for chain '{}': {}",
-                        conn.a_chain, err
+                        conn.b_chain, err
                     );
                     continue;
                 }
-                (Ok(a), Ok(b)) => (a, b),
             };
 
             s.spawn(|_| {

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -379,7 +379,7 @@ impl Chain for CosmosSdkChain {
         )
         .map_err(Kind::EventMonitor)?;
 
-        event_monitor.subscribe().unwrap();
+        event_monitor.subscribe().map_err(Kind::EventMonitor)?;
 
         let monitor_thread = thread::spawn(move || event_monitor.run());
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -376,9 +376,11 @@ impl Chain for CosmosSdkChain {
             self.config.id.clone(),
             self.config.websocket_addr.clone(),
             rt,
-        )?;
+        )
+        .map_err(Kind::EventMonitor)?;
 
         event_monitor.subscribe().unwrap();
+
         let monitor_thread = thread::spawn(move || event_monitor.run());
 
         Ok((event_receiver, Some(monitor_thread)))

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -89,10 +89,10 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
         let light_client = chain.init_light_client()?;
 
         // Start the event monitor
-        let (event_receiver, event_monitor_thread) = chain.init_event_monitor(rt.clone())?;
+        let (event_batch_rx, event_monitor_thread) = chain.init_event_monitor(rt.clone())?;
 
         // Instantiate & spawn the runtime
-        let (handle, runtime_thread) = Self::init(chain, light_client, event_receiver, rt);
+        let (handle, runtime_thread) = Self::init(chain, light_client, event_batch_rx, rt);
 
         let threads = Threads {
             chain_runtime: runtime_thread,

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -2,21 +2,22 @@ use std::{sync::Arc, thread};
 
 use crossbeam_channel as channel;
 use tokio::runtime::Runtime as TokioRuntime;
+use tracing::error;
 
-use ibc::ics02_client::client_consensus::AnyConsensusStateWithHeight;
-use ibc::ics02_client::events::UpdateClient;
-use ibc::ics02_client::misbehaviour::AnyMisbehaviour;
 use ibc::{
     events::IbcEvent,
     ics02_client::{
-        client_consensus::{AnyConsensusState, ConsensusState},
+        client_consensus::{AnyConsensusState, AnyConsensusStateWithHeight, ConsensusState},
         client_state::{AnyClientState, ClientState},
+        events::UpdateClient,
         header::{AnyHeader, Header},
+        misbehaviour::AnyMisbehaviour,
     },
-    ics03_connection::connection::ConnectionEnd,
-    ics03_connection::version::Version,
-    ics04_channel::channel::ChannelEnd,
-    ics04_channel::packet::{PacketMsgType, Sequence},
+    ics03_connection::{connection::ConnectionEnd, version::Version},
+    ics04_channel::{
+        channel::ChannelEnd,
+        packet::{PacketMsgType, Sequence},
+    },
     ics23_commitment::commitment::CommitmentPrefix,
     ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
     proofs::Proofs,
@@ -24,6 +25,7 @@ use ibc::{
     signer::Signer,
     Height,
 };
+
 use ibc_proto::ibc::core::client::v1::{QueryClientStatesRequest, QueryConsensusStatesRequest};
 use ibc_proto::ibc::core::{
     channel::v1::{
@@ -151,12 +153,13 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
         loop {
             channel::select! {
                 recv(self.event_receiver) -> event_batch => {
-                    if let Ok(event_batch) = event_batch {
-                        self.event_bus
-                            .broadcast(Arc::new(event_batch))
-                            .map_err(|e| Kind::Channel.context(e))?;
-                    } else {
-                        // TODO: Handle error
+                    match event_batch {
+                        Ok(event_batch) => {
+                            self.event_bus
+                                .broadcast(Arc::new(event_batch))
+                                .map_err(|e| Kind::Channel.context(e))?;
+                        },
+                        Err(e) => error!("received error via event bus: {}", e),
                     }
                 },
                 recv(self.request_receiver) -> event => {
@@ -290,7 +293,7 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
                             self.query_txs(request, reply_to)?
                         },
 
-                        Err(_e) => todo!(), // TODO: Handle error?
+                        Err(e) => error!("received error via chain request channel: {}", e),
                     }
                 },
             }

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -34,6 +34,10 @@ pub enum Kind {
     #[error("Websocket error to endpoint {0}")]
     Websocket(tendermint_rpc::Url),
 
+    /// Event monitor error
+    #[error("Event monitor")]
+    EventMonitor(crate::event::monitor::Error),
+
     /// GRPC error (typically raised by the GRPC client or the GRPC requester)
     #[error("GRPC error")]
     Grpc,

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -31,13 +31,13 @@ use ibc_proto::ibc::core::channel::v1::{
     QueryPacketCommitmentsRequest, QueryUnreceivedAcksRequest, QueryUnreceivedPacketsRequest,
 };
 
-use crate::chain::handle::ChainHandle;
 use crate::channel::{Channel, ChannelError, ChannelSide};
 use crate::connection::ConnectionError;
 use crate::error::Error;
 use crate::event::monitor::EventBatch;
 use crate::foreign_client::{ForeignClient, ForeignClientError};
 use crate::relay::MAX_ITER;
+use crate::{chain::handle::ChainHandle, transfer::PacketError};
 use ibc::events::VecIbcEvents;
 
 #[derive(Debug, Error)]
@@ -45,23 +45,26 @@ pub enum LinkError {
     #[error("failed with underlying error: {0}")]
     Failed(String),
 
+    #[error("failed with underlying error: {0}")]
+    Generic(#[from] Error),
+
     #[error("failed to construct packet proofs for chain {0} with error: {1}")]
     PacketProofsConstructor(ChainId, Error),
 
     #[error("failed during query to chain id {0} with underlying error: {1}")]
     QueryError(ChainId, Error),
 
-    #[error("ConnectionError: {0}:")]
+    #[error("connection error: {0}:")]
     ConnectionError(#[from] ConnectionError),
 
-    #[error("ChannelError:  {0}:")]
+    #[error("channel error:  {0}:")]
     ChannelError(#[from] ChannelError),
 
-    #[error("Failed during a client operation: {0}:")]
+    #[error("failed during a client operation: {0}:")]
     ClientError(ForeignClientError),
 
-    #[error("PacketError: {0}:")]
-    PacketError(#[from] Error),
+    #[error("packet error: {0}:")]
+    PacketError(#[from] PacketError),
 
     #[error("clearing of old packets failed")]
     OldPacketClearingFailed,

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anomaly::BoxError;
 use crossbeam_channel::{Receiver, Sender};
+use tracing::{error, error_span, info, warn};
 
 use ibc::{
     events::IbcEvent,
@@ -18,7 +19,6 @@ use ibc::{
     ics24_host::identifier::{ChainId, ChannelId, PortId},
     Height,
 };
-use tracing::{info, warn};
 
 use crate::{
     chain::handle::ChainHandle,
@@ -245,12 +245,15 @@ impl Worker {
 
     /// Run the worker event loop.
     fn run(self, object: Object) {
+        let span = error_span!("worker", path = %object.short_name());
+        let _guard = span.enter();
+
         let result = match object {
             Object::UnidirectionalChannelPath(path) => self.run_uni_chan_path(path),
         };
 
         if let Err(e) = result {
-            eprintln!("worker error: {}", e);
+            error!("worker error: {}", e);
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #863

## Description

- Fix crash during initialization of event monitor when node is down
- Skip spawning the supervisor for a pair of chains if the chain runtime initialization fails
- Improve modeling of errors in event monitor
- Add more context to worker error trace (ie. path short name)

## Follow-up

- [ ] It seems like the `WebSocketClient` does not notify us when the connection goes down so we cannot print a warning and try to reconnect. Will investigate and open an issue on tendermint-rs.

______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.