### PR TITLE
Multi-keys keyring and `--key` option for `tx raw ft-transfer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
-> Nothing yet,
+### FEATURES
+
+- [ibc-relayer-cli]
+  - Add a `--key` option to the tx raw ft-transfer command to override the account used for sending messages ([#963])
+
+- [ibc-relayer]
+  - Add support for multiple keys to the keyring ([#963])
+
+[#963]: https://github.com/informalsystems/ibc-rs/issues/963
 
 ## v0.3.1
 *May 14h, 2021*

--- a/ci/bootstrap_gaia.sh
+++ b/ci/bootstrap_gaia.sh
@@ -52,15 +52,27 @@ gaiad keys add validator --keyring-backend="test" --home "$CHAIN_HOME" --output 
 cat "$CHAIN_HOME"/validator_seed.json
 
 echo "-------------------------------------------------------------------------------------------------------------------"
-echo "Adding use key"
+echo "Adding user key"
 echo "-------------------------------------------------------------------------------------------------------------------"
 gaiad keys add user --keyring-backend="test" --home $CHAIN_HOME --output json > "$CHAIN_HOME"/key_seed.json
 cat "$CHAIN_HOME"/key_seed.json
 
 echo "-------------------------------------------------------------------------------------------------------------------"
+echo "Adding user2 key"
+echo "-------------------------------------------------------------------------------------------------------------------"
+gaiad keys add user2 --keyring-backend="test" --home $CHAIN_HOME --output json > "$CHAIN_HOME"/user2_seed.json
+cat "$CHAIN_HOME"/user2_seed.json
+
+echo "-------------------------------------------------------------------------------------------------------------------"
 echo "Adding user account to genesis"
 echo "-------------------------------------------------------------------------------------------------------------------"
 gaiad --home "$CHAIN_HOME" add-genesis-account $(gaiad --home "$CHAIN_HOME" keys --keyring-backend="test" show user -a) 1000000000stake
+echo "Done!"
+
+echo "-------------------------------------------------------------------------------------------------------------------"
+echo "Adding user2 account to genesis"
+echo "-------------------------------------------------------------------------------------------------------------------"
+gaiad --home "$CHAIN_HOME" add-genesis-account $(gaiad --home "$CHAIN_HOME" keys --keyring-backend="test" show user2 -a) 1000000000stake
 echo "Done!"
 
 echo "-------------------------------------------------------------------------------------------------------------------"

--- a/ci/bootstrap_gaia.sh
+++ b/ci/bootstrap_gaia.sh
@@ -57,11 +57,11 @@ echo "--------------------------------------------------------------------------
 gaiad keys add user --keyring-backend="test" --home $CHAIN_HOME --output json > "$CHAIN_HOME"/key_seed.json
 cat "$CHAIN_HOME"/key_seed.json
 
-echo "-------------------------------------------------------------------------------------------------------------------"
-echo "Adding user2 key"
-echo "-------------------------------------------------------------------------------------------------------------------"
-gaiad keys add user2 --keyring-backend="test" --home $CHAIN_HOME --output json > "$CHAIN_HOME"/user2_seed.json
-cat "$CHAIN_HOME"/user2_seed.json
+# echo "-------------------------------------------------------------------------------------------------------------------"
+# echo "Adding user2 key"
+# echo "-------------------------------------------------------------------------------------------------------------------"
+# gaiad keys add user2 --keyring-backend="test" --home $CHAIN_HOME --output json > "$CHAIN_HOME"/user2_seed.json
+# cat "$CHAIN_HOME"/user2_seed.json
 
 echo "-------------------------------------------------------------------------------------------------------------------"
 echo "Adding user account to genesis"
@@ -69,11 +69,11 @@ echo "--------------------------------------------------------------------------
 gaiad --home "$CHAIN_HOME" add-genesis-account $(gaiad --home "$CHAIN_HOME" keys --keyring-backend="test" show user -a) 1000000000stake
 echo "Done!"
 
-echo "-------------------------------------------------------------------------------------------------------------------"
-echo "Adding user2 account to genesis"
-echo "-------------------------------------------------------------------------------------------------------------------"
-gaiad --home "$CHAIN_HOME" add-genesis-account $(gaiad --home "$CHAIN_HOME" keys --keyring-backend="test" show user2 -a) 1000000000stake
-echo "Done!"
+# echo "-------------------------------------------------------------------------------------------------------------------"
+# echo "Adding user2 account to genesis"
+# echo "-------------------------------------------------------------------------------------------------------------------"
+# gaiad --home "$CHAIN_HOME" add-genesis-account $(gaiad --home "$CHAIN_HOME" keys --keyring-backend="test" show user2 -a) 1000000000stake
+# echo "Done!"
 
 echo "-------------------------------------------------------------------------------------------------------------------"
 echo "Adding validator account to genesis"

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -33,6 +33,8 @@ echo "Add keys for chains"
 echo "-----------------------------------------------------------------------------------------------------------------"
 hermes -c "$CONFIG_PATH" keys add "$CHAIN_A" -f key_seed_"$CHAIN_A".json
 hermes -c "$CONFIG_PATH" keys add "$CHAIN_B" -f key_seed_"$CHAIN_B".json
+hermes -c "$CONFIG_PATH" keys add "$CHAIN_A" -f user2_seed_"$CHAIN_A".json
+hermes -c "$CONFIG_PATH" keys add "$CHAIN_B" -f user2_seed_"$CHAIN_B".json
 
 echo "================================================================================================================="
 echo "                                             END-TO-END TESTS                                                    "

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -33,8 +33,8 @@ echo "Add keys for chains"
 echo "-----------------------------------------------------------------------------------------------------------------"
 hermes -c "$CONFIG_PATH" keys add "$CHAIN_A" -f key_seed_"$CHAIN_A".json
 hermes -c "$CONFIG_PATH" keys add "$CHAIN_B" -f key_seed_"$CHAIN_B".json
-hermes -c "$CONFIG_PATH" keys add "$CHAIN_A" -f user2_seed_"$CHAIN_A".json
-hermes -c "$CONFIG_PATH" keys add "$CHAIN_B" -f user2_seed_"$CHAIN_B".json
+# hermes -c "$CONFIG_PATH" keys add "$CHAIN_A" -f user2_seed_"$CHAIN_A".json
+# hermes -c "$CONFIG_PATH" keys add "$CHAIN_B" -f user2_seed_"$CHAIN_B".json
 
 echo "================================================================================================================="
 echo "                                             END-TO-END TESTS                                                    "

--- a/ci/relayer.Dockerfile
+++ b/ci/relayer.Dockerfile
@@ -27,8 +27,8 @@ COPY e2e ./e2e
 # Copy key files
 COPY ci/chains/gaia/$RELEASE/ibc-0/key_seed.json  ./key_seed_ibc-0.json
 COPY ci/chains/gaia/$RELEASE/ibc-1/key_seed.json  ./key_seed_ibc-1.json
-COPY ci/chains/gaia/$RELEASE/ibc-0/user2_seed.json ./user2_seed_ibc-0.json
-COPY ci/chains/gaia/$RELEASE/ibc-1/user2_seed.json ./user2_seed_ibc-1.json
+# COPY ci/chains/gaia/$RELEASE/ibc-0/user2_seed.json ./user2_seed_ibc-0.json
+# COPY ci/chains/gaia/$RELEASE/ibc-1/user2_seed.json ./user2_seed_ibc-1.json
 
 # Make it executable
 RUN chmod +x e2e.sh

--- a/ci/relayer.Dockerfile
+++ b/ci/relayer.Dockerfile
@@ -25,8 +25,10 @@ COPY ci/e2e.sh .
 COPY e2e ./e2e
 
 # Copy key files
-COPY ci/chains/gaia/$RELEASE/ibc-0/key_seed.json ./key_seed_ibc-0.json
-COPY ci/chains/gaia/$RELEASE/ibc-1/key_seed.json ./key_seed_ibc-1.json
+COPY ci/chains/gaia/$RELEASE/ibc-0/key_seed.json  ./key_seed_ibc-0.json
+COPY ci/chains/gaia/$RELEASE/ibc-1/key_seed.json  ./key_seed_ibc-1.json
+COPY ci/chains/gaia/$RELEASE/ibc-0/user2_seed.json ./user2_seed_ibc-0.json
+COPY ci/chains/gaia/$RELEASE/ibc-1/user2_seed.json ./user2_seed_ibc-1.json
 
 # Make it executable
 RUN chmod +x e2e.sh

--- a/e2e/e2e/packet.py
+++ b/e2e/e2e/packet.py
@@ -31,7 +31,8 @@ class TxPacketSend(Cmd[TxPacketSendRes]):
     src_channel: ChannelId
     amount: int
     height_offset: int
-    number_msgs: Optional[int]
+    number_msgs: Optional[int] = None
+    key: Optional[str] = None
 
     def args(self) -> List[str]:
         args = [
@@ -45,6 +46,9 @@ class TxPacketSend(Cmd[TxPacketSendRes]):
 
         if self.number_msgs != None:
             args.extend(['-n', str(self.number_msgs)])
+
+        if self.key != None:
+            args.extend(['-k', str(self.key)])
 
         return args
 
@@ -189,13 +193,15 @@ def query_unreceived_acks(
 
 def packet_send(c: Config, src: ChainId, dst: ChainId,
                 src_port: PortId, src_channel: ChannelId,
-                amount: int, height_offset: int, number_msgs: Optional[int] = None) -> Packet:
+                amount: int, height_offset: int, number_msgs: Optional[int] = None,
+                key: Optional[str] = None) -> Packet:
 
     cmd = TxPacketSend(dst_chain_id=dst, src_chain_id=src,
                        src_port=src_port, src_channel=src_channel,
                        amount=amount,
                        number_msgs=number_msgs,
-                       height_offset=height_offset)
+                       height_offset=height_offset,
+                       key=key)
 
     res = cmd.run(c).success()
     l.info(
@@ -243,7 +249,8 @@ def ping_pong(c: Config,
               port_id: PortId = PortId('transfer')):
 
     pkt_send_a = packet_send(c, side_a, side_b, port_id,
-                             a_chan, amount=9999, height_offset=1000)
+                             a_chan, amount=9999, height_offset=1000,
+                             key='hermes')
 
     split()
 
@@ -265,7 +272,8 @@ def ping_pong(c: Config,
     split()
 
     pkt_send_b = packet_send(c, side_b, side_a, port_id,
-                             b_chan, amount=9999, height_offset=1000)
+                             b_chan, amount=9999, height_offset=1000,
+                             key='hermes')
 
     split()
 
@@ -290,7 +298,8 @@ def timeout(c: Config,
             port_id: PortId = PortId('transfer')):
 
     pkt_send_a = packet_send(c, side_a, side_b, port_id,
-                             a_chan, amount=9999, height_offset=1)
+                             a_chan, amount=9999, height_offset=1,
+                             key='hermes')
 
     split()
 
@@ -303,7 +312,8 @@ def timeout(c: Config,
     split()
 
     pkt_send_b = packet_send(c, side_b, side_a, port_id,
-                             b_chan, amount=9999, height_offset=1)
+                             b_chan, amount=9999, height_offset=1,
+                             key='hermes')
 
     split()
 

--- a/e2e/e2e/packet.py
+++ b/e2e/e2e/packet.py
@@ -249,8 +249,7 @@ def ping_pong(c: Config,
               port_id: PortId = PortId('transfer')):
 
     pkt_send_a = packet_send(c, side_a, side_b, port_id,
-                             a_chan, amount=9999, height_offset=1000,
-                             key='user2')
+                             a_chan, amount=9999, height_offset=1000)
 
     split()
 
@@ -272,8 +271,7 @@ def ping_pong(c: Config,
     split()
 
     pkt_send_b = packet_send(c, side_b, side_a, port_id,
-                             b_chan, amount=9999, height_offset=1000,
-                             key='user2')
+                             b_chan, amount=9999, height_offset=1000)
 
     split()
 
@@ -298,8 +296,7 @@ def timeout(c: Config,
             port_id: PortId = PortId('transfer')):
 
     pkt_send_a = packet_send(c, side_a, side_b, port_id,
-                             a_chan, amount=9999, height_offset=1,
-                             key='user2')
+                             a_chan, amount=9999, height_offset=1)
 
     split()
 
@@ -312,8 +309,7 @@ def timeout(c: Config,
     split()
 
     pkt_send_b = packet_send(c, side_b, side_a, port_id,
-                             b_chan, amount=9999, height_offset=1,
-                             key='user2')
+                             b_chan, amount=9999, height_offset=1)
 
     split()
 

--- a/e2e/e2e/packet.py
+++ b/e2e/e2e/packet.py
@@ -250,7 +250,7 @@ def ping_pong(c: Config,
 
     pkt_send_a = packet_send(c, side_a, side_b, port_id,
                              a_chan, amount=9999, height_offset=1000,
-                             key='hermes')
+                             key='user2')
 
     split()
 
@@ -273,7 +273,7 @@ def ping_pong(c: Config,
 
     pkt_send_b = packet_send(c, side_b, side_a, port_id,
                              b_chan, amount=9999, height_offset=1000,
-                             key='hermes')
+                             key='user2')
 
     split()
 
@@ -299,7 +299,7 @@ def timeout(c: Config,
 
     pkt_send_a = packet_send(c, side_a, side_b, port_id,
                              a_chan, amount=9999, height_offset=1,
-                             key='hermes')
+                             key='user2')
 
     split()
 
@@ -313,7 +313,7 @@ def timeout(c: Config,
 
     pkt_send_b = packet_send(c, side_b, side_a, port_id,
                              b_chan, amount=9999, height_offset=1,
-                             key='hermes')
+                             key='user2')
 
     split()
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -48,7 +48,7 @@ def loop(c: Config):
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
                        src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
-                       key='hemes')
+                       key='hermes')
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -26,13 +26,11 @@ def loop(c: Config):
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 2
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
-                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=2,
-                       key='user2')
+                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=2)
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 2
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
-                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=2,
-                       key='user2')
+                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=2)
     sleep(5.0)
 
     # hermes tx raw packet-recv ibc-1 ibc-0 transfer channel-0
@@ -47,13 +45,11 @@ def loop(c: Config):
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
-                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
-                       key='user2')
+                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3)
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
-                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4,
-                       key='user2')
+                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4)
 
     sleep(10.0)
 
@@ -94,13 +90,11 @@ def loop(c: Config):
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
-                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
-                       key='user2')
+                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3)
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
-                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4,
-                       key='user2')
+                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4)
 
     sleep(10.0)
 
@@ -108,25 +102,29 @@ def loop(c: Config):
     unreceived = packet.query_unreceived_packets(
         c, chain=IBC_1, port=TRANSFER, channel=IBC_1_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived packets mismatch (expected 0)")
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived packets mismatch (expected 0)")
 
     # hermes query packet unreceived-acks ibc-1 transfer channel-1
     unreceived = packet.query_unreceived_acks(
         c, chain=IBC_1, port=TRANSFER, channel=IBC_1_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived acks mismatch (expected 0)")
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived acks mismatch (expected 0)")
 
     # hermes query packet unreceived-packets ibc-0 transfer channel-0
     unreceived = packet.query_unreceived_packets(
         c, chain=IBC_0, port=TRANSFER, channel=IBC_0_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived packets mismatch (expected 0)")
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived packets mismatch (expected 0)")
 
     # hermes query packet unreceived-acks ibc-0 transfer channel-0
     unreceived = packet.query_unreceived_acks(
         c, chain=IBC_0, port=TRANSFER, channel=IBC_0_CHANNEL)
 
-    assert (len(unreceived) == 0), (unreceived, "unreceived acks mismatch (expected 0)")
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived acks mismatch (expected 0)")
 
     # 6. All good, stop the relayer
     proc.kill()

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -26,11 +26,13 @@ def loop(c: Config):
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 2
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
-                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=2)
+                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=2,
+                       key='hermes')
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 2
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
-                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=2)
+                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=2,
+                       key='hermes')
     sleep(5.0)
 
     # hermes tx raw packet-recv ibc-1 ibc-0 transfer channel-0
@@ -45,11 +47,13 @@ def loop(c: Config):
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
-                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3)
+                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
+                       key='hemes')
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
-                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4)
+                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4,
+                       key='hermes')
 
     sleep(10.0)
 
@@ -90,11 +94,13 @@ def loop(c: Config):
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
-                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3)
+                       src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
+                       key='hermes')
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
-                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4)
+                       src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4,
+                       key='hermes')
 
     sleep(10.0)
 

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -27,12 +27,12 @@ def loop(c: Config):
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 2
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
                        src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=2,
-                       key='hermes')
+                       key='user2')
 
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 2
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
                        src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=2,
-                       key='hermes')
+                       key='user2')
     sleep(5.0)
 
     # hermes tx raw packet-recv ibc-1 ibc-0 transfer channel-0
@@ -48,12 +48,12 @@ def loop(c: Config):
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
                        src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
-                       key='hermes')
+                       key='user2')
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
                        src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4,
-                       key='hermes')
+                       key='user2')
 
     sleep(10.0)
 
@@ -95,12 +95,12 @@ def loop(c: Config):
     # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
     packet.packet_send(c, src=IBC_1, dst=IBC_0, src_port=TRANSFER,
                        src_channel=IBC_1_CHANNEL, amount=10000, height_offset=1000, number_msgs=3,
-                       key='hermes')
+                       key='user2')
 
     # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
     packet.packet_send(c, src=IBC_0, dst=IBC_1, src_port=TRANSFER,
                        src_channel=IBC_0_CHANNEL, amount=10000, height_offset=1000, number_msgs=4,
-                       key='hermes')
+                       key='user2')
 
     sleep(10.0)
 

--- a/guide/src/tutorials/local-chains/start.md
+++ b/guide/src/tutorials/local-chains/start.md
@@ -129,14 +129,16 @@ data
 │   ├── config
 │   ├── data
 │   ├── keyring-test
-│   ├── key_seed.json
+│   ├── user_seed.json
+│   ├── user2_seed.json
 │   └── validator_seed.json
 ├── ibc-0.log
 ├── ibc-1
 │   ├── config
 │   ├── data
 │   ├── keyring-test
-│   ├── key_seed.json
+│   ├── user_seed.json
+│   ├── user2_seed.json
 │   └── validator_seed.json
 └── ibc-1.log
 

--- a/relayer-cli/src/commands.rs
+++ b/relayer-cli/src/commands.rs
@@ -7,7 +7,9 @@
 
 use std::path::PathBuf;
 
-use abscissa_core::{Command, Configurable, FrameworkError, Help, Options, Runnable};
+use abscissa_core::{
+    config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable,
+};
 use tracing::info;
 
 use crate::config::Config;
@@ -111,6 +113,20 @@ impl Configurable<Config> for CliCmd {
     /// This can be safely deleted if you don't want to override config
     /// settings from command-line options.
     fn process_config(&self, config: Config) -> Result<Config, FrameworkError> {
-        Ok(config)
+        match self {
+            CliCmd::Tx(cmd) => cmd.override_config(config),
+            // CliCmd::Help(cmd) => cmd.override_config(config),
+            // CliCmd::Keys(cmd) => cmd.override_config(config),
+            // CliCmd::Create(cmd) => cmd.override_config(config),
+            // CliCmd::Update(cmd) => cmd.override_config(config),
+            // CliCmd::Upgrade(cmd) => cmd.override_config(config),
+            // CliCmd::Start(cmd) => cmd.override_config(config),
+            // CliCmd::StartMulti(cmd) => cmd.override_config(config),
+            // CliCmd::Query(cmd) => cmd.override_config(config),
+            // CliCmd::Listen(cmd) => cmd.override_config(config),
+            // CliCmd::Misbehaviour(cmd) => cmd.override_config(config),
+            // CliCmd::Version(cmd) => cmd.override_config(config),
+            _ => Ok(config),
+        }
     }
 }

--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -69,12 +69,12 @@ impl Runnable for KeysAddCmd {
 }
 
 pub fn add_key(config: ChainConfig, file: &Path) -> Result<KeyEntry, BoxError> {
-    let mut keyring = KeyRing::new(Store::Test, config)?;
+    let mut keyring = KeyRing::new(Store::Test, &config.account_prefix, &config.id)?;
 
     let key_contents = fs::read_to_string(file).map_err(|_| "error reading the key file")?;
     let key = keyring.key_from_seed_file(&key_contents)?;
 
-    keyring.add_key(key.clone())?;
+    keyring.add_key(&config.key_name, key.clone())?;
 
     Ok(key)
 }

--- a/relayer-cli/src/commands/keys/list.rs
+++ b/relayer-cli/src/commands/keys/list.rs
@@ -57,7 +57,7 @@ pub struct KeysListOptions {
 }
 
 pub fn list_keys(config: ChainConfig) -> Result<KeyEntry, BoxError> {
-    let keyring = KeyRing::new(Store::Test, config)?;
-    let key_entry = keyring.get_key()?;
+    let keyring = KeyRing::new(Store::Test, &config.account_prefix, &config.id)?;
+    let key_entry = keyring.get_key(&config.key_name)?;
     Ok(key_entry)
 }

--- a/relayer-cli/src/commands/keys/restore.rs
+++ b/relayer-cli/src/commands/keys/restore.rs
@@ -76,9 +76,10 @@ pub fn restore_key(
     coin_type: CoinType,
     config: ChainConfig,
 ) -> Result<KeyEntry, BoxError> {
-    let mut keyring = KeyRing::new(Store::Test, config)?;
+    let key_name = config.key_name.clone();
+    let mut keyring = KeyRing::new(Store::Test, &config.account_prefix, &config.id)?;
     let key_entry = keyring.key_from_mnemonic(mnemonic, coin_type)?;
-    keyring.add_key(key_entry.clone())?;
+    keyring.add_key(&key_name, key_entry.clone())?;
 
     Ok(key_entry)
 }

--- a/relayer-cli/src/commands/tx.rs
+++ b/relayer-cli/src/commands/tx.rs
@@ -1,5 +1,6 @@
 //! `tx` subcommand
-use abscissa_core::{Command, Help, Options, Runnable};
+use abscissa_core::{config::Override, Command, Help, Options, Runnable};
+use ibc_relayer::config::Config;
 
 use crate::commands::tx::client::{TxCreateClientCmd, TxUpdateClientCmd, TxUpgradeClientCmd};
 
@@ -11,6 +12,7 @@ mod transfer;
 mod upgrade;
 
 /// `tx` subcommand
+#[allow(clippy::large_enum_variant)]
 #[derive(Command, Debug, Options, Runnable)]
 pub enum TxCmd {
     /// The `help` subcommand
@@ -95,4 +97,22 @@ pub enum TxRawCommands {
     /// The `tx raw upgrade-chain` subcommand
     #[options(help = "Send an upgrade plan")]
     UpgradeChain(upgrade::TxUpgradeChainCmd),
+}
+
+impl Override<Config> for TxCmd {
+    fn override_config(&self, config: Config) -> Result<Config, abscissa_core::FrameworkError> {
+        match self {
+            Self::Raw(cmd) => cmd.override_config(config),
+            _ => Ok(config),
+        }
+    }
+}
+
+impl Override<Config> for TxRawCommands {
+    fn override_config(&self, config: Config) -> Result<Config, abscissa_core::FrameworkError> {
+        match self {
+            Self::FtTransfer(cmd) => cmd.override_config(config),
+            _ => Ok(config),
+        }
+    }
 }

--- a/relayer-cli/src/commands/tx/transfer.rs
+++ b/relayer-cli/src/commands/tx/transfer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use abscissa_core::{Command, Options, Runnable};
+use abscissa_core::{config::Override, Command, FrameworkErrorKind, Options, Runnable};
 use anomaly::BoxError;
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -59,6 +59,26 @@ pub struct TxIcs20MsgTransferCmd {
 
     #[options(help = "number of messages to send", short = "n")]
     number_msgs: Option<usize>,
+
+    #[options(
+        help = "use the given signing key (default: `key_name` config)",
+        short = "k"
+    )]
+    key: Option<String>,
+}
+
+impl Override<Config> for TxIcs20MsgTransferCmd {
+    fn override_config(&self, mut config: Config) -> Result<Config, abscissa_core::FrameworkError> {
+        let src_chain_config = config.find_chain_mut(&self.src_chain_id).ok_or_else(|| {
+            FrameworkErrorKind::ComponentError.context("missing src chain configuration")
+        })?;
+
+        if let Some(ref key_name) = self.key {
+            src_chain_config.key_name = key_name.to_string();
+        }
+
+        Ok(config)
+    }
 }
 
 impl TxIcs20MsgTransferCmd {
@@ -153,17 +173,22 @@ impl Runnable for TxIcs20MsgTransferCmd {
             }
             Some(cid) => cid,
         };
+
         let conn_end = src_chain
             .query_connection(conn_id, Height::zero())
             .unwrap_or_else(exit_with_unrecoverable_error);
+
         debug!("connection hop underlying the channel: {:?}", conn_end);
+
         let src_chain_client_state = src_chain
             .query_client_state(conn_end.client_id(), Height::zero())
             .unwrap_or_else(exit_with_unrecoverable_error);
+
         debug!(
             "client state underlying the channel: {:?}",
             src_chain_client_state
         );
+
         if src_chain_client_state.chain_id != self.dst_chain_id {
             return Output::error(
                 format!("the requested port/channel ({}/{}) provides a path from chain '{}' to \

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -148,7 +148,7 @@ impl CosmosSdkChain {
 
         let key = self
             .keybase()
-            .get_key()
+            .get_key(&self.config.key_name)
             .map_err(|e| Kind::KeyBase.context(e))?;
 
         // Create TxBody
@@ -218,7 +218,7 @@ impl CosmosSdkChain {
         // Sign doc and broadcast
         let signed = self
             .keybase
-            .sign_msg(signdoc_buf)
+            .sign_msg(&self.config.key_name, signdoc_buf)
             .map_err(|e| Kind::KeyBase.context(e))?;
 
         let tx_raw = TxRaw {
@@ -328,8 +328,8 @@ impl Chain for CosmosSdkChain {
             .map_err(|e| Kind::Rpc(config.rpc_addr.clone()).context(e))?;
 
         // Initialize key store and load key
-        let keybase =
-            KeyRing::new(Store::Test, config.clone()).map_err(|e| Kind::KeyBase.context(e))?;
+        let keybase = KeyRing::new(Store::Test, &config.account_prefix, &config.id)
+            .map_err(|e| Kind::KeyBase.context(e))?;
 
         let grpc_addr =
             Uri::from_str(&config.grpc_addr.to_string()).map_err(|e| Kind::Grpc.context(e))?;
@@ -432,7 +432,7 @@ impl Chain for CosmosSdkChain {
         // Get the key from key seed file
         let key = self
             .keybase()
-            .get_key()
+            .get_key(&self.config.key_name)
             .map_err(|e| Kind::KeyBase.context(e))?;
 
         let bech32 = encode_to_bech32(&key.address.to_hex(), &self.config.account_prefix)?;
@@ -446,7 +446,7 @@ impl Chain for CosmosSdkChain {
         // Get the key from key seed file
         let key = self
             .keybase()
-            .get_key()
+            .get_key(&self.config.key_name)
             .map_err(|e| Kind::KeyBase.context(e))?;
 
         Ok(key)

--- a/relayer/src/keyring.rs
+++ b/relayer/src/keyring.rs
@@ -1,7 +1,10 @@
-use std::convert::{TryFrom, TryInto};
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+};
 
 use bech32::{ToBase32, Variant};
 use bip39::{Language, Mnemonic, Seed};
@@ -11,6 +14,7 @@ use bitcoin::{
     util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey},
 };
 use hdpath::StandardHDPath;
+use ibc::ics24_host::identifier::ChainId;
 use k256::ecdsa::{signature::Signer, Signature, SigningKey};
 use ripemd160::Ripemd160;
 use serde::{Deserialize, Serialize};
@@ -19,13 +23,11 @@ use sha2::{Digest, Sha256};
 use errors::{Error, Kind};
 pub use pub_key::EncodedPubKey;
 
-use crate::config::ChainConfig;
-
 pub mod errors;
 mod pub_key;
 
 pub const KEYSTORE_DEFAULT_FOLDER: &str = ".hermes/keys/";
-pub const KEYSTORE_DISK_BACKEND: &str = "keyring-test"; // TODO: Change to "keyring"
+pub const KEYSTORE_DISK_BACKEND: &str = "keyring-test";
 pub const KEYSTORE_FILE_EXTENSION: &str = "json";
 
 /// [Coin type][coin-type] associated with a key.
@@ -139,38 +141,39 @@ impl TryFrom<KeyFile> for KeyEntry {
 }
 
 pub trait KeyStore {
-    fn get_key(&self) -> Result<KeyEntry, Error>;
-    fn add_key(&mut self, key_entry: KeyEntry) -> Result<(), Error>;
+    fn get_key(&self, key_name: &str) -> Result<KeyEntry, Error>;
+    fn add_key(&mut self, key_name: &str, key_entry: KeyEntry) -> Result<(), Error>;
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Memory {
     account_prefix: String,
-    key_entry: Option<KeyEntry>,
+    keys: HashMap<String, KeyEntry>,
 }
 
 impl Memory {
-    pub fn new(account_prefix: String, key_entry: Option<KeyEntry>) -> Self {
+    pub fn new(account_prefix: String) -> Self {
         Self {
             account_prefix,
-            key_entry,
+            keys: HashMap::new(),
         }
     }
 }
 
 impl KeyStore for Memory {
-    fn get_key(&self) -> Result<KeyEntry, Error> {
-        self.key_entry
-            .clone()
+    fn get_key(&self, key_name: &str) -> Result<KeyEntry, Error> {
+        self.keys
+            .get(key_name)
+            .cloned()
             .ok_or_else(|| Kind::KeyNotFound.into())
     }
 
-    fn add_key(&mut self, key_entry: KeyEntry) -> Result<(), Error> {
-        if self.key_entry.is_some() {
+    fn add_key(&mut self, key_name: &str, key_entry: KeyEntry) -> Result<(), Error> {
+        if self.keys.contains_key(key_name) {
             return Err(Kind::ExistingKey.into());
         }
 
-        self.key_entry = Some(key_entry);
+        self.keys.insert(key_name.to_string(), key_entry);
 
         Ok(())
     }
@@ -178,15 +181,13 @@ impl KeyStore for Memory {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Test {
-    key_name: String,
     account_prefix: String,
     store: PathBuf,
 }
 
 impl Test {
-    pub fn new(key_name: String, account_prefix: String, store: PathBuf) -> Self {
+    pub fn new(account_prefix: String, store: PathBuf) -> Self {
         Self {
-            key_name,
             account_prefix,
             store,
         }
@@ -194,8 +195,8 @@ impl Test {
 }
 
 impl KeyStore for Test {
-    fn get_key(&self) -> Result<KeyEntry, Error> {
-        let mut filename = self.store.join(&self.key_name);
+    fn get_key(&self, key_name: &str) -> Result<KeyEntry, Error> {
+        let mut filename = self.store.join(key_name);
         filename.set_extension(KEYSTORE_FILE_EXTENSION);
 
         if !filename.as_path().exists() {
@@ -211,8 +212,8 @@ impl KeyStore for Test {
         Ok(key_entry)
     }
 
-    fn add_key(&mut self, key_entry: KeyEntry) -> Result<(), Error> {
-        let mut filename = self.store.join(&self.key_name);
+    fn add_key(&mut self, key_name: &str, key_entry: KeyEntry) -> Result<(), Error> {
+        let mut filename = self.store.join(key_name);
         filename.set_extension(KEYSTORE_FILE_EXTENSION);
 
         let file = File::create(filename)
@@ -238,12 +239,12 @@ pub enum KeyRing {
 }
 
 impl KeyRing {
-    pub fn new(store: Store, chain_config: ChainConfig) -> Result<Self, Error> {
+    pub fn new(store: Store, account_prefix: &str, chain_id: &ChainId) -> Result<Self, Error> {
         match store {
-            Store::Memory => Ok(Self::Memory(Memory::new(chain_config.account_prefix, None))),
+            Store::Memory => Ok(Self::Memory(Memory::new(account_prefix.to_string()))),
 
             Store::Test => {
-                let keys_folder = disk_store_path(chain_config.id.as_str()).map_err(|e| {
+                let keys_folder = disk_store_path(chain_id.as_str()).map_err(|e| {
                     Kind::KeyStore.context(format!("failed to compute keys folder path: {:?}", e))
                 })?;
 
@@ -253,25 +254,24 @@ impl KeyRing {
                 })?;
 
                 Ok(Self::Test(Test::new(
-                    chain_config.key_name,
-                    chain_config.account_prefix,
+                    account_prefix.to_string(),
                     keys_folder,
                 )))
             }
         }
     }
 
-    pub fn get_key(&self) -> Result<KeyEntry, Error> {
+    pub fn get_key(&self, key_name: &str) -> Result<KeyEntry, Error> {
         match self {
-            KeyRing::Memory(m) => m.get_key(),
-            KeyRing::Test(d) => d.get_key(),
+            KeyRing::Memory(m) => m.get_key(key_name),
+            KeyRing::Test(d) => d.get_key(key_name),
         }
     }
 
-    pub fn add_key(&mut self, key_entry: KeyEntry) -> Result<(), Error> {
+    pub fn add_key(&mut self, key_name: &str, key_entry: KeyEntry) -> Result<(), Error> {
         match self {
-            KeyRing::Memory(m) => m.add_key(key_entry),
-            KeyRing::Test(d) => d.add_key(key_entry),
+            KeyRing::Memory(m) => m.add_key(key_name, key_entry),
+            KeyRing::Test(d) => d.add_key(key_name, key_entry),
         }
     }
 
@@ -312,8 +312,8 @@ impl KeyRing {
     }
 
     /// Sign a message
-    pub fn sign_msg(&self, msg: Vec<u8>) -> Result<Vec<u8>, Error> {
-        let key = self.get_key()?;
+    pub fn sign_msg(&self, key_name: &str, msg: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let key = self.get_key(key_name)?;
 
         let private_key_bytes = key.private_key.private_key.to_bytes();
         let signing_key = SigningKey::from_bytes(private_key_bytes.as_slice()).map_err(|_| {

--- a/relayer/src/keyring.rs
+++ b/relayer/src/keyring.rs
@@ -208,18 +208,21 @@ impl Test {
 
 impl KeyStore for Test {
     fn get_key(&self, key_name: &str) -> Result<KeyEntry, Error> {
-        let mut filename = self.store.join(key_name);
-        filename.set_extension(KEYSTORE_FILE_EXTENSION);
+        let mut key_file = self.store.join(key_name);
+        key_file.set_extension(KEYSTORE_FILE_EXTENSION);
 
-        if !filename.as_path().exists() {
-            return Err(Kind::KeyStore.context("cannot find key file").into());
+        if !key_file.as_path().exists() {
+            return Err(Kind::KeyStore
+                .context(format!("cannot find key file at '{}'", key_file.display()))
+                .into());
         }
 
         let file =
-            File::open(filename).map_err(|_| Kind::KeyStore.context("cannot open key file"))?;
+            File::open(&key_file).map_err(|_| Kind::KeyStore.context("cannot open key file"))?;
 
-        let key_entry = serde_json::from_reader(file)
-            .map_err(|_| Kind::KeyStore.context("cannot ready key file"))?;
+        let key_entry = serde_json::from_reader(file).map_err(|_| {
+            Kind::KeyStore.context(format!("cannot read key file at '{}'", key_file.display()))
+        })?;
 
         Ok(key_entry)
     }

--- a/scripts/init-hermes
+++ b/scripts/init-hermes
@@ -63,14 +63,14 @@ cargo build -q --locked
 
 # add the key seeds to the keyring of each chain
 echo "Importing keys..."
-cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_0_ID" -f "$GAIA_DATA/$CHAIN_0_ID/key_seed.json"
-cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_0_ID" -f "$GAIA_DATA/$CHAIN_0_ID/hermes_seed.json" -n hermes
-cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_1_ID" -f "$GAIA_DATA/$CHAIN_1_ID/key_seed.json"
-cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_1_ID" -f "$GAIA_DATA/$CHAIN_1_ID/hermes_seed.json" -n hermes
+cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_0_ID" -f "$GAIA_DATA/$CHAIN_0_ID/user_seed.json"
+cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_0_ID" -f "$GAIA_DATA/$CHAIN_0_ID/user2_seed.json" -n user2
+cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_1_ID" -f "$GAIA_DATA/$CHAIN_1_ID/user_seed.json"
+cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_1_ID" -f "$GAIA_DATA/$CHAIN_1_ID/user2_seed.json" -n user2
 
 if [ -n "$CHAIN_2_ID" ]; then
-  cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_2_ID" -f "$GAIA_DATA/$CHAIN_2_ID/key_seed.json"
-  cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_2_ID" -f "$GAIA_DATA/$CHAIN_2_ID/hermes_seed.json" -n hermes
+  cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_2_ID" -f "$GAIA_DATA/$CHAIN_2_ID/user_seed.json"
+  cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_2_ID" -f "$GAIA_DATA/$CHAIN_2_ID/user2_seed.json" -n user2
 fi
 
 echo "Done!"

--- a/scripts/init-hermes
+++ b/scripts/init-hermes
@@ -64,10 +64,13 @@ cargo build -q --locked
 # add the key seeds to the keyring of each chain
 echo "Importing keys..."
 cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_0_ID" -f "$GAIA_DATA/$CHAIN_0_ID/key_seed.json"
+cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_0_ID" -f "$GAIA_DATA/$CHAIN_0_ID/hermes_seed.json" -n hermes
 cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_1_ID" -f "$GAIA_DATA/$CHAIN_1_ID/key_seed.json"
+cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_1_ID" -f "$GAIA_DATA/$CHAIN_1_ID/hermes_seed.json" -n hermes
 
 if [ -n "$CHAIN_2_ID" ]; then
   cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_2_ID" -f "$GAIA_DATA/$CHAIN_2_ID/key_seed.json"
+  cargo run -q --bin hermes -- -c "$CONFIG_FILE" keys add "$CHAIN_2_ID" -f "$GAIA_DATA/$CHAIN_2_ID/hermes_seed.json" -n hermes
 fi
 
 echo "Done!"

--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -68,14 +68,25 @@ fi
 
 # Build genesis file incl account for passed address
 STAKE="100000000000stake"
-# - the user also needs stake to perform actions
+
+# The user also needs stake to perform actions
 USER_COINS="${STAKE},${SAMOLEANS}samoleans"
+
+# Hermes also needs stake to perform actions
+HERMES_COINS="${STAKE},${SAMOLEANS}samoleans"
 
 $BINARY --home $CHAIN_DIR/$CHAIN_ID --chain-id $CHAIN_ID init $CHAIN_ID &> /dev/null
 sleep 1
 $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add validator --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/validator_seed.json 2> /dev/null
 sleep 1
+$BINARY --home $CHAIN_DIR/$CHAIN_ID keys add hermes --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/hermes_seed.json 2> /dev/null
+sleep 1
 $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add user --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/key_seed.json 2> /dev/null
+sleep 1
+
+# Add samoleans to Hermes
+HERMES=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show hermes -a)
+$BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $HERMES $USER_COINS &> /dev/null
 sleep 1
 
 # Add samoleans to user
@@ -136,5 +147,7 @@ sleep 3
 RPC_ADDR="tcp://localhost:$RPC_PORT"
 echo "Balances for validator '$VALIDATOR' @ '$RPC_ADDR'"
 $BINARY --node "$RPC_ADDR" query bank balances $VALIDATOR --log_level error
+echo "Balances for user '$HERMES' @ '$RPC_ADDR'"
+$BINARY --node "$RPC_ADDR" query bank balances $HERMES --log_level error
 echo "Balances for user '$USER' @ '$RPC_ADDR'"
 $BINARY --node "$RPC_ADDR" query bank balances $USER --log_level error

--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -79,20 +79,21 @@ $BINARY --home $CHAIN_DIR/$CHAIN_ID --chain-id $CHAIN_ID init $CHAIN_ID &> /dev/
 sleep 1
 $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add validator --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/validator_seed.json 2> /dev/null
 sleep 1
-$BINARY --home $CHAIN_DIR/$CHAIN_ID keys add hermes --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/hermes_seed.json 2> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID keys add user --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/user_seed.json 2> /dev/null
 sleep 1
-$BINARY --home $CHAIN_DIR/$CHAIN_ID keys add user --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/key_seed.json 2> /dev/null
-sleep 1
-
-# Add samoleans to Hermes
-HERMES=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show hermes -a)
-$BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $HERMES $USER_COINS &> /dev/null
+$BINARY --home $CHAIN_DIR/$CHAIN_ID keys add user2 --keyring-backend="test" --output json > $CHAIN_DIR/$CHAIN_ID/user2_seed.json 2> /dev/null
 sleep 1
 
 # Add samoleans to user
 USER=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show user -a)
 $BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $USER $USER_COINS &> /dev/null
 sleep 1
+
+# Add samoleans to user2
+USER2=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show user2 -a)
+$BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $USER2 $USER_COINS &> /dev/null
+sleep 1
+
 
 # Add stake to validator
 VALIDATOR=$($BINARY --home $CHAIN_DIR/$CHAIN_ID keys --keyring-backend="test" show validator -a)
@@ -147,7 +148,7 @@ sleep 3
 RPC_ADDR="tcp://localhost:$RPC_PORT"
 echo "Balances for validator '$VALIDATOR' @ '$RPC_ADDR'"
 $BINARY --node "$RPC_ADDR" query bank balances $VALIDATOR --log_level error
-echo "Balances for user '$HERMES' @ '$RPC_ADDR'"
-$BINARY --node "$RPC_ADDR" query bank balances $HERMES --log_level error
 echo "Balances for user '$USER' @ '$RPC_ADDR'"
 $BINARY --node "$RPC_ADDR" query bank balances $USER --log_level error
+echo "Balances for user '$USER2' @ '$RPC_ADDR'"
+$BINARY --node "$RPC_ADDR" query bank balances $USER2 --log_level error


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #963

## Description

- [x] Update the `dev-env` script:
  - [x] Create a new `user2` account on top of the existing `user` account
  - [x] Add this new account to the Hermes keyring under the key name `user2`
  - [x] The key for the default `user` account is added with the default `key_name` specified in the config
- [x] Add support for multiple keys to the keyring
- [x] Add a `--key` option to the `tx raw ft-transfer` command to override the default `key_name` used for sending messages
- [ ] **POSTPONED:** Update the `e2e` test suite to use the new `user2` account for transferring messages

## How to test

1. Run the `dev-env` script as usual
2. Start hermes with `hermes start-multi`
3. Send packets with `hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 9999 -t 1000 -n 1000 -k user2`

______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [x] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.