### PR TITLE
Hermes `fr-transfer`: Verify open channel before sending message

### DIFF
--- a/e2e/run.py
+++ b/e2e/run.py
@@ -102,25 +102,25 @@ def loop(c: Config):
     unreceived = packet.query_unreceived_packets(
         c, chain=IBC_1, port=TRANSFER, channel=IBC_1_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived packet mismatch")
+    assert (len(unreceived) == 0), (unreceived, "unreceived packets mismatch (expected 0)")
 
     # hermes query packet unreceived-acks ibc-1 transfer channel-1
     unreceived = packet.query_unreceived_acks(
         c, chain=IBC_1, port=TRANSFER, channel=IBC_1_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived packet mismatch")
+    assert (len(unreceived) == 0), (unreceived, "unreceived acks mismatch (expected 0)")
 
     # hermes query packet unreceived-packets ibc-0 transfer channel-0
     unreceived = packet.query_unreceived_packets(
         c, chain=IBC_0, port=TRANSFER, channel=IBC_0_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived packet mismatch")
+    assert (len(unreceived) == 0), (unreceived, "unreceived packets mismatch (expected 0)")
 
     # hermes query packet unreceived-acks ibc-0 transfer channel-0
     unreceived = packet.query_unreceived_acks(
         c, chain=IBC_0, port=TRANSFER, channel=IBC_0_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived packet mismatch")
+    assert (len(unreceived) == 0), (unreceived, "unreceived acks mismatch (expected 0)")
 
     # 6. All good, stop the relayer
     proc.kill()

--- a/relayer-cli/src/commands/tx/transfer.rs
+++ b/relayer-cli/src/commands/tx/transfer.rs
@@ -142,6 +142,16 @@ impl Runnable for TxIcs20MsgTransferCmd {
                 Height::zero(),
             )
             .unwrap_or_else(exit_with_unrecoverable_error);
+        if !channel_end.is_open() {
+            return Output::error(format!(
+                "the requested port/channel ('{}'/'{}') on chain id '{}' is in state '{}'; expected 'open' state",
+                opts.packet_src_port_id,
+                opts.packet_src_channel_id,
+                self.src_chain_id,
+                channel_end.state
+            ))
+            .exit();
+        }
 
         let conn_id = match channel_end.connection_hops.first() {
             None => {
@@ -166,7 +176,7 @@ impl Runnable for TxIcs20MsgTransferCmd {
         );
         if src_chain_client_state.chain_id != self.dst_chain_id {
             return Output::error(
-                format!("the requested port/channel ({}/{}) provides a path from chain '{}' to \
+                format!("the requested port/channel ('{}'/'{}') provides a path from chain '{}' to \
                  chain '{}' (not to the destination chain '{}'). Bailing due to mismatching arguments.",
                         opts.packet_src_port_id, opts.packet_src_channel_id,
                         self.src_chain_id,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #958 

## Description

Using a non-Open channel will result in an explicit error. For example, channel `channel-3` on chain `ibc-0` is in state `Init`.

```bash
$ hermes --json tx raw ft-transfer ibc-1 ibc-0 transfer channel-3 10000 -o 1000 -n 2
```

> {"result":"the requested port/channel ('transfer'/'channel-3') on chain id 'ibc-0' is in state 'INIT'; expected 'open' state","status":"error"}


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.