### PR TITLE
Event monitor: Bulk events from all transactions included in a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 ## Unreleased
 
-> Nothing yet,
+### FEATURES
+
+> Nothing
+
+### IMPROVEMENTS
+
+- [ibc-relayer]
+  - Bulk events from all transactions included in a block ([#957])
+
+### BUG FIXES
+
+> Nothing
+
+### BREAKING CHANGES
+
+> Nothing
+
+[#957]: https://github.com/informalsystems/ibc-rs/issues/957
 
 ## v0.3.1
 *May 14h, 2021*
@@ -31,6 +48,8 @@ as well as support Protobuf-encoded keys.
   - Process raw `delay_period` field as nanoseconds instead of seconds. ([#927])
 
 ### BREAKING CHANGES
+
+> Nothing
 
 
 [#875]: https://github.com/informalsystems/ibc-rs/issues/875

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,7 @@ name = "ibc-relayer"
 version = "0.3.1"
 dependencies = [
  "anomaly",
+ "async-stream",
  "async-trait",
  "bech32 0.8.0",
  "bitcoin",

--- a/relayer-cli/src/commands/listen.rs
+++ b/relayer-cli/src/commands/listen.rs
@@ -1,18 +1,58 @@
-use std::{ops::Deref, sync::Arc, thread};
+use std::{fmt, ops::Deref, str::FromStr, sync::Arc, thread};
 
 use abscissa_core::{application::fatal_error, error::BoxError, Command, Options, Runnable};
 use itertools::Itertools;
 use tokio::runtime::Runtime as TokioRuntime;
 
-use tendermint_rpc::query::{EventType, Query};
+use ibc::{events::IbcEvent, ics24_host::identifier::ChainId};
 
-use ibc::ics24_host::identifier::ChainId;
 use ibc_relayer::{
     config::ChainConfig,
     event::monitor::{EventMonitor, EventReceiver},
 };
 
 use crate::prelude::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventFilter {
+    NewBlock,
+    Tx,
+}
+
+impl EventFilter {
+    pub fn matches(&self, event: &IbcEvent) -> bool {
+        match self {
+            EventFilter::NewBlock => matches!(event, IbcEvent::NewBlock(_)),
+            EventFilter::Tx => {
+                !(matches!(
+                    event,
+                    IbcEvent::NewBlock(_) | IbcEvent::Empty(_) | IbcEvent::ChainError(_)
+                ))
+            }
+        }
+    }
+}
+
+impl fmt::Display for EventFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NewBlock => write!(f, "NewBlock"),
+            Self::Tx => write!(f, "Tx"),
+        }
+    }
+}
+
+impl FromStr for EventFilter {
+    type Err = BoxError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "NewBlock" => Ok(Self::NewBlock),
+            "Tx" => Ok(Self::Tx),
+            invalid => Err(format!("unrecognized event type: {}", invalid).into()),
+        }
+    }
+}
 
 #[derive(Command, Debug, Options)]
 pub struct ListenCmd {
@@ -22,7 +62,7 @@ pub struct ListenCmd {
 
     /// Add an event type to listen for, can be repeated. Listen for all events by default (available: Tx, NewBlock)
     #[options(short = "e", long = "event", meta = "EVENT")]
-    events: Vec<EventType>,
+    events: Vec<EventFilter>,
 }
 
 impl ListenCmd {
@@ -34,7 +74,7 @@ impl ListenCmd {
             .ok_or_else(|| format!("chain '{}' not found in configuration", self.chain_id))?;
 
         let events = if self.events.is_empty() {
-            &[EventType::Tx, EventType::NewBlock]
+            &[EventFilter::Tx, EventFilter::NewBlock]
         } else {
             self.events.as_slice()
         };
@@ -51,29 +91,42 @@ impl Runnable for ListenCmd {
 }
 
 /// Listen to events
-pub fn listen(config: &ChainConfig, events: &[EventType]) -> Result<(), BoxError> {
+pub fn listen(config: &ChainConfig, filters: &[EventFilter]) -> Result<(), BoxError> {
     println!(
         "[info] Listening for events `{}` on '{}'...",
-        events.iter().format(", "),
+        filters.iter().format(", "),
         config.id
     );
 
     let rt = Arc::new(TokioRuntime::new()?);
-    let queries = events.iter().cloned().map(Query::from).collect();
-    let (event_monitor, rx) = subscribe(&config, queries, rt)?;
+    let (event_monitor, rx) = subscribe(&config, rt)?;
 
     thread::spawn(|| event_monitor.run());
 
     while let Ok(event_batch) = rx.recv() {
-        println!("{:#?}", event_batch);
+        match event_batch {
+            Ok(batch) => {
+                println!("- Event batch at height {}", batch.height);
+                for event in batch.events {
+                    if event_match(&event, filters) {
+                        println!("+ {:#?}", event);
+                    }
+                }
+                println!();
+            }
+            Err(e) => println!("- Error: {}", e),
+        }
     }
 
     Ok(())
 }
 
+fn event_match(event: &IbcEvent, filters: &[EventFilter]) -> bool {
+    filters.iter().any(|f| f.matches(event))
+}
+
 fn subscribe(
     chain_config: &ChainConfig,
-    queries: Vec<Query>,
     rt: Arc<TokioRuntime>,
 ) -> Result<(EventMonitor, EventReceiver), BoxError> {
     let (mut event_monitor, rx) = EventMonitor::new(
@@ -82,8 +135,6 @@ fn subscribe(
         rt,
     )
     .map_err(|e| format!("could not initialize event monitor: {}", e))?;
-
-    event_monitor.set_queries(queries);
 
     event_monitor
         .subscribe()

--- a/relayer-cli/src/commands/listen.rs
+++ b/relayer-cli/src/commands/listen.rs
@@ -106,12 +106,22 @@ pub fn listen(config: &ChainConfig, filters: &[EventFilter]) -> Result<(), BoxEr
     while let Ok(event_batch) = rx.recv() {
         match event_batch {
             Ok(batch) => {
-                println!("- Event batch at height {}", batch.height);
-                for event in batch.events {
-                    if event_match(&event, filters) {
-                        println!("+ {:#?}", event);
-                    }
+                let matching_events = batch
+                    .events
+                    .into_iter()
+                    .filter(|e| event_match(&e, filters))
+                    .collect_vec();
+
+                if matching_events.is_empty() {
+                    continue;
                 }
+
+                println!("- Event batch at height {}", batch.height);
+
+                for event in matching_events {
+                    println!("+ {:#?}", event);
+                }
+
                 println!();
             }
             Err(e) => println!("- Error: {}", e),

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -51,6 +51,7 @@ tonic = "0.4"
 dirs-next = "2.0.0"
 dyn-clone = "1.0.3"
 retry = { version = "1.2.1", default-features = false }
+async-stream = "0.3.1"
 
 [dependencies.tendermint]
 version = "=0.19.0"

--- a/relayer/src/util.rs
+++ b/relayer/src/util.rs
@@ -7,3 +7,4 @@ pub use recv_multiple::{recv_multiple, try_recv_multiple};
 pub mod iter;
 pub mod retry;
 pub mod sled;
+pub mod stream;

--- a/relayer/src/util/stream.rs
+++ b/relayer/src/util/stream.rs
@@ -1,0 +1,74 @@
+use async_stream::stream;
+use futures::stream::Stream;
+
+/// ## Example
+///
+/// ```rust,ignore
+/// let input = stream::iter(vec![0, 0, 0, 1, 1, 2, 3, 3, 3, 3]);
+/// let output = group_while(stream, |a, b| a == b).collect::<Vec<_>>().await;
+/// assert_eq!(output, vec![vec![0, 0, 0], vec![1, 1], vec![2], vec![3, 3, 3, 3]]);
+/// ```
+pub fn group_while<A, S, F>(input: S, group_these: F) -> impl Stream<Item = Vec<A>>
+where
+    S: Stream<Item = A>,
+    F: Fn(&A, &A) -> bool + 'static,
+{
+    struct State<A> {
+        cur: A,
+        group: Vec<A>,
+    }
+
+    stream! {
+        let mut state = None;
+
+        for await x in input {
+            match &mut state {
+                None => {
+                    state = Some(State { cur: x, group: vec![] });
+                },
+                Some(state) if group_these(&state.cur, &x) => {
+                    let prev = std::mem::replace(&mut state.cur, x);
+                    state.group.push(prev);
+                },
+                Some(state) => {
+                    let cur = std::mem::replace(&mut state.cur, x);
+                    state.group.push(cur);
+                    let group = std::mem::replace(&mut state.group, vec![]);
+                    yield group;
+                }
+            }
+        }
+
+        if let Some(State{ cur, mut group }) = state {
+            group.push(cur);
+            yield group;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::group_while;
+    use futures::{executor::block_on, stream, StreamExt};
+
+    #[test]
+    fn group_while_non_empty() {
+        let input = stream::iter(vec![1, 1, 2, 3, 3, 3, 4, 5, 5]);
+        let output = group_while(input, |a, b| a == b).collect::<Vec<_>>();
+        let result = block_on(output);
+
+        assert_eq!(
+            result,
+            vec![vec![1, 1], vec![2], vec![3, 3, 3], vec![4], vec![5, 5]]
+        );
+    }
+
+    #[test]
+    fn group_while_empty() {
+        let input = stream::iter(Vec::<i32>::new());
+        let output = group_while(input, |a, b| a == b).collect::<Vec<_>>();
+        let result = block_on(output);
+
+        assert_eq!(result, Vec::<Vec<i32>>::new());
+    }
+}

--- a/relayer/src/util/stream.rs
+++ b/relayer/src/util/stream.rs
@@ -53,13 +53,30 @@ mod tests {
 
     #[test]
     fn group_while_non_empty() {
-        let input = stream::iter(vec![1, 1, 2, 3, 3, 3, 4, 5, 5]);
-        let output = group_while(input, |a, b| a == b).collect::<Vec<_>>();
+        let input = stream::iter(vec![
+            (1, 1),
+            (1, 2),
+            (2, 1),
+            (3, 1),
+            (3, 2),
+            (3, 3),
+            (4, 1),
+            (5, 1),
+            (5, 2),
+        ]);
+
+        let output = group_while(input, |a, b| a.0 == b.0).collect::<Vec<_>>();
         let result = block_on(output);
 
         assert_eq!(
             result,
-            vec![vec![1, 1], vec![2], vec![3, 3, 3], vec![4], vec![5, 5]]
+            vec![
+                vec![(1, 1), (1, 2)],
+                vec![(2, 1)],
+                vec![(3, 1), (3, 2), (3, 3)],
+                vec![(4, 1)],
+                vec![(5, 1), (5, 2)]
+            ]
         );
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #957

## Description

Bulk events from all transactions included in a block by grouping all the IBC events extracted from the subscription stream by height.

This allows the supervisor to process all events emitted at the same height at once, and substantially improves performance (eg. relaying 250 packets now take ~4 seconds instead of a dozen minutes).


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [x] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.