### PR TITLE
Fix Hermes help to provide a useful message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [ibc-relayer-cli]
   - Improve config loading message ([#996])
   - Improve Hermes worker spawn time for `start` command ([#998])
+  - Better Hermes help message when command is unrecognized ([#1003])
 
 ### BUG FIXES
 
@@ -38,6 +39,7 @@
 [#983]: https://github.com/informalsystems/ibc-rs/issues/983
 [#996]: https://github.com/informalsystems/ibc-rs/issues/996
 [#998]: https://github.com/informalsystems/ibc-rs/issues/998
+[#1003]: https://github.com/informalsystems/ibc-rs/issues/1003
 
 ## v0.3.2
 *May 21st, 2021*

--- a/relayer-cli/src/entry.rs
+++ b/relayer-cli/src/entry.rs
@@ -15,10 +15,6 @@ where
     #[options(short = "c", help = "path to configuration file")]
     pub config: Option<PathBuf>,
 
-    /// Obtain help about the current command
-    #[options(short = "h", help = "print help message")]
-    pub help: bool,
-
     /// Toggle JSON output mode one verbosity setting
     #[options(short = "j", help = "enable JSON output")]
     pub json: bool,
@@ -61,9 +57,18 @@ where
         "hermes"
     }
 
-    /// Description of this program
+    /// Description of this program.
+    /// Used whenever a command's usage is printed
+    /// (i.e., after the user invoked a command wrongly).
+    ///
+    /// # Note:
+    ///     Any new line or extra white spaces in the returned &str
+    ///     here will be trimmed (see [`Usage`]), so the returned
+    ///     &str should be a concise one-liner help message.
     fn description() -> &'static str {
-        Cmd::description()
+        r#"
+        For help, run `hermes [<FLAGS>] help <COMMAND>`, for example: `hermes help create client`
+        "#
     }
 
     /// Version of this program

--- a/relayer-cli/src/entry.rs
+++ b/relayer-cli/src/entry.rs
@@ -61,9 +61,9 @@ where
     /// Used whenever a command's usage is printed
     /// (i.e., after the user invoked a command wrongly).
     ///
-    /// # Note:
+    /// Note:
     ///     Any new line or extra white spaces in the returned &str
-    ///     here will be trimmed (see [`Usage`]), so the returned
+    ///     here will be trimmed (see `Usage`), so the returned
     ///     &str should be a concise one-liner help message.
     fn description() -> &'static str {
         r#"


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1003 

## Description

When a command is invoked incorrectly, Hermes prints an error diagnostic followed by a generic help message, [for example](https://github.com/informalsystems/ibc-rs/issues/1003#issuecomment-850181883):


```
$ hermes create client
error: missing required free argument               <<<<<<---- diagnostic

hermes 0.3.2
Informal Systems <hello@informal.systems>                 <<--- 
Hermes is an IBC Relayer written in Rust.                 <<---- generic help message
                                                          <<--- 
FLAGS:                                                    <<--- 
    -c, --config CONFIG       path to configuration file  <<--- 
    -h, --help                print help message          <<--- 
    -j, --json                enable JSON output          <<--- 

```

The problem is that the `-h` mentioned in the generic help message does not work (#134, #1003).

With this PR, the generic help message is changed. The `-h` flag was removed, and the message is as follows:

```
$ hermes create client
error: missing required free argument

hermes 0.3.2
Informal Systems <hello@informal.systems>
For help, run `hermes [<FLAGS>] help <COMMAND>`, for example: `hermes help create client`

FLAGS:
    -c, --config CONFIG       path to configuration file
    -j, --json                enable JSON output
```


This help message should only appear when the user invoked a command with the wrong parameters. The other commands (e.g., `hermes help`) will not contain this new message:

```
$ hermes help
   hermes 0.3.2
Informal Systems <hello@informal.systems>
Hermes is an IBC Relayer written in Rust.

USAGE:
    hermes <SUBCOMMAND>

SUBCOMMANDS:
    help       Get usage information
    keys       Manage keys in the relayer for each chain
    create     Create objects (client, co
...
```


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.