### PR TITLE
Don't handle optimistic sends, don't exit if chain doesn't include header in updates

### DIFF
--- a/modules/src/ics02_client/client_state.rs
+++ b/modules/src/ics02_client/client_state.rs
@@ -67,12 +67,21 @@ impl AnyClientState {
         }
     }
 
-    pub fn refresh_time(&self) -> Option<Duration> {
+    pub fn refresh_period(&self) -> Option<Duration> {
         match self {
             AnyClientState::Tendermint(tm_state) => tm_state.refresh_time(),
 
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(mock_state) => mock_state.refresh_time(),
+        }
+    }
+
+    pub fn expired(&self, elapsed_since_latest: Duration) -> bool {
+        match self {
+            AnyClientState::Tendermint(tm_state) => tm_state.expired(elapsed_since_latest),
+
+            #[cfg(any(test, feature = "mocks"))]
+            AnyClientState::Mock(mock_state) => mock_state.expired(elapsed_since_latest),
         }
     }
 }

--- a/modules/src/ics02_client/client_state.rs
+++ b/modules/src/ics02_client/client_state.rs
@@ -166,6 +166,15 @@ pub struct IdentifiedAnyClientState {
     pub client_state: AnyClientState,
 }
 
+impl IdentifiedAnyClientState {
+    pub fn new(client_id: ClientId, client_state: AnyClientState) -> Self {
+        IdentifiedAnyClientState {
+            client_id,
+            client_state,
+        }
+    }
+}
+
 impl Protobuf<IdentifiedClientState> for IdentifiedAnyClientState {}
 
 impl TryFrom<IdentifiedClientState> for IdentifiedAnyClientState {

--- a/modules/src/ics04_channel/channel.rs
+++ b/modules/src/ics04_channel/channel.rs
@@ -26,6 +26,16 @@ pub struct IdentifiedChannelEnd {
     pub channel_end: ChannelEnd,
 }
 
+impl IdentifiedChannelEnd {
+    pub fn new(port_id: PortId, channel_id: ChannelId, channel_end: ChannelEnd) -> Self {
+        IdentifiedChannelEnd {
+            port_id,
+            channel_id,
+            channel_end,
+        }
+    }
+}
+
 impl Protobuf<RawIdentifiedChannel> for IdentifiedChannelEnd {}
 
 impl TryFrom<RawIdentifiedChannel> for IdentifiedChannelEnd {

--- a/modules/src/ics04_channel/events.rs
+++ b/modules/src/ics04_channel/events.rs
@@ -159,6 +159,15 @@ pub struct Attributes {
     pub counterparty_channel_id: Option<ChannelId>,
 }
 
+impl Attributes {
+    pub fn port_id(&self) -> &PortId {
+        &self.port_id
+    }
+    pub fn channel_id(&self) -> &Option<ChannelId> {
+        &self.channel_id
+    }
+}
+
 impl Default for Attributes {
     fn default() -> Self {
         Attributes {
@@ -264,6 +273,9 @@ impl From<OpenTry> for IbcEvent {
 pub struct OpenAck(Attributes);
 
 impl OpenAck {
+    pub fn attributes(&self) -> &Attributes {
+        &self.0
+    }
     pub fn channel_id(&self) -> &Option<ChannelId> {
         &self.0.channel_id
     }
@@ -308,6 +320,9 @@ impl From<OpenAck> for IbcEvent {
 pub struct OpenConfirm(Attributes);
 
 impl OpenConfirm {
+    pub fn attributes(&self) -> &Attributes {
+        &self.0
+    }
     pub fn channel_id(&self) -> &Option<ChannelId> {
         &self.0.channel_id
     }

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -127,7 +127,13 @@ impl ClientState {
 
     /// Get the refresh time to ensure the state does not expire
     pub fn refresh_time(&self) -> Option<Duration> {
-        Some(self.trusting_period / 2)
+        Some(2 * self.trusting_period / 3)
+    }
+
+    /// Check if the state is expired when `elapsed` time has passed since the latest consensus
+    /// state timestamp
+    pub fn expired(&self, elapsed: Duration) -> bool {
+        elapsed > self.trusting_period
     }
 }
 

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -42,7 +42,7 @@ impl Header {
         match self_header_height.cmp(&&ibc_client_height) {
             Ordering::Equal => {
                 // 1 - fork
-                self.signed_header.commit.block_id != other_header.signed_header.commit.block_id
+                self.signed_header.commit.block_id == other_header.signed_header.commit.block_id
             }
             Ordering::Greater => {
                 // 2 - BFT time violation

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -42,7 +42,7 @@ impl Header {
         match self_header_height.cmp(&&ibc_client_height) {
             Ordering::Equal => {
                 // 1 - fork
-                self.signed_header.commit.block_id == other_header.signed_header.commit.block_id
+                self.signed_header.commit.block_id != other_header.signed_header.commit.block_id
             }
             Ordering::Greater => {
                 // 2 - BFT time violation

--- a/modules/src/mock/client_state.rs
+++ b/modules/src/mock/client_state.rs
@@ -49,6 +49,9 @@ impl MockClientState {
     pub fn refresh_time(&self) -> Option<Duration> {
         None
     }
+    pub fn expired(&self, _elapsed: Duration) -> bool {
+        false
+    }
 }
 
 impl From<MockClientState> for AnyClientState {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
Some leftover work from #872
- exit client worker only if expired or frozen
- don't handle optimistic sends
- start client worker when first channel is opened and not on update client event. The worker still receives the update client events and checks for misbehaviour

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.