### PR TITLE
Make supervisor more resilient to node going down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Jongwhan Lee (@leejw51crypto) ([#878]).
 
 - [ibc-relayer]
   - Change the default for client creation to allow governance recovery in case of expiration or misbehaviour ([#785])
+  - The relayer is now more resilient to a node not being up or going down, and will attempt to reconnect ([#871])
 
 ### BUG FIXES
 
@@ -54,6 +55,7 @@ Jongwhan Lee (@leejw51crypto) ([#878]).
 [#861]: https://github.com/informalsystems/ibc-rs/issues/861
 [#863]: https://github.com/informalsystems/ibc-rs/issues/863
 [#869]: https://github.com/informalsystems/ibc-rs/issues/869
+[#871]: https://github.com/informalsystems/ibc-rs/issues/871
 [#878]: https://github.com/informalsystems/ibc-rs/issues/878
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,7 @@ dependencies = [
  "k256",
  "prost",
  "prost-types",
+ "retry",
  "ripemd160",
  "serde",
  "serde_cbor",
@@ -2023,6 +2024,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "retry"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ee4a654b43dd7e3768be7a1c0fc20e90f0a84b72a60ffb6c11e1cae2545c2e"
 
 [[package]]
 name = "ring"

--- a/relayer-cli/src/commands/listen.rs
+++ b/relayer-cli/src/commands/listen.rs
@@ -1,7 +1,6 @@
 use std::{ops::Deref, sync::Arc, thread};
 
 use abscissa_core::{application::fatal_error, error::BoxError, Command, Options, Runnable};
-use crossbeam_channel as channel;
 use itertools::Itertools;
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -10,7 +9,7 @@ use tendermint_rpc::query::{EventType, Query};
 use ibc::ics24_host::identifier::ChainId;
 use ibc_relayer::{
     config::ChainConfig,
-    event::monitor::{Error as EventMonitorError, EventBatch, EventMonitor},
+    event::monitor::{EventMonitor, EventReceiver},
 };
 
 use crate::prelude::*;
@@ -76,13 +75,7 @@ fn subscribe(
     chain_config: &ChainConfig,
     queries: Vec<Query>,
     rt: Arc<TokioRuntime>,
-) -> Result<
-    (
-        EventMonitor,
-        channel::Receiver<Result<EventBatch, EventMonitorError>>,
-    ),
-    BoxError,
-> {
+) -> Result<(EventMonitor, EventReceiver), BoxError> {
     let (mut event_monitor, rx) = EventMonitor::new(
         chain_config.id.clone(),
         chain_config.websocket_addr.clone(),

--- a/relayer-cli/src/commands/listen.rs
+++ b/relayer-cli/src/commands/listen.rs
@@ -8,7 +8,10 @@ use tokio::runtime::Runtime as TokioRuntime;
 use tendermint_rpc::query::{EventType, Query};
 
 use ibc::ics24_host::identifier::ChainId;
-use ibc_relayer::{config::ChainConfig, event::monitor::*};
+use ibc_relayer::{
+    config::ChainConfig,
+    event::monitor::{Error as EventMonitorError, EventBatch, EventMonitor},
+};
 
 use crate::prelude::*;
 
@@ -73,7 +76,13 @@ fn subscribe(
     chain_config: &ChainConfig,
     queries: Vec<Query>,
     rt: Arc<TokioRuntime>,
-) -> Result<(EventMonitor, channel::Receiver<EventBatch>), BoxError> {
+) -> Result<
+    (
+        EventMonitor,
+        channel::Receiver<Result<EventBatch, EventMonitorError>>,
+    ),
+    BoxError,
+> {
     let (mut event_monitor, rx) = EventMonitor::new(
         chain_config.id.clone(),
         chain_config.websocket_addr.clone(),

--- a/relayer-cli/src/commands/start_multi.rs
+++ b/relayer-cli/src/commands/start_multi.rs
@@ -116,7 +116,7 @@ fn start_all_connections(config: &Config) -> Result<Output, BoxError> {
     });
 
     match result {
-        Ok(Ok(())) => Ok(Output::success_msg("ok")),
+        Ok(Ok(())) => Ok(Output::success_msg("supervisor shutdown")),
         Ok(Err(e)) => Err(e),
         Err(e) => std::panic::resume_unwind(e),
     }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -50,6 +50,7 @@ dyn-clonable = "0.9.0"
 tonic = "0.4"
 dirs-next = "2.0.0"
 dyn-clone = "1.0.3"
+retry = { version = "1.2.1", default-features = false }
 
 [dependencies.tendermint]
 version = "=0.19.0"

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, thread};
 
-use crossbeam_channel as channel;
 use prost_types::Any;
 use tendermint::block::Height;
 use tokio::runtime::Runtime as TokioRuntime;
@@ -33,12 +32,11 @@ use ibc_proto::ibc::core::connection::v1::{
     QueryClientConnectionsRequest, QueryConnectionsRequest,
 };
 
-use crate::config::ChainConfig;
 use crate::connection::ConnectionMsgType;
 use crate::error::{Error, Kind};
-use crate::event::monitor::EventBatch;
 use crate::keyring::{KeyEntry, KeyRing};
 use crate::light_client::LightClient;
+use crate::{config::ChainConfig, event::monitor::EventReceiver};
 
 pub(crate) mod cosmos;
 pub mod handle;
@@ -89,13 +87,7 @@ pub trait Chain: Sized {
     fn init_event_monitor(
         &self,
         rt: Arc<TokioRuntime>,
-    ) -> Result<
-        (
-            channel::Receiver<EventBatch>,
-            Option<thread::JoinHandle<()>>,
-        ),
-        Error,
-    >;
+    ) -> Result<(EventReceiver, Option<thread::JoinHandle<()>>), Error>;
 
     /// Returns the chain's identifier
     fn id(&self) -> &ChainId;

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -6,7 +6,6 @@ use std::{
 use anomaly::fail;
 use bech32::{ToBase32, Variant};
 use bitcoin::hashes::hex::ToHex;
-use crossbeam_channel as channel;
 use prost::Message;
 use prost_types::Any;
 use tendermint::abci::Path as TendermintABCIPath;
@@ -65,7 +64,7 @@ use ibc_proto::ibc::core::connection::v1::{
 use crate::chain::QueryResponse;
 use crate::config::ChainConfig;
 use crate::error::{Error, Kind};
-use crate::event::monitor::{EventBatch, EventMonitor};
+use crate::event::monitor::{EventMonitor, EventReceiver};
 use crate::keyring::{KeyEntry, KeyRing, Store};
 use crate::light_client::tendermint::LightClient as TmLightClient;
 use crate::light_client::LightClient;
@@ -361,13 +360,7 @@ impl Chain for CosmosSdkChain {
     fn init_event_monitor(
         &self,
         rt: Arc<TokioRuntime>,
-    ) -> Result<
-        (
-            channel::Receiver<EventBatch>,
-            Option<thread::JoinHandle<()>>,
-        ),
-        Error,
-    > {
+    ) -> Result<(EventReceiver, Option<thread::JoinHandle<()>>), Error> {
         crate::time!("init_event_monitor");
 
         let (mut event_monitor, event_receiver) = EventMonitor::new(

--- a/relayer/src/chain/handle.rs
+++ b/relayer/src/chain/handle.rs
@@ -34,13 +34,16 @@ use ibc_proto::ibc::core::client::v1::QueryConsensusStatesRequest;
 use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 pub use prod::ProdChainHandle;
 
-use crate::connection::ConnectionMsgType;
-use crate::keyring::KeyEntry;
-use crate::{error::Error, event::monitor::EventBatch};
+use crate::{
+    connection::ConnectionMsgType,
+    error::Error,
+    event::monitor::{Error as EventMonitorError, EventBatch},
+    keyring::KeyEntry,
+};
 
 mod prod;
 
-pub type Subscription = channel::Receiver<Arc<EventBatch>>;
+pub type Subscription = channel::Receiver<Arc<Result<EventBatch, EventMonitorError>>>;
 
 pub type ReplyTo<T> = channel::Sender<Result<T, Error>>;
 pub type Reply<T> = channel::Receiver<Result<T, Error>>;

--- a/relayer/src/chain/handle.rs
+++ b/relayer/src/chain/handle.rs
@@ -37,13 +37,13 @@ pub use prod::ProdChainHandle;
 use crate::{
     connection::ConnectionMsgType,
     error::Error,
-    event::monitor::{Error as EventMonitorError, EventBatch},
+    event::monitor::{EventBatch, Result as MonitorResult},
     keyring::KeyEntry,
 };
 
 mod prod;
 
-pub type Subscription = channel::Receiver<Arc<Result<EventBatch, EventMonitorError>>>;
+pub type Subscription = channel::Receiver<Arc<MonitorResult<EventBatch>>>;
 
 pub type ReplyTo<T> = channel::Sender<Result<T, Error>>;
 pub type Reply<T> = channel::Receiver<Result<T, Error>>;

--- a/relayer/src/chain/mock.rs
+++ b/relayer/src/chain/mock.rs
@@ -41,7 +41,7 @@ use ibc_proto::ibc::core::connection::v1::{
 use crate::chain::Chain;
 use crate::config::ChainConfig;
 use crate::error::{Error, Kind};
-use crate::event::monitor::EventBatch;
+use crate::event::monitor::EventReceiver;
 use crate::keyring::{KeyEntry, KeyRing};
 use crate::light_client::{mock::LightClient as MockLightClient, LightClient};
 
@@ -79,13 +79,7 @@ impl Chain for MockChain {
     fn init_event_monitor(
         &self,
         _rt: Arc<Runtime>,
-    ) -> Result<
-        (
-            channel::Receiver<EventBatch>,
-            Option<thread::JoinHandle<()>>,
-        ),
-        Error,
-    > {
+    ) -> Result<(EventReceiver, Option<thread::JoinHandle<()>>), Error> {
         let (_, rx) = channel::unbounded();
         Ok((rx, None))
     }

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -122,7 +122,12 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
         let handle = chain_runtime.handle();
 
         // Spawn the runtime & return
-        let thread = thread::spawn(move || chain_runtime.run().unwrap());
+        let id = handle.id();
+        let thread = thread::spawn(move || {
+            if let Err(e) = chain_runtime.run() {
+                error!("failed to start runtime for chain '{}': {}", id, e);
+            }
+        });
 
         (handle, thread)
     }

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -43,7 +43,7 @@ use crate::{
     error::{Error, Kind},
     event::{
         bus::EventBus,
-        monitor::{Error as EventMonitorError, EventBatch},
+        monitor::{EventBatch, EventReceiver, Result as MonitorResult},
     },
     keyring::KeyEntry,
     light_client::LightClient,
@@ -72,10 +72,10 @@ pub struct ChainRuntime<C: Chain> {
     request_receiver: channel::Receiver<ChainRequest>,
 
     /// An event bus, for broadcasting events that this runtime receives (via `event_receiver`) to subscribers
-    event_bus: EventBus<Arc<Result<EventBatch, EventMonitorError>>>,
+    event_bus: EventBus<Arc<MonitorResult<EventBatch>>>,
 
     /// Receiver channel from the event bus
-    event_receiver: channel::Receiver<Result<EventBatch, EventMonitorError>>,
+    event_receiver: EventReceiver,
 
     /// A handle to the light client
     light_client: Box<dyn LightClient<C>>,
@@ -113,7 +113,7 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
     fn init(
         chain: C,
         light_client: Box<dyn LightClient<C>>,
-        event_receiver: channel::Receiver<Result<EventBatch, EventMonitorError>>,
+        event_receiver: EventReceiver,
         rt: Arc<TokioRuntime>,
     ) -> (Box<dyn ChainHandle>, thread::JoinHandle<()>) {
         let chain_runtime = Self::new(chain, light_client, event_receiver, rt);
@@ -136,7 +136,7 @@ impl<C: Chain + Send + 'static> ChainRuntime<C> {
     fn new(
         chain: C,
         light_client: Box<dyn LightClient<C>>,
-        event_receiver: channel::Receiver<Result<EventBatch, EventMonitorError>>,
+        event_receiver: EventReceiver,
         rt: Arc<TokioRuntime>,
     ) -> Self {
         let (request_sender, request_receiver) = channel::unbounded::<ChainRequest>();

--- a/relayer/src/event/monitor.rs
+++ b/relayer/src/event/monitor.rs
@@ -4,7 +4,7 @@ use crossbeam_channel as channel;
 use futures::stream::StreamExt;
 use futures::{stream::select_all, Stream};
 use itertools::Itertools;
-use retry::delay::Exponential;
+use retry::delay::Fibonacci;
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio::{runtime::Runtime as TokioRuntime, sync::mpsc};
@@ -246,7 +246,7 @@ impl EventMonitor {
         use retry::{retry_with_index, OperationResult as TryResult};
 
         let strategy = Clamped::new(
-            Exponential::from_millis_with_factor(INITIAL_RETRY_DELAY.as_millis() as u64, 1.1),
+            Fibonacci::from(INITIAL_RETRY_DELAY),
             MAX_RETRY_DELAY,
             MAX_RETRIES,
         );

--- a/relayer/src/event/monitor.rs
+++ b/relayer/src/event/monitor.rs
@@ -111,7 +111,7 @@ async fn run_driver(
 ) {
     if let Err(e) = driver.run().await {
         if tx.send(e).is_err() {
-            println!("failed to relay driver error to event monitor");
+            error!("failed to relay driver error to event monitor");
         }
     }
 }
@@ -241,13 +241,13 @@ impl EventMonitor {
 
             // Try to reconnect
             if let Err(e) = self.try_reconnect() {
-                println!("error on reconnecting: {}", e);
+                error!("error when reconnecting: {}", e);
                 continue;
             }
 
             // Try to resubscribe
             if let Err(e) = self.try_resubscribe() {
-                println!("error on reconnecting: {}", e);
+                error!("error when reconnecting: {}", e);
                 continue;
             }
 

--- a/relayer/src/event/monitor.rs
+++ b/relayer/src/event/monitor.rs
@@ -1,33 +1,45 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crossbeam_channel as channel;
 use futures::stream::StreamExt;
 use futures::{stream::select_all, Stream};
 use itertools::Itertools;
-use tendermint_rpc::{query::EventType, query::Query, SubscriptionClient, WebSocketClient};
 use thiserror::Error;
-use tokio::runtime::Runtime as TokioRuntime;
 use tokio::task::JoinHandle;
+use tokio::{runtime::Runtime as TokioRuntime, sync::mpsc};
 use tracing::{debug, error, info, warn};
+
+use tendermint_rpc::{
+    event::Event as RpcEvent,
+    query::{EventType, Query},
+    Error as RpcError, Result as RpcResult, SubscriptionClient, WebSocketClient,
+    WebSocketClientDriver,
+};
 
 use ibc::{events::IbcEvent, ics02_client::height::Height, ics24_host::identifier::ChainId};
 
+const DEFAULT_RETRIES: usize = 100;
+const DEFAULT_DELAY: Duration = Duration::from_secs(5);
+
 #[derive(Debug, Clone, Error)]
 pub enum Error {
-    #[error("failed to create WebSocket client driver: {0}")]
-    ClientCreationFailed(tendermint_rpc::Error),
+    #[error("WebSocket driver failed: {0}")]
+    WebSocketDriver(RpcError),
 
-    #[error("failed to terminate previous WebSocket client driver: {0}")]
+    #[error("failed to create WebSocket driver: {0}")]
+    ClientCreationFailed(RpcError),
+
+    #[error("failed to terminate previous WebSocket driver: {0}")]
     ClientTerminationFailed(Arc<tokio::task::JoinError>),
 
-    #[error("failed to run previous WebSocket client driver to completion: {0}")]
-    ClientCompletionFailed(tendermint_rpc::Error),
+    #[error("failed to run previous WebSocket driver to completion: {0}")]
+    ClientCompletionFailed(RpcError),
 
     #[error("failed to subscribe to events via WebSocket client: {0}")]
-    ClientSubscriptionFailed(tendermint_rpc::Error),
+    ClientSubscriptionFailed(RpcError),
 
     #[error("failed to collect events over WebSocket subscription: {0}")]
-    NextEventBatchFailed(tendermint_rpc::Error),
+    NextEventBatchFailed(RpcError),
 
     #[error("failed to extract IBC events: {0}")]
     CollectEventsFailed(String),
@@ -44,14 +56,22 @@ pub struct EventBatch {
     pub events: Vec<IbcEvent>,
 }
 
-impl EventBatch {
-    pub fn unwrap_or_clone(self: Arc<Self>) -> Self {
+pub trait UnwrapOrClone {
+    fn unwrap_or_clone(self: Arc<Self>) -> Self;
+}
+
+impl UnwrapOrClone for Result<EventBatch> {
+    fn unwrap_or_clone(self: Arc<Self>) -> Self {
         Arc::try_unwrap(self).unwrap_or_else(|batch| batch.as_ref().clone())
     }
 }
 
-type SubscriptionResult = Result<tendermint_rpc::event::Event, tendermint_rpc::Error>;
+type SubscriptionResult = RpcResult<RpcEvent>;
 type SubscriptionStream = dyn Stream<Item = SubscriptionResult> + Send + Sync + Unpin;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub type EventReceiver = channel::Receiver<Result<EventBatch>>;
 
 /// Connect to a Tendermint node, subscribe to a set of queries,
 /// receive push events over a websocket, and filter them for the
@@ -66,11 +86,15 @@ type SubscriptionStream = dyn Stream<Item = SubscriptionResult> + Send + Sync + 
 pub struct EventMonitor {
     chain_id: ChainId,
     /// WebSocket to collect events from
-    websocket_client: WebSocketClient,
+    client: WebSocketClient,
     /// Async task handle for the WebSocket client's driver
-    websocket_driver_handle: JoinHandle<tendermint_rpc::Result<()>>,
+    driver_handle: JoinHandle<()>,
     /// Channel to handler where the monitor for this chain sends the events
-    tx_batch: channel::Sender<EventBatch>,
+    tx_batch: channel::Sender<Result<EventBatch>>,
+    /// Channel where to receive client driver errors
+    rx_err: mpsc::UnboundedReceiver<tendermint_rpc::Error>,
+    /// Channel where to send client driver errors
+    tx_err: mpsc::UnboundedSender<tendermint_rpc::Error>,
     /// Node Address
     node_addr: tendermint_rpc::Url,
     /// Queries
@@ -81,21 +105,33 @@ pub struct EventMonitor {
     rt: Arc<TokioRuntime>,
 }
 
+async fn run_driver(
+    driver: WebSocketClientDriver,
+    tx: mpsc::UnboundedSender<tendermint_rpc::Error>,
+) {
+    if let Err(e) = driver.run().await {
+        if tx.send(e).is_err() {
+            println!("failed to relay driver error to event monitor");
+        }
+    }
+}
+
 impl EventMonitor {
     /// Create an event monitor, and connect to a node
     pub fn new(
         chain_id: ChainId,
         node_addr: tendermint_rpc::Url,
         rt: Arc<TokioRuntime>,
-    ) -> Result<(Self, channel::Receiver<EventBatch>), Error> {
-        let (tx, rx) = channel::unbounded();
+    ) -> Result<(Self, EventReceiver)> {
+        let (tx_batch, rx_batch) = channel::unbounded();
 
         let ws_addr = node_addr.clone();
-        let (websocket_client, websocket_driver) = rt
-            .block_on(async move { WebSocketClient::new(ws_addr.clone()).await })
+        let (client, driver) = rt
+            .block_on(async move { WebSocketClient::new(ws_addr).await })
             .map_err(Error::ClientCreationFailed)?;
 
-        let websocket_driver_handle = rt.spawn(websocket_driver.run());
+        let (tx_err, rx_err) = mpsc::unbounded_channel();
+        let websocket_driver_handle = rt.spawn(run_driver(driver, tx_err.clone()));
 
         // TODO: move them to config file(?)
         let event_queries = vec![Query::from(EventType::Tx), Query::from(EventType::NewBlock)];
@@ -103,15 +139,17 @@ impl EventMonitor {
         let monitor = Self {
             rt,
             chain_id,
-            websocket_client,
-            websocket_driver_handle,
+            client,
+            driver_handle: websocket_driver_handle,
             event_queries,
-            tx_batch: tx,
+            tx_batch,
+            rx_err,
+            tx_err,
             node_addr,
             subscriptions: Box::new(futures::stream::empty()),
         };
 
-        Ok((monitor, rx))
+        Ok((monitor, rx_batch))
     }
 
     /// Set the queries to subscribe to.
@@ -131,7 +169,7 @@ impl EventMonitor {
     }
 
     /// Clear the current subscriptions, and subscribe again to all queries.
-    pub fn subscribe(&mut self) -> Result<(), Error> {
+    pub fn subscribe(&mut self) -> Result<()> {
         let mut subscriptions = vec![];
 
         for query in &self.event_queries {
@@ -139,7 +177,7 @@ impl EventMonitor {
 
             let subscription = self
                 .rt
-                .block_on(self.websocket_client.subscribe(query.clone()))
+                .block_on(self.client.subscribe(query.clone()))
                 .map_err(Error::ClientSubscriptionFailed)?;
 
             subscriptions.push(subscription);
@@ -152,85 +190,108 @@ impl EventMonitor {
         Ok(())
     }
 
-    fn try_reconnect(&mut self) -> Result<(), Error> {
+    fn try_reconnect(&mut self) -> Result<()> {
         warn!(
             "trying to reconnect to WebSocket endpoint: {}",
             self.node_addr
         );
 
         // Try to reconnect
-        let (mut websocket_client, websocket_driver) = self
+        let (mut client, driver) = self
             .rt
             .block_on(WebSocketClient::new(self.node_addr.clone()))
             .map_err(Error::ClientCreationFailed)?;
 
-        let mut websocket_driver_handle = self.rt.spawn(websocket_driver.run());
+        let mut driver_handle = self.rt.spawn(run_driver(driver, self.tx_err.clone()));
 
         // Swap the new client with the previous one which failed,
         // so that we can shut the latter down gracefully.
-        std::mem::swap(&mut self.websocket_client, &mut websocket_client);
-        std::mem::swap(
-            &mut self.websocket_driver_handle,
-            &mut websocket_driver_handle,
-        );
+        std::mem::swap(&mut self.client, &mut client);
+        std::mem::swap(&mut self.driver_handle, &mut driver_handle);
 
         warn!("reconnected to WebSocket endpoint: {}", self.node_addr);
 
         // Shut down previous client
         debug!("gracefully shutting down previous client");
 
-        if let Err(e) = websocket_client.close() {
+        if let Err(e) = client.close() {
             error!("previous websocket client closing failure {}", e);
         }
 
-        let result = self
-            .rt
-            .block_on(websocket_driver_handle)
+        self.rt
+            .block_on(driver_handle)
             .map_err(|e| Error::ClientTerminationFailed(Arc::new(e)))?;
 
         debug!("previous client successfully shutdown");
 
-        result.map_err(Error::ClientCompletionFailed)
+        Ok(())
     }
 
     /// Try to resubscribe to events
-    fn try_resubscribe(&mut self) -> Result<(), Error> {
+    fn try_resubscribe(&mut self) -> Result<()> {
         warn!("trying to resubscribe to events");
 
         self.subscribe()
+    }
+
+    /// Attempt to restart the WebSocket client at most a given number of times.
+    fn restart(&mut self, max_retries: usize, delay: Duration) {
+        for _ in 0..max_retries {
+            std::thread::sleep(delay);
+
+            // Try to reconnect
+            if let Err(e) = self.try_reconnect() {
+                println!("error on reconnecting: {}", e);
+                continue;
+            }
+
+            // Try to resubscribe
+            if let Err(e) = self.try_resubscribe() {
+                println!("error on reconnecting: {}", e);
+                continue;
+            }
+
+            return;
+        }
     }
 
     /// Event monitor loop
     pub fn run(mut self) {
         info!(chain.id = %self.chain_id, "starting event monitor");
 
+        let rt = self.rt.clone();
+
         loop {
-            match self.collect_events() {
+            let result = rt.block_on(async {
+                tokio::select! {
+                    Some(event) = self.subscriptions.next() => {
+                        event
+                            .map_err(Error::NextEventBatchFailed)
+                            .and_then(|e| self.collect_events(e))
+                    },
+                    Some(e) = self.rx_err.recv() => Err(Error::WebSocketDriver(e)),
+                }
+            });
+
+            match result {
                 Ok(batches) => self.process_batches(batches).unwrap_or_else(|e| {
                     error!("failed to process event batch: {}", e);
                 }),
                 Err(e) => {
                     error!("failed to collect events: {}", e);
 
-                    // Try to reconnect
-                    self.try_reconnect().unwrap_or_else(|e| {
-                        error!("error on reconnecting: {}", e);
-                    });
-
-                    // Try to resubscribe
-                    self.try_resubscribe().unwrap_or_else(|e| {
-                        error!("error on reconnecting: {}", e);
-                    });
+                    // Restart the event monitor
+                    self.restart(DEFAULT_RETRIES, DEFAULT_DELAY);
                 }
             }
         }
     }
 
     /// Collect the IBC events from the subscriptions
-    fn process_batches(&self, batches: Vec<EventBatch>) -> Result<(), Error> {
+    fn process_batches(&self, batches: Vec<EventBatch>) -> Result<()> {
         for batch in batches {
             self.tx_batch
-                .send(batch)
+                .send(Ok(batch))
                 .map_err(|_| Error::ChannelSendFailed)?;
         }
 
@@ -238,25 +299,20 @@ impl EventMonitor {
     }
 
     /// Collect the IBC events from the subscriptions
-    fn collect_events(&mut self) -> Result<Vec<EventBatch>, Error> {
-        if let Some(event) = self.rt.block_on(self.subscriptions.next()) {
-            let event = event.map_err(Error::NextEventBatchFailed)?;
-            let ibc_events = crate::event::rpc::get_all_events(&self.chain_id, event)
-                .map_err(Error::CollectEventsFailed)?;
+    fn collect_events(&mut self, event: RpcEvent) -> Result<Vec<EventBatch>> {
+        let ibc_events = crate::event::rpc::get_all_events(&self.chain_id, event)
+            .map_err(Error::CollectEventsFailed)?;
 
-            let events_by_height = ibc_events.into_iter().into_group_map();
-            let batches = events_by_height
-                .into_iter()
-                .map(|(height, events)| EventBatch {
-                    chain_id: self.chain_id.clone(),
-                    height,
-                    events,
-                })
-                .collect();
+        let events_by_height = ibc_events.into_iter().into_group_map();
+        let batches = events_by_height
+            .into_iter()
+            .map(|(height, events)| EventBatch {
+                chain_id: self.chain_id.clone(),
+                height,
+                events,
+            })
+            .collect();
 
-            Ok(batches)
-        } else {
-            Ok(vec![])
-        }
+        Ok(batches)
     }
 }

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -480,9 +480,10 @@ impl ForeignClient {
         })?;
 
         debug!(
-            "[{}] MsgUpdateAnyClient for target {:?} trusted {:?}",
+            "[{}] MsgUpdateAnyClient for target height {} and trusted height {}",
             self, target_height, trusted_height
         );
+
         let new_msg = MsgUpdateAnyClient {
             client_id: self.id.clone(),
             header,

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -449,24 +449,22 @@ impl Worker {
         client: &ForeignClient,
         update: Option<UpdateClient>,
     ) -> bool {
-        let mut skip_misbehaviour = false;
-        let res = client.detect_misbehaviour_and_submit_evidence(update);
-        match res {
-            MisbehaviourResults::ValidClient => {}
+        match client.detect_misbehaviour_and_submit_evidence(update) {
+            MisbehaviourResults::ValidClient => false,
             MisbehaviourResults::VerificationError => {
                 // can retry in next call
+                false
             }
-            MisbehaviourResults::EvidenceSubmitted(_events) => {
+            MisbehaviourResults::EvidenceSubmitted(_) => {
                 // if evidence was submitted successfully then exit
-                skip_misbehaviour = true;
+                true
             }
             MisbehaviourResults::CannotExecute => {
                 // skip misbehaviour checking if chain does not have support for it (i.e. client
                 // update event does not include the header)
-                skip_misbehaviour = true;
+                true
             }
-        };
-        skip_misbehaviour
+        }
     }
 
     /// Run the event loop for events associated with a [`Client`].

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -584,7 +584,7 @@ pub struct Client {
 impl Client {
     pub fn short_name(&self) -> String {
         format!(
-            "{} -> {}:{}",
+            "{}->{}:{}",
             self.src_chain_id, self.dst_chain_id, self.dst_client_id
         )
     }
@@ -609,7 +609,7 @@ pub struct UnidirectionalChannelPath {
 impl UnidirectionalChannelPath {
     pub fn short_name(&self) -> String {
         format!(
-            "{}/{}:{} -> {}",
+            "{}/{}:{}->{}",
             self.src_channel_id, self.src_port_id, self.src_chain_id, self.dst_chain_id,
         )
     }

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -365,9 +365,8 @@ impl Supervisor {
                         .map_err(Into::into)
                         .and_then(|batch| self.process_batch(chain.clone(), batch));
 
-                    match result {
-                        Ok(()) => trace!("[{}] batch processing complete", chain.id()),
-                        Err(e) => error!("[{}] error during batch processing: {}", chain.id(), e),
+                    if let Err(e) = result {
+                        error!("[{}] error during batch processing: {}", chain.id(), e);
                     }
                 }
                 Err(e) => error!("error when waiting for events: {}", e),

--- a/relayer/src/util.rs
+++ b/relayer/src/util.rs
@@ -2,4 +2,5 @@ mod block_on;
 pub use block_on::block_on;
 
 pub mod iter;
+pub mod retry;
 pub mod sled;

--- a/relayer/src/util/retry.rs
+++ b/relayer/src/util/retry.rs
@@ -1,0 +1,134 @@
+use std::time::Duration;
+
+#[derive(Copy, Clone, Debug)]
+pub struct ConstantGrowth {
+    delay: Duration,
+    incr: Duration,
+}
+
+impl ConstantGrowth {
+    pub const fn new(delay: Duration, incr: Duration) -> Self {
+        Self { delay, incr }
+    }
+
+    pub const fn clamp(self, max_delay: Duration, max_retries: usize) -> Clamped<Self> {
+        Clamped::new(self, max_delay, max_retries)
+    }
+}
+
+impl From<Duration> for ConstantGrowth {
+    fn from(delay: Duration) -> Self {
+        Self::new(delay, Duration::from_secs(1))
+    }
+}
+
+impl Iterator for ConstantGrowth {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        let delay = self.delay;
+
+        if let Some(next) = self.delay.checked_add(self.incr) {
+            self.delay = next;
+        }
+
+        Some(delay)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Clamped<S> {
+    pub strategy: S,
+    pub max_delay: Duration,
+    pub max_retries: usize,
+}
+
+impl<S> Clamped<S> {
+    pub const fn new(strategy: S, max_delay: Duration, max_retries: usize) -> Self {
+        Self {
+            strategy,
+            max_delay,
+            max_retries,
+        }
+    }
+
+    pub fn iter(self) -> impl Iterator<Item = Duration>
+    where
+        S: Iterator<Item = Duration>,
+    {
+        let Self {
+            strategy,
+            max_retries,
+            max_delay,
+        } = self;
+
+        strategy
+            .take(max_retries)
+            .map(move |delay| delay.min(max_delay))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONST_STRATEGY: ConstantGrowth =
+        ConstantGrowth::new(Duration::from_secs(1), Duration::from_millis(500));
+
+    #[test]
+    fn const_growth_no_clamp() {
+        let delays = CONST_STRATEGY.take(10).collect::<Vec<_>>();
+        assert_eq!(
+            delays,
+            vec![
+                Duration::from_millis(1000),
+                Duration::from_millis(1500),
+                Duration::from_millis(2000),
+                Duration::from_millis(2500),
+                Duration::from_millis(3000),
+                Duration::from_millis(3500),
+                Duration::from_millis(4000),
+                Duration::from_millis(4500),
+                Duration::from_millis(5000),
+                Duration::from_millis(5500)
+            ]
+        );
+    }
+
+    #[test]
+    fn clamped_const_growth_max_delay() {
+        let strategy = CONST_STRATEGY.clamp(Duration::from_secs(10), 10);
+        let delays = strategy.iter().collect::<Vec<_>>();
+        assert_eq!(
+            delays,
+            vec![
+                Duration::from_millis(1000),
+                Duration::from_millis(1500),
+                Duration::from_millis(2000),
+                Duration::from_millis(2500),
+                Duration::from_millis(3000),
+                Duration::from_millis(3500),
+                Duration::from_millis(4000),
+                Duration::from_millis(4500),
+                Duration::from_millis(5000),
+                Duration::from_millis(5500)
+            ]
+        );
+    }
+
+    #[test]
+    fn clamped_const_growth_max_retries() {
+        let strategy = CONST_STRATEGY.clamp(Duration::from_secs(10000), 5);
+        let delays = strategy.iter().collect::<Vec<_>>();
+        assert_eq!(
+            delays,
+            vec![
+                Duration::from_millis(1000),
+                Duration::from_millis(1500),
+                Duration::from_millis(2000),
+                Duration::from_millis(2500),
+                Duration::from_millis(3000)
+            ]
+        );
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Follow-up to #895
See also #871

## Description

The supervisor should now be more resilient to a node going down temporarily.
Instead of sitting there waiting for events via the subscription, the supervisor is
now notified that something went wrong, while the event monitor will attempt to
reconnect for a limited time (max retries with a delay between attempts).

Errors yielded by the client and packet workers are now caught at the top-level run loop of the worker,
and printed to the console rather than causing the worker to exits. This is quite brittle still
and will need more work and thought put into for the next milestone.

## Tested with

1. setup the chains, clients, connections, and channels:

```
❯ ./scripts/dev-env ibc-0 ibc-1 ibc-2
❯ hermes create channel ibc-0 ibc-1 --port-a transfer --port-b transfer -o unordered
❯ hermes create channel ibc-1 ibc-2 --port-a transfer --port-b transfer -o unordered
```

2. in a new console, with the debug log level in the config:

```
❯ hermes start-multi
```

3. send some packets if you want:

```
❯ hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 9999 1000 -n 5
...
```

4. kill one of the node, eg. `ibc-1`:

```
❯ ps aux | rg gaiad | rg ibc-1 | awk '{ print $2 }' | xargs -I{} kill -9 {}
```

5. watch the output of `start-multi`, it should show some errors about the WebSocket connection being down and perhaps some RPC queries failing but keep going and retrying to connect to the WebSocket.

6. start the nodes again (will automatically kill the remaining ones):

```
❯ ./scripts/dev-env ibc-0 ibc-1 ibc-2
❯ hermes create channel ibc-0 ibc-1 --port-a transfer --port-b transfer -o unordered
❯ hermes create channel ibc-1 ibc-2 --port-a transfer --port-b transfer -o unordered
```

7. after a while it should be able to reconnect and you can send some packets

```
❯ hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 9999 1000 -n 5
```

______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.