### PR TITLE
Fine grained error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
  "futures",
  "hdpath",
  "hex",
+ "http",
  "humantime-serde",
  "ibc",
  "ibc-proto",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -21,6 +21,7 @@ ibc           = { version = "0.4.0", path = "../modules" }
 ibc-proto     = { version = "0.8.0", path = "../proto" }
 ibc-telemetry = { version = "0.4.0", path = "../telemetry", optional = true }
 
+http = "0.2.4"
 subtle-encoding = "0.5"
 anomaly = "0.2.0"
 async-trait = "0.1.50"

--- a/relayer/src/chain/handle/prod.rs
+++ b/relayer/src/chain/handle/prod.rs
@@ -35,7 +35,7 @@ use ibc_proto::ibc::core::connection::v1::QueryClientConnectionsRequest;
 
 use crate::{
     connection::ConnectionMsgType,
-    error::{Error, Kind},
+    error::{recv_error, send_error, Error},
     keyring::KeyEntry,
 };
 
@@ -66,11 +66,9 @@ impl ProdChainHandle {
         let (sender, receiver) = reply_channel();
         let input = f(sender);
 
-        self.runtime_sender
-            .send(input)
-            .map_err(|e| Kind::Channel.context(e))?;
+        self.runtime_sender.send(input).map_err(send_error)?;
 
-        receiver.recv().map_err(|e| Kind::Channel.context(e))?
+        receiver.recv().map_err(recv_error)?
     }
 }
 

--- a/relayer/src/chain/mock.rs
+++ b/relayer/src/chain/mock.rs
@@ -41,7 +41,7 @@ use ibc_proto::ibc::core::connection::v1::{
 
 use crate::chain::Chain;
 use crate::config::ChainConfig;
-use crate::error::{Error, Kind};
+use crate::error::{ics18_relayer_error, Error, Kind};
 use crate::event::monitor::{EventReceiver, EventSender};
 use crate::keyring::{KeyEntry, KeyRing};
 use crate::light_client::{mock::LightClient as MockLightClient, LightClient};
@@ -105,10 +105,7 @@ impl Chain for MockChain {
 
     fn send_msgs(&mut self, proto_msgs: Vec<Any>) -> Result<Vec<IbcEvent>, Error> {
         // Use the ICS18Context interface to submit the set of messages.
-        let events = self
-            .context
-            .send(proto_msgs)
-            .map_err(|e| Kind::Rpc(self.config.rpc_addr.clone()).context(e))?;
+        let events = self.context.send(proto_msgs).map_err(ics18_relayer_error)?;
 
         Ok(events)
     }

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -1,12 +1,22 @@
 //! This module defines the various errors that be raised in the relayer.
 
+use crate::sdk_error::{sdk_error_from_tx_result, SdkError};
+use crate::util::retry::RetryableError;
 use anomaly::{BoxError, Context};
-use thiserror::Error;
-
+use crossbeam_channel::{RecvError, SendError};
+use http::uri::InvalidUri;
 use ibc::{
-    ics02_client::client_type::ClientType,
+    ics02_client::{client_type::ClientType, error::Error as ClientError},
     ics24_host::identifier::{ChannelId, ConnectionId},
 };
+use prost::DecodeError;
+use std::any::type_name;
+use std::fmt::Debug;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::endpoint::broadcast::tx_commit::TxResult;
+use tendermint_rpc::Error as TendermintRpcError;
+use thiserror::Error;
+use tonic::{transport::Error as TransportError, Status};
 
 /// An error that can be raised by the relayer.
 pub type Error = anomaly::Error<Kind>;
@@ -27,8 +37,17 @@ pub enum Kind {
     Config,
 
     /// RPC error (typically raised by the RPC client or the RPC requester)
-    #[error("RPC error to endpoint {0}")]
-    Rpc(tendermint_rpc::Url),
+    #[error("call to Tendermint RPC endpoint {0} returned error")]
+    TendermintRpc(tendermint_rpc::Url),
+
+    #[error("ABCI query returns error: {0:?}")]
+    AbciQuery(AbciQuery),
+
+    #[error("CheckTX Commit returns error: {0}. RawResult: {1:?}")]
+    CheckTx(SdkError, TxResult),
+
+    #[error("DeliverTX Commit returns error: {0}. RawResult: {1:?}")]
+    DeliverTx(SdkError, TxResult),
 
     /// Websocket error (typically raised by the Websocket client)
     #[error("Websocket error to endpoint {0}")]
@@ -41,6 +60,15 @@ pub enum Kind {
     /// GRPC error (typically raised by the GRPC client or the GRPC requester)
     #[error("GRPC error")]
     Grpc,
+
+    #[error("GRPC call return error status {0}")]
+    GrpcStatus(Status),
+
+    #[error("error in underlying transport when making GRPC call")]
+    GrpcTransport,
+
+    #[error("missing parameter in GRPC response: {0}")]
+    GrpcResponseParam(String),
 
     /// Light client instance error, typically raised by a `Client`
     #[error("Light client error for RPC address {0}")]
@@ -77,6 +105,9 @@ pub enum Kind {
     /// Unable to build the client state
     #[error("Failed to create client state")]
     BuildClientStateFailure,
+
+    #[error("Error converting from raw client state")]
+    InvalidRawClientState,
 
     /// Create client failure
     #[error("Failed to create client {0}")]
@@ -142,13 +173,16 @@ pub enum Kind {
     #[error("Message transaction failure: {0}")]
     MessageTransaction(String),
 
+    #[error("Error decoding protocol buffer for {0}")]
+    ProtobufDecode(String),
+
     /// Failed query
     #[error("Query error occurred (failed to query for {0})")]
     Query(String),
 
     /// Keybase related error
-    #[error("Keybase error")]
-    KeyBase,
+    #[error("Key ring error: {0}")]
+    KeyRing(crate::keyring::errors::Kind),
 
     /// ICS 007 error
     #[error("ICS 007 error")]
@@ -156,7 +190,13 @@ pub enum Kind {
 
     /// ICS 023 error
     #[error("ICS 023 error")]
-    Ics023(#[from] ibc::ics23_commitment::error::Error),
+    Ics023(ibc::ics23_commitment::error::Error),
+
+    #[error("ICS 018 error: {0}")]
+    Ics18(ibc::ics18_relayer::error::Kind),
+
+    #[error("error parsing URI {0} - {0}")]
+    InvalidUri(String, String),
 
     /// Invalid chain identifier
     #[error("invalid chain identifier format: {0}")]
@@ -166,7 +206,10 @@ pub enum Kind {
     NonProvableData,
 
     #[error("failed to send or receive through channel")]
-    Channel,
+    ChannelSend,
+
+    #[error("failed to send or receive through channel")]
+    ChannelReceive,
 
     #[error("the input header is not recognized as a header for this chain")]
     InvalidInputHeader,
@@ -187,6 +230,80 @@ pub enum Kind {
     },
 }
 
+impl RetryableError for Kind {
+    fn is_retryable(&self) -> bool {
+        // TODO: actually classify whether an error kind is retryable
+        true
+    }
+}
+
+fn error_with_source(err: Kind, source: impl Into<BoxError>) -> Error {
+    Context::new(err, Some(source.into())).into()
+}
+
+fn error(err: Kind) -> Error {
+    Context::new(err, None).into()
+}
+
+pub fn send_error<T>(err: SendError<T>) -> Error
+where
+    T: Send + Sync + 'static,
+{
+    error_with_source(Kind::ChannelSend, err)
+}
+
+pub fn recv_error(err: RecvError) -> Error {
+    error_with_source(Kind::ChannelReceive, err)
+}
+
+pub fn grpc_status_error(status: Status) -> Error {
+    error(Kind::GrpcStatus(status))
+}
+
+pub fn grpc_transport_error(err: TransportError) -> Error {
+    error_with_source(Kind::GrpcTransport, err)
+}
+
+pub fn grpc_response_param_error(msg: &str) -> Error {
+    error(Kind::GrpcResponseParam(msg.to_string()))
+}
+
+pub fn tendermint_rpc_error(url: &tendermint_rpc::Url, err: TendermintRpcError) -> Error {
+    error_with_source(Kind::TendermintRpc(url.clone()), err)
+}
+
+pub fn abci_query_error(query: AbciQuery) -> Error {
+    error(Kind::AbciQuery(query))
+}
+
+pub fn invalid_uri_error(uri: String, err: InvalidUri) -> Error {
+    error(Kind::InvalidUri(uri, format!("{}", err)))
+}
+
+pub fn protobuf_decode_error<T>(err: DecodeError) -> Error {
+    error_with_source(Kind::ProtobufDecode(type_name::<T>().to_string()), err)
+}
+
+pub fn invalid_raw_client_state_error(err: ClientError) -> Error {
+    error_with_source(Kind::InvalidRawClientState, err)
+}
+
+pub fn ics18_relayer_error(err: ibc::ics18_relayer::error::Error) -> Error {
+    error_with_source(Kind::Ics18(err.kind().clone()), err)
+}
+
+pub fn keyring_error(err: crate::keyring::errors::Error) -> Error {
+    error_with_source(Kind::KeyRing(err.kind().clone()), err)
+}
+
+pub fn check_tx_error(result: TxResult) -> Error {
+    error(Kind::CheckTx(sdk_error_from_tx_result(&result), result))
+}
+
+pub fn deliver_tx_error(result: TxResult) -> Error {
+    error(Kind::DeliverTx(sdk_error_from_tx_result(&result), result))
+}
+
 impl Kind {
     /// Add a given source error as context for this error kind
     ///
@@ -198,9 +315,5 @@ impl Kind {
     /// ```
     pub fn context(self, source: impl Into<BoxError>) -> Context<Self> {
         Context::new(self, Some(source.into()))
-    }
-
-    pub fn channel(err: impl Into<BoxError>) -> Context<Self> {
-        Self::Channel.context(err)
     }
 }

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -29,6 +29,7 @@ pub mod link;
 pub mod macros;
 pub mod object;
 pub mod registry;
+pub mod sdk_error;
 pub mod supervisor;
 pub mod telemetry;
 pub mod transfer;

--- a/relayer/src/sdk_error.rs
+++ b/relayer/src/sdk_error.rs
@@ -1,0 +1,162 @@
+use tendermint::abci::Code;
+use tendermint_rpc::endpoint::broadcast::tx_commit::TxResult;
+use thiserror::Error;
+
+// Provides mapping for errors returned from ibc-go and cosmos-sdk
+#[derive(Clone, Debug, Error)]
+pub enum SdkError {
+    #[error("ICS02 Client Error: {0}")]
+    Client(ClientError),
+
+    #[error("Unknown SDK Error")]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum ClientError {
+    #[error("light client already exists")]
+    LightClientAlreadyExists,
+
+    #[error("light client is invalid")]
+    InvalidLightClient,
+
+    #[error("light client not found")]
+    LightClientNotFound,
+
+    #[error("light client is frozen due to misbehaviour")]
+    FrozenLightClient,
+
+    #[error("invalid client metadata")]
+    InvalidClientMetadata,
+
+    #[error("consensus state not found")]
+    ConsensusStateNotFound,
+
+    #[error("invalid consensus state")]
+    InvalidConsensusState,
+
+    #[error("client type not found")]
+    ClientTypeNotFound,
+
+    #[error("invalid client type")]
+    InvalidClientType,
+
+    #[error("commitment root not found")]
+    CommitmentRootNotFound,
+
+    #[error("invalid client header")]
+    InvalidClientHeader,
+
+    #[error("invalid light client misbehaviour")]
+    InvalidLightClientMisbehavior,
+
+    #[error("client state verification failed")]
+    ClientStateVerificationFailed,
+
+    #[error("client consensus state verification failed")]
+    ClientConsensusStateVerificationFailed,
+
+    #[error("connection state verification failed")]
+    ConnectionStateVerificationFailed,
+
+    #[error("channel state verification failed")]
+    ChannelStateVerificationFailed,
+
+    #[error("packet commitment verification failed")]
+    PacketCommitmentVerificationFailed,
+
+    #[error("packet acknowledgement verification failed")]
+    PacketAcknowledgementVerificationFailed,
+
+    #[error("packet receipt verification failed")]
+    PacketReceiptVerificationFailed,
+
+    #[error("next sequence receive verification failed")]
+    NextSequenceReceiveVerificationFailed,
+
+    #[error("self consensus state not found")]
+    SelfConsensusStateNotFound,
+
+    #[error("unable to update light client")]
+    UpdateLightClientFailed,
+
+    #[error("invalid update client proposal")]
+    InvalidUpdateClientProposal,
+
+    #[error("invalid client upgrade")]
+    InvalidClientUpgrade,
+
+    #[error("invalid height")]
+    InvalidHeight,
+
+    #[error("invalid client state substitute")]
+    InvalidClientStateSubstitute,
+
+    #[error("invalid upgrade proposal")]
+    InvalidUpgradeProposal,
+
+    #[error("client is not active")]
+    InactiveClient,
+
+    #[error("Unknown client error")]
+    Unknown,
+}
+
+impl ClientError {
+    // The error code mapping follows the Go code at
+    // ibc-go/modules/core/02-client/types/errors.go
+    fn from_code(code: u32) -> ClientError {
+        match code {
+            2 => ClientError::LightClientAlreadyExists,
+            3 => ClientError::InvalidLightClient,
+            4 => ClientError::LightClientNotFound,
+            5 => ClientError::FrozenLightClient,
+            6 => ClientError::InvalidClientMetadata,
+            7 => ClientError::ConsensusStateNotFound,
+            8 => ClientError::InvalidConsensusState,
+            9 => ClientError::ClientTypeNotFound,
+            10 => ClientError::InvalidClientType,
+            11 => ClientError::CommitmentRootNotFound,
+            12 => ClientError::InvalidClientHeader,
+            13 => ClientError::InvalidLightClientMisbehavior,
+            14 => ClientError::ClientStateVerificationFailed,
+            15 => ClientError::ClientConsensusStateVerificationFailed,
+            16 => ClientError::ConnectionStateVerificationFailed,
+            17 => ClientError::ChannelStateVerificationFailed,
+            18 => ClientError::PacketCommitmentVerificationFailed,
+            19 => ClientError::PacketAcknowledgementVerificationFailed,
+            20 => ClientError::PacketReceiptVerificationFailed,
+            21 => ClientError::NextSequenceReceiveVerificationFailed,
+            22 => ClientError::SelfConsensusStateNotFound,
+            23 => ClientError::UpdateLightClientFailed,
+            24 => ClientError::InvalidUpdateClientProposal,
+            25 => ClientError::InvalidClientUpgrade,
+            26 => ClientError::InvalidHeight,
+            27 => ClientError::InvalidClientStateSubstitute,
+            28 => ClientError::InvalidUpgradeProposal,
+            29 => ClientError::InactiveClient,
+            _ => ClientError::Unknown,
+        }
+    }
+}
+
+// Converts the error in a TxResult into SdkError with the same
+// mapping as defined in ibc-go and cosmos-sdk. This assumes the
+// target chain we are interacting with are using cosmos-sdk and ibc-go.
+//
+// TODO: investigate ways to automatically generate the mapping by parsing
+// the errors.go source code directly
+pub fn sdk_error_from_tx_result(result: &TxResult) -> SdkError {
+    match result.code {
+        Code::Ok => SdkError::Unknown,
+        Code::Err(code) => {
+            let codespace = result.codespace.to_string();
+            if codespace == "client" {
+                SdkError::Client(ClientError::from_code(code))
+            } else {
+                // TODO: Implement mapping for other codespaces in ibc-go
+                SdkError::Unknown
+            }
+        }
+    }
+}

--- a/relayer/src/util/retry.rs
+++ b/relayer/src/util/retry.rs
@@ -1,9 +1,26 @@
+use anomaly::BoxError;
+use std::fmt::{Debug, Display};
 use std::time::Duration;
 
 pub use retry::{
     delay::{Fibonacci, Fixed},
     retry_with_index, OperationResult as RetryResult,
 };
+
+/// When encountering an error, indicates whether the relayer should
+/// perform retry on the same operation.
+pub trait RetryableError {
+    fn is_retryable(&self) -> bool;
+}
+
+impl<Kind> RetryableError for anomaly::Error<Kind>
+where
+    Kind: RetryableError + Clone + Debug + Display + Into<BoxError>,
+{
+    fn is_retryable(&self) -> bool {
+        self.kind().is_retryable()
+    }
+}
 
 #[derive(Copy, Clone, Debug)]
 pub struct ConstantGrowth {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Partially Fixes: #712

## Description

This is an initial refactoring that I have done to try and tame the error handling logic in the relayer. There are some design decisions which I'll try to explain here. We could also create an ADR to describe the design.

### Error Constructors

Currently we are using `anomaly` to manage nested errors and backtraces. The abstraction provided by `anomaly` allows us to easily capture backtraces, with an error context containing previous dynamic errors that cause an error of interest. While the design of `anomaly` is good enough for its intended purpose, there are some issues arise from its use.

In particular, the dynamic nature of `anomaly` makes it very easy to raise errors from any source error type. This makes it difficult for us to statically inspect what kind of underlying errors can cause a particular error to be raised. As an example, the `Grpc` error is raised when any error occurs when making a GRPC call, whether it is caused by connection issues, decoding errors, or application errors.

To fix this issue, we want to use static types to help enforce what kind of underlying errors can cause the current error to be raised. As an example, we may want to split the `Grpc` error into sub-errors such as `GrpcStatusError` when invalid response status is returned, and `GrpcTransportError` when there is an error in the underlying transport.  Furthermore, we want to use the type system to enforce such that the error cause cannot be mixed. i.e. we want to prevent the code from accidentally raising a `GrpcStatusError` when the underlying cause is actually a transport error.

To enforce this, we could try to modify the constructor for each sub-error to have the underlying cause as an argument. However doing so would break the abstraction that `anomaly` has given to us, since we would then have to manually expose the error context and backtraces. We could alternatively consider other error handling libraries, or come out with our own error handling abstraction. However doing so would require significant effort to refactor the entire code base to move away from `anomaly`.

Instead, a more pragmatic approach is to try and retrofit our requirement on top of `anomaly`, so that we can slowly migrate to the new error handling approach. In our proposed solution, we continue to use the `Kind` pattern to classify the errors, and use `anomaly` to propagate the underlying errors. However we want to refactor the code such that we can keep  all constructors to the `Kind` error private, and expose _error constructor functions_ to construct errors.

The main idea is that with a constructor function, the concrete type of the underlying error must also be provided alongside. Inside the constructor function, we proceed as usual and type-erase the underlying error using `anomaly::Context`. But from the outside, the only way to construct a specific error is by giving the concrete error value.

As an example, in this PR we have the error constructor function `fn grpc_transport_error(err: tonic::transport::Error) -> Error`, which allows the application to raise a `GrpcTransportError` only when a `tonic::transport::Error` happens.

### RetryableError

Another abstraction I try to introduce is the `RetryableError` trait. This trait abstracts away the error details, and tell us whether an operation should be retried when a given error happens. By implementing this trait on the error types of interest, we can decouple the retry operations from the logic of determining whether an error should be retried.

Currently as the possible errors are under-specified, I leave a default implementation that all sub-errors in an error type being retryable. We can slowly refine the implementation as we understand better on each specific errors.

### Case Splitting Underlying Errors

With our proposed approach, all underlying errors are still type-erased by `anomaly` into `BoxError`. However when implementing `RetryableError`, we may encounter cases where we will need to peek into an underlying sub-error to determine whether the error is retryable. In such case, there is a simpler solution, which is to inspect the underlying error during construction, and classify them as different sub-errors.

As an example, consider the error constructor `fn tendermint_rpc_error(err: tendermint_rpc::Error) -> Error`. We may want to decide whether the outer error is retryable depending on the error code returned by Tendermint RPC. In such case, we would inspect the error code inside `tendermint_rpc_error`, and construct either of the sub-errors `RecoverableTendermintError` and `UnrecoverableTendermintError`.

### Different Roles of Error Constructs

In summary, we try to identify different roles of the error constructs, and see how different abstractions are used to handle the roles separately.

#### Error Context and Backtraces

This is for debugging purpose when an error is raised, and we want to find out how the error is propagated. This is handled well by `anomaly`.

#### Error Construction

We want to construct errors such that a higher-level sub-error is caused by a specific lower-level error type. This allows errors to be properly classified and avoid cases where dynamic errors are misclassified. The application code is only concerned with constructing (throwing) errors and do not care about the internal structure. 

The error constructor function allows us to address this issue.

#### Error Display

When an error is raised, we want to inform the user with as much information available. This is handled by defining separate sub-errors in an error enum and use the `#[error()]` pragma by `thiserror` to format the different error messages.

#### Error Recovery

A higher-level application may want to recover from errors raised by a lower-level application by inspecting the internal enum structure. In this case, each sub-error in the enum may carry additional information on whether an error is recoverable.

In practice, we are not doing much on error recovery based on specific sub-errors. As a result, our classification of sub-errors in the error enums are used more for display and information purposes.

#### Error Retry

A concept related to error recovery is on retrying an operation when errors are raised. This is different from the error recovery mechanism, as here the application is only concerned with whether it should retry the operation. On the contrary, error recovery typically need to understand more details about the internal organization of the lower-level errors. In this PR, we introduce the `RetryableError` so that it encapsulates the information on whether a sub-error is retryable.


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.