### PR TITLE
Fix broken link to Cosmos IBC Protobuf definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This project comprises primarily four crates:
 - The [`ibc-relayer-cli`][relayer-cli-crate-link] is a CLI (a wrapper
   over the `ibc-relayer` library), comprising the
   [`hermes`](https://hermes.informal.systems) binary.
-- The [`ibc-proto`][ibc-proto-crate-link] is a library with proto definitions
-  necessary for interacting with Cosmos SDK
-  [IBC structs](https://github.com/cosmos/ibc-go/tree/main/proto/ibc).
+- The [`ibc-proto`][ibc-proto-crate-link] is a library with Rust types generated from .proto definitions
+  necessary for interacting with [Cosmos SDK](https://github.com/cosmos/cosmos-sdk/tree/master/proto/cosmos)
+  and its [IBC structs](https://github.com/cosmos/ibc-go/tree/main/proto/ibc).
 
 See the table below for more details.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project comprises primarily four crates:
   [`hermes`](https://hermes.informal.systems) binary.
 - The [`ibc-proto`][ibc-proto-crate-link] is a library with proto definitions
   necessary for interacting with Cosmos SDK
-  [IBC structs](https://github.com/cosmos/cosmos-sdk/tree/master/proto/ibc).
+  [IBC structs](https://github.com/cosmos/ibc-go/tree/main/proto/ibc).
 
 See the table below for more details.
 


### PR DESCRIPTION
## Description

I couldn't track down the original source of the `ibc` proto definitions linked from the `ibc-rs` README, but these seem like a reasonable alternative. Apologies if not!


> ______
> 
> For contributor use:
> 
> - [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
> - [ ] If applicable: Unit tests written, added test to CI.
> - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
> - [ ] Updated relevant documentation (`docs/`) and code comments.
> - [ ] Re-reviewed `Files changed` in the Github PR explorer.

(not applicable, README change)