### PR TITLE
Process raw delay_period field as nanoseconds instead of seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@
 
 ### BUG FIXES
 
+- [ibc]
+  - Process raw `delay_period` field as nanoseconds instead of seconds. ([#927])
+
 ### BREAKING CHANGES
 
 
 [#875]: https://github.com/informalsystems/ibc-rs/issues/875
 [#920]: https://github.com/informalsystems/ibc-rs/issues/920
+[#927]: https://github.com/informalsystems/ibc-rs/issues/927
 
 
 ## v0.3.0

--- a/guide/src/commands/path-setup/channels.md
+++ b/guide/src/commands/path-setup/channels.md
@@ -132,7 +132,7 @@ hermes create channel ibc-0 ibc-1 --port-a transfer --port-b transfer -o unorder
 )
 
 🥂🥂🥂  Connection handshake finished for [Connection {
-    delay_period: 0ns,
+    delay_period: 0s,
     a_side: ConnectionSide {
         chain: ProdChainHandle {
             chain_id: ChainId {
@@ -261,7 +261,7 @@ hermes create channel ibc-0 ibc-1 --port-a transfer --port-b transfer -o unorder
             "channel-0",
         ),
     },
-    connection_delay: 0ns,
+    connection_delay: 0s,
 }
 
 Success: Channel {
@@ -308,7 +308,7 @@ Success: Channel {
             "channel-0",
         ),
     },
-    connection_delay: 0ns,
+    connection_delay: 0s,
 }
 ```
 
@@ -424,7 +424,7 @@ figure it out by looking up the given connection on `ibc-0`.
             "channel-1",
         ),
     },
-    connection_delay: 0ns,
+    connection_delay: 0s,
 }
 
 Success: Channel {
@@ -471,6 +471,6 @@ Success: Channel {
             "channel-1",
         ),
     },
-    connection_delay: 0ns,
+    connection_delay: 0s,
 }
 ```

--- a/guide/src/commands/path-setup/connections.md
+++ b/guide/src/commands/path-setup/connections.md
@@ -124,7 +124,7 @@ hermes create connection ibc-0 ibc-1
 )
 
 🥂🥂🥂  Connection handshake finished for [Connection {
-    delay_period: 0ns,
+    delay_period: 0s,
     a_side: ConnectionSide {
         chain: ProdChainHandle {
             chain_id: ChainId {
@@ -158,7 +158,7 @@ hermes create connection ibc-0 ibc-1
 }]
 
 Success: Connection {
-    delay_period: 0ns,
+    delay_period: 0s,
     a_side: ConnectionSide {
         chain: ProdChainHandle {
             chain_id: ChainId {

--- a/guide/src/commands/queries/connection.md
+++ b/guide/src/commands/queries/connection.md
@@ -105,7 +105,7 @@ Success: ConnectionEnd {
             ],
         },
     ],
-    delay_period: 0ns,
+    delay_period: 0s,
 }
 ```
 
@@ -140,4 +140,3 @@ Success: [
     ),
 ]
 ```
-

--- a/guide/src/tutorials/local-chains/relay-paths/create-new-path.md
+++ b/guide/src/tutorials/local-chains/relay-paths/create-new-path.md
@@ -53,7 +53,7 @@ Success: Channel {
             "channel-1",
         ),
     },
-    connection_delay: 0ns,
+    connection_delay: 0s,
     version: Some(
         "ics20-1",
     ),
@@ -61,4 +61,4 @@ Success: Channel {
 
 ```
 
-Note that for each side, *a_side* (__ibc-0__) and *b_side* (__ibc-1__) there are a __client_id__, __connection_id__, __channel_id__ and __port_id__. With all these established, you have [a path that you can relay packets](./existing-path.md) 
+Note that for each side, *a_side* (__ibc-0__) and *b_side* (__ibc-1__) there are a __client_id__, __connection_id__, __channel_id__ and __port_id__. With all these established, you have [a path that you can relay packets](./existing-path.md)

--- a/guide/src/tutorials/local-chains/relay-paths/multiple-paths.md
+++ b/guide/src/tutorials/local-chains/relay-paths/multiple-paths.md
@@ -135,7 +135,7 @@ the `start-multi` command.
                 "channel-0",
             ),
         },
-        connection_delay: 0ns,
+        connection_delay: 0s,
         version: Some(
             "ics20-1",
         ),
@@ -197,7 +197,7 @@ the `start-multi` command.
                 "channel-0",
             ),
         },
-        connection_delay: 0ns,
+        connection_delay: 0s,
         version: Some(
             "ics20-1",
         ),

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -31,7 +31,7 @@ impl Default for ConnectionEnd {
             client_id: Default::default(),
             counterparty: Default::default(),
             versions: vec![],
-            delay_period: Duration::from_secs(0),
+            delay_period: Duration::default(),
         }
     }
 }
@@ -65,7 +65,7 @@ impl TryFrom<RawConnectionEnd> for ConnectionEnd {
                 .map(Version::try_from)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| Kind::InvalidVersion.context(e))?,
-            Duration::from_secs(value.delay_period),
+            Duration::from_nanos(value.delay_period),
         ))
     }
 }
@@ -81,7 +81,7 @@ impl From<ConnectionEnd> for RawConnectionEnd {
                 .collect(),
             state: value.state as i32,
             counterparty: Some(value.counterparty.into()),
-            delay_period: value.delay_period.as_secs(),
+            delay_period: value.delay_period.as_nanos() as u64,
         }
     }
 }

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -14,6 +14,7 @@ use crate::ics03_connection::version::Version;
 use crate::ics23_commitment::commitment::CommitmentPrefix;
 use crate::ics24_host::error::ValidationError;
 use crate::ics24_host::identifier::{ClientId, ConnectionId};
+use crate::timestamp::ZERO_DURATION;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConnectionEnd {
@@ -31,7 +32,7 @@ impl Default for ConnectionEnd {
             client_id: Default::default(),
             counterparty: Default::default(),
             versions: vec![],
-            delay_period: Duration::default(),
+            delay_period: ZERO_DURATION,
         }
     }
 }

--- a/modules/src/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/ics03_connection/handler/conn_open_ack.rs
@@ -157,7 +157,7 @@ mod tests {
                 CommitmentPrefix::from(b"ibc".to_vec()),
             ),
             vec![msg_ack.version().clone()],
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         // A connection end with incorrect state `Open`; will be part of the context.

--- a/modules/src/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/ics03_connection/handler/conn_open_ack.rs
@@ -104,7 +104,6 @@ pub(crate) fn process(
 mod tests {
     use std::convert::TryFrom;
     use std::str::FromStr;
-    use std::time::Duration;
 
     use crate::events::IbcEvent;
     use crate::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
@@ -117,6 +116,7 @@ mod tests {
     use crate::ics24_host::identifier::{ChainId, ClientId};
     use crate::mock::context::MockContext;
     use crate::mock::host::HostType;
+    use crate::timestamp::ZERO_DURATION;
 
     #[test]
     fn conn_open_ack_msg_processing() {
@@ -157,7 +157,7 @@ mod tests {
                 CommitmentPrefix::from(b"ibc".to_vec()),
             ),
             vec![msg_ack.version().clone()],
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         // A connection end with incorrect state `Open`; will be part of the context.

--- a/modules/src/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/ics03_connection/handler/conn_open_confirm.rs
@@ -78,7 +78,6 @@ pub(crate) fn process(
 mod tests {
     use std::convert::TryFrom;
     use std::str::FromStr;
-    use std::time::Duration;
 
     use crate::events::IbcEvent;
     use crate::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
@@ -90,6 +89,7 @@ mod tests {
     use crate::ics23_commitment::commitment::CommitmentPrefix;
     use crate::ics24_host::identifier::ClientId;
     use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
     use crate::Height;
 
     #[test]
@@ -117,7 +117,7 @@ mod tests {
             client_id.clone(),
             counterparty,
             context.get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let mut correct_conn_end = incorrect_conn_end_state.clone();

--- a/modules/src/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/ics03_connection/handler/conn_open_confirm.rs
@@ -117,7 +117,7 @@ mod tests {
             client_id.clone(),
             counterparty,
             context.get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let mut correct_conn_end = incorrect_conn_end_state.clone();

--- a/modules/src/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_init.rs
@@ -70,7 +70,7 @@ impl TryFrom<RawMsgConnectionOpenInit> for MsgConnectionOpenInit {
                 .ok_or(Kind::InvalidVersion)?
                 .try_into()
                 .map_err(|e| Kind::InvalidVersion.context(e))?,
-            delay_period: Duration::from_secs(msg.delay_period),
+            delay_period: Duration::from_nanos(msg.delay_period),
             signer: msg.signer.into(),
         })
     }
@@ -82,7 +82,7 @@ impl From<MsgConnectionOpenInit> for RawMsgConnectionOpenInit {
             client_id: ics_msg.client_id.as_str().to_string(),
             counterparty: Some(ics_msg.counterparty.into()),
             version: Some(ics_msg.version.into()),
-            delay_period: ics_msg.delay_period.as_secs(),
+            delay_period: ics_msg.delay_period.as_nanos() as u64,
             signer: ics_msg.signer.to_string(),
         }
     }

--- a/modules/src/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/ics03_connection/msgs/conn_open_try.rs
@@ -158,7 +158,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
                 proof_height,
             )
             .map_err(|e| Kind::InvalidProof.context(e))?,
-            delay_period: Duration::from_secs(msg.delay_period),
+            delay_period: Duration::from_nanos(msg.delay_period),
             signer: msg.signer.into(),
         })
     }
@@ -175,7 +175,7 @@ impl From<MsgConnectionOpenTry> for RawMsgConnectionOpenTry {
                 .client_state
                 .map_or_else(|| None, |v| Some(v.into())),
             counterparty: Some(ics_msg.counterparty.into()),
-            delay_period: ics_msg.delay_period.as_secs(),
+            delay_period: ics_msg.delay_period.as_nanos() as u64,
             counterparty_versions: ics_msg
                 .counterparty_versions
                 .iter()

--- a/modules/src/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/ics04_channel/handler/acknowledgement.rs
@@ -142,9 +142,9 @@ mod tests {
     use crate::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
     use crate::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
     use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
 
     use std::convert::TryFrom;
-    use std::time::Duration;
 
     #[test]
     fn ack_packet_processing() {
@@ -193,7 +193,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/ics04_channel/handler/acknowledgement.rs
@@ -193,7 +193,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/ics04_channel/handler/chan_open_confirm.rs
@@ -99,7 +99,6 @@ pub(crate) fn process(
 #[cfg(test)]
 mod tests {
     use std::convert::TryFrom;
-    use std::time::Duration;
 
     use crate::events::IbcEvent;
     use crate::ics02_client::client_type::ClientType;
@@ -116,6 +115,7 @@ mod tests {
     use crate::ics04_channel::msgs::ChannelMsg;
     use crate::ics24_host::identifier::{ClientId, ConnectionId};
     use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
     use crate::Height;
 
     // TODO: The tests here should use the same structure as `handler::chan_open_try::tests`.
@@ -138,7 +138,7 @@ mod tests {
             client_id.clone(),
             ConnectionCounterparty::try_from(get_dummy_raw_counterparty()).unwrap(),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let msg_chan_confirm = MsgChannelOpenConfirm::try_from(

--- a/modules/src/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/ics04_channel/handler/chan_open_confirm.rs
@@ -138,7 +138,7 @@ mod tests {
             client_id.clone(),
             ConnectionCounterparty::try_from(get_dummy_raw_counterparty()).unwrap(),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let msg_chan_confirm = MsgChannelOpenConfirm::try_from(

--- a/modules/src/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/ics04_channel/handler/chan_open_try.rs
@@ -208,7 +208,7 @@ mod tests {
             client_id.clone(),
             ConnectionCounterparty::try_from(get_dummy_raw_counterparty()).unwrap(),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         // We're going to test message processing against this message.

--- a/modules/src/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/ics04_channel/handler/chan_open_try.rs
@@ -165,7 +165,6 @@ pub(crate) fn process(
 #[cfg(test)]
 mod tests {
     use std::convert::TryFrom;
-    use std::time::Duration;
 
     use crate::events::IbcEvent;
     use crate::ics02_client::client_type::ClientType;
@@ -182,6 +181,7 @@ mod tests {
     use crate::ics04_channel::msgs::ChannelMsg;
     use crate::ics24_host::identifier::{ChannelId, ClientId, ConnectionId};
     use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
     use crate::Height;
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
             client_id.clone(),
             ConnectionCounterparty::try_from(get_dummy_raw_counterparty()).unwrap(),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         // We're going to test message processing against this message.

--- a/modules/src/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/ics04_channel/handler/recv_packet.rs
@@ -136,7 +136,6 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
 #[cfg(test)]
 mod tests {
     use std::convert::TryFrom;
-    use std::time::Duration;
 
     use crate::ics03_connection::connection::ConnectionEnd;
     use crate::ics03_connection::connection::Counterparty as ConnectionCounterparty;
@@ -151,6 +150,7 @@ mod tests {
     use crate::mock::context::MockContext;
     use crate::test_utils::get_dummy_account_id;
     use crate::timestamp::Timestamp;
+    use crate::timestamp::ZERO_DURATION;
     use crate::{events::IbcEvent, ics04_channel::packet::Packet};
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/ics04_channel/handler/recv_packet.rs
@@ -208,7 +208,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/send_packet.rs
+++ b/modules/src/ics04_channel/handler/send_packet.rs
@@ -164,7 +164,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let mut packet_old: Packet = get_dummy_raw_packet(1, 1).try_into().unwrap();

--- a/modules/src/ics04_channel/handler/send_packet.rs
+++ b/modules/src/ics04_channel/handler/send_packet.rs
@@ -117,7 +117,6 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
 #[cfg(test)]
 mod tests {
     use std::convert::TryInto;
-    use std::time::Duration;
 
     use crate::events::IbcEvent;
     use crate::ics02_client::height::Height;
@@ -131,6 +130,7 @@ mod tests {
     use crate::ics04_channel::packet::Packet;
     use crate::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
     use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
 
     #[test]
     fn send_packet_processing() {
@@ -164,7 +164,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let mut packet_old: Packet = get_dummy_raw_packet(1, 1).try_into().unwrap();

--- a/modules/src/ics04_channel/handler/timeout.rs
+++ b/modules/src/ics04_channel/handler/timeout.rs
@@ -155,11 +155,11 @@ mod tests {
     use crate::ics04_channel::msgs::timeout::test_util::get_dummy_raw_msg_timeout;
     use crate::ics04_channel::msgs::timeout::MsgTimeout;
     use crate::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+    use crate::timestamp::ZERO_DURATION;
 
     use crate::mock::context::MockContext;
 
     use std::convert::TryFrom;
-    use std::time::Duration;
 
     #[test]
     fn timeout_packet_processing() {
@@ -215,7 +215,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/timeout.rs
+++ b/modules/src/ics04_channel/handler/timeout.rs
@@ -215,7 +215,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/ics04_channel/handler/timeout_on_close.rs
@@ -151,11 +151,11 @@ mod tests {
     use crate::ics04_channel::msgs::timeout_on_close::test_util::get_dummy_raw_msg_timeout_on_close;
     use crate::ics04_channel::msgs::timeout_on_close::MsgTimeoutOnClose;
     use crate::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+    use crate::timestamp::ZERO_DURATION;
 
     use crate::mock::context::MockContext;
 
     use std::convert::TryFrom;
-    use std::time::Duration;
 
     #[test]
     fn timeout_on_close_packet_processing() {
@@ -208,7 +208,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/ics04_channel/handler/timeout_on_close.rs
@@ -208,7 +208,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/ics04_channel/handler/write_acknowledgement.rs
@@ -82,7 +82,6 @@ pub fn process(
 #[cfg(test)]
 mod tests {
     use std::convert::TryInto;
-    use std::time::Duration;
 
     use crate::ics02_client::height::Height;
     use crate::ics03_connection::connection::ConnectionEnd;
@@ -94,6 +93,7 @@ mod tests {
     use crate::ics04_channel::packet::test_utils::get_dummy_raw_packet;
     use crate::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
     use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
     use crate::{events::IbcEvent, ics04_channel::packet::Packet};
 
     #[test]
@@ -137,7 +137,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/ics04_channel/handler/write_acknowledgement.rs
@@ -137,7 +137,7 @@ mod tests {
                 Default::default(),
             ),
             get_compatible_versions(),
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         let tests: Vec<Test> = vec![

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -16,6 +16,7 @@ use crate::ics07_tendermint::error::{Error, Kind};
 use crate::ics07_tendermint::header::Header;
 use crate::ics23_commitment::specs::ProofSpecs;
 use crate::ics24_host::identifier::ChainId;
+use crate::timestamp::ZERO_DURATION;
 use crate::Height;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -113,7 +114,7 @@ impl ClientState {
     /// Helper function to verify the upgrade client procedure.
     /// Resets all fields except the blockchain-specific ones.
     pub fn zero_custom_fields(mut client_state: Self) -> Self {
-        client_state.trusting_period = Duration::default();
+        client_state.trusting_period = ZERO_DURATION;
         client_state.trust_level = TrustThresholdFraction {
             numerator: 0,
             denominator: 0,
@@ -121,7 +122,7 @@ impl ClientState {
         client_state.allow_update.after_expiry = false;
         client_state.allow_update.after_misbehaviour = false;
         client_state.frozen_height = Height::zero();
-        client_state.max_clock_drift = Duration::default();
+        client_state.max_clock_drift = ZERO_DURATION;
         client_state
     }
 
@@ -241,6 +242,7 @@ mod tests {
     use crate::ics07_tendermint::client_state::{AllowUpdate, ClientState};
     use crate::ics24_host::identifier::ChainId;
     use crate::test::test_serialization_roundtrip;
+    use crate::timestamp::ZERO_DURATION;
     use crate::Height;
 
     #[test]
@@ -315,7 +317,7 @@ mod tests {
             Test {
                 name: "Invalid unbonding period".to_string(),
                 params: ClientStateParams {
-                    unbonding_period: Duration::default(),
+                    unbonding_period: ZERO_DURATION,
                     ..default_params.clone()
                 },
                 want_pass: false,
@@ -323,7 +325,7 @@ mod tests {
             Test {
                 name: "Invalid (too small) trusting period".to_string(),
                 params: ClientStateParams {
-                    trusting_period: Duration::default(),
+                    trusting_period: ZERO_DURATION,
                     ..default_params.clone()
                 },
                 want_pass: false,

--- a/modules/src/ics07_tendermint/client_state.rs
+++ b/modules/src/ics07_tendermint/client_state.rs
@@ -113,7 +113,7 @@ impl ClientState {
     /// Helper function to verify the upgrade client procedure.
     /// Resets all fields except the blockchain-specific ones.
     pub fn zero_custom_fields(mut client_state: Self) -> Self {
-        client_state.trusting_period = Duration::from_secs(0);
+        client_state.trusting_period = Duration::default();
         client_state.trust_level = TrustThresholdFraction {
             numerator: 0,
             denominator: 0,
@@ -121,7 +121,7 @@ impl ClientState {
         client_state.allow_update.after_expiry = false;
         client_state.allow_update.after_misbehaviour = false;
         client_state.frozen_height = Height::zero();
-        client_state.max_clock_drift = Duration::from_secs(0);
+        client_state.max_clock_drift = Duration::default();
         client_state
     }
 

--- a/modules/src/timestamp.rs
+++ b/modules/src/timestamp.rs
@@ -2,10 +2,13 @@ use std::convert::TryInto;
 use std::fmt::Display;
 use std::num::{ParseIntError, TryFromIntError};
 use std::str::FromStr;
+use std::time::Duration;
 
 use chrono::{offset::Utc, DateTime, TimeZone};
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
+
+pub const ZERO_DURATION: Duration = Duration::from_secs(0);
 
 /// A newtype wrapper over `Option<DateTime<Utc>>` to keep track of
 /// IBC packet timeout.
@@ -65,7 +68,7 @@ impl Timestamp {
     /// Returns the difference in time as an [`std::time::Duration`].
     /// Returns `None` if the other `Timestamp` is more advanced
     /// than the current or if either of the `Timestamp`s is not set.
-    pub fn duration_since(&self, other: &Timestamp) -> Option<std::time::Duration> {
+    pub fn duration_since(&self, other: &Timestamp) -> Option<Duration> {
         match (self.time, other.time) {
             (Some(time1), Some(time2)) => time1.signed_duration_since(time2).to_std().ok(),
             _ => None,

--- a/modules/tests/runner/mod.rs
+++ b/modules/tests/runner/mod.rs
@@ -35,6 +35,7 @@ use ibc::mock::header::MockHeader;
 use ibc::mock::host::HostType;
 use ibc::proofs::{ConsensusProof, Proofs};
 use ibc::signer::Signer;
+use ibc::timestamp::ZERO_DURATION;
 use ibc::Height;
 use step::{Action, ActionOutcome, Chain, Step};
 
@@ -166,7 +167,7 @@ impl IbcTestRunner {
     }
 
     pub fn delay_period() -> Duration {
-        Duration::default()
+        ZERO_DURATION
     }
 
     pub fn commitment_prefix() -> CommitmentPrefix {

--- a/modules/tests/runner/mod.rs
+++ b/modules/tests/runner/mod.rs
@@ -166,7 +166,7 @@ impl IbcTestRunner {
     }
 
     pub fn delay_period() -> Duration {
-        Duration::from_secs(0)
+        Duration::default()
     }
 
     pub fn commitment_prefix() -> CommitmentPrefix {

--- a/relayer-cli/src/commands/tx/connection.rs
+++ b/relayer-cli/src/commands/tx/connection.rs
@@ -1,9 +1,8 @@
-use std::time::Duration;
-
 use abscissa_core::{Command, Options, Runnable};
 
 use ibc::events::IbcEvent;
 use ibc::ics24_host::identifier::{ChainId, ClientId, ConnectionId};
+use ibc::timestamp::ZERO_DURATION;
 use ibc_relayer::connection::{Connection, ConnectionSide};
 
 use crate::cli_utils::ChainHandlePair;
@@ -58,7 +57,7 @@ impl Runnable for TxRawConnInitCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::default(),
+                    delay_period: ZERO_DURATION,
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),
@@ -106,7 +105,7 @@ impl Runnable for TxRawConnTryCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::default(),
+                    delay_period: ZERO_DURATION,
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),
@@ -162,7 +161,7 @@ impl Runnable for TxRawConnAckCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::default(),
+                    delay_period: ZERO_DURATION,
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),
@@ -218,7 +217,7 @@ impl Runnable for TxRawConnConfirmCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::default(),
+                    delay_period: ZERO_DURATION,
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),

--- a/relayer-cli/src/commands/tx/connection.rs
+++ b/relayer-cli/src/commands/tx/connection.rs
@@ -58,7 +58,7 @@ impl Runnable for TxRawConnInitCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::from_secs(0),
+                    delay_period: Duration::default(),
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),
@@ -106,7 +106,7 @@ impl Runnable for TxRawConnTryCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::from_secs(0),
+                    delay_period: Duration::default(),
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),
@@ -162,7 +162,7 @@ impl Runnable for TxRawConnAckCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::from_secs(0),
+                    delay_period: Duration::default(),
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),
@@ -218,7 +218,7 @@ impl Runnable for TxRawConnConfirmCmd {
             self,
             |chains: ChainHandlePair| {
                 Connection {
-                    delay_period: Duration::from_secs(0),
+                    delay_period: Duration::default(),
                     a_side: ConnectionSide::new(
                         chains.src,
                         self.src_client_id.clone(),

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -115,7 +115,7 @@ impl CosmosSdkChain {
             .unbonding_time
             .ok_or_else(|| Kind::Grpc.context("none unbonding time".to_string()))?;
 
-        Ok(Duration::from_secs(res.seconds as u64))
+        Ok(Duration::new(res.seconds as u64, res.nanos as u32))
     }
 
     fn rpc_client(&self) -> &HttpClient {

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -27,7 +27,7 @@ pub mod default {
     }
 
     pub fn connection_delay() -> Duration {
-        Duration::from_secs(0)
+        Duration::default()
     }
 
     pub fn channel_ordering() -> Order {

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -7,6 +7,7 @@ use tendermint_light_client::types::TrustThreshold;
 
 use ibc::ics04_channel::channel::Order;
 use ibc::ics24_host::identifier::{ChainId, PortId};
+use ibc::timestamp::ZERO_DURATION;
 
 use crate::error;
 
@@ -27,7 +28,7 @@ pub mod default {
     }
 
     pub fn connection_delay() -> Duration {
-        Duration::default()
+        ZERO_DURATION
     }
 
     pub fn channel_ordering() -> Order {

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -15,6 +15,7 @@ use ibc::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenConfirm;
 use ibc::ics03_connection::msgs::conn_open_init::MsgConnectionOpenInit;
 use ibc::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
 use ibc::ics24_host::identifier::{ChainId, ClientId, ConnectionId};
+use ibc::timestamp::ZERO_DURATION;
 use ibc::tx_msg::Msg;
 use ibc::Height as ICSHeight;
 
@@ -381,7 +382,7 @@ impl Connection {
             self.dst_client_id().clone(),
             counterparty,
             versions,
-            Duration::default(),
+            ZERO_DURATION,
         );
 
         // Retrieve existing connection if any

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -381,7 +381,7 @@ impl Connection {
             self.dst_client_id().clone(),
             counterparty,
             versions,
-            Duration::from_secs(0),
+            Duration::default(),
         );
 
         // Retrieve existing connection if any
@@ -504,11 +504,11 @@ impl Connection {
         // Cross-check the delay_period
         let delay = if src_connection.delay_period() != self.delay_period {
             warn!("`delay_period` for ConnectionEnd @{} is {}s; delay period on local Connection object is set to {}s",
-                self.src_chain().id(), src_connection.delay_period().as_secs(), self.delay_period.as_secs());
+                self.src_chain().id(), src_connection.delay_period().as_secs_f64(), self.delay_period.as_secs_f64());
 
             warn!(
                 "Overriding delay period for local connection object to {}s",
-                src_connection.delay_period().as_secs()
+                src_connection.delay_period().as_secs_f64()
             );
 
             src_connection.delay_period()

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -720,7 +720,7 @@ impl RelayPath {
     /// Returns `true` if the delay for this relaying path is zero.
     /// Conversely, returns `false` if the delay is non-zero.
     fn zero_delay(&self) -> bool {
-        self.channel.connection_delay.as_nanos() == 0
+        self.channel.connection_delay.is_zero()
     }
 
     /// Handles updating the client on the destination chain

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -23,6 +23,7 @@ use ibc::{
     ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId},
     query::QueryTxRequest,
     signer::Signer,
+    timestamp::ZERO_DURATION,
     tx_msg::Msg,
     Height,
 };
@@ -720,7 +721,7 @@ impl RelayPath {
     /// Returns `true` if the delay for this relaying path is zero.
     /// Conversely, returns `false` if the delay is non-zero.
     fn zero_delay(&self) -> bool {
-        self.channel.connection_delay.is_zero()
+        self.channel.connection_delay == ZERO_DURATION
     }
 
     /// Handles updating the client on the destination chain


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #927

## Description

- Process raw `delay_period` field as nanoseconds instead of seconds.
- Use `Duration::default()` instead of `Duration::from_secs(0)` for empty duration.
- Use `Duration::new()` for construction from raw duration field with both seconds and nanoseconds.
- Print CLI output using `.as_secs_f64()` instead of `.as_secs()` to also show sub-second duration.


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.