### PR TITLE
Restart the event monitor event loop to reinitialize the subscriptions `Stream` after a restart

### DIFF
--- a/relayer/src/event/monitor.rs
+++ b/relayer/src/event/monitor.rs
@@ -332,7 +332,10 @@ impl EventMonitor {
                     // and subscribe again to the queries.
                     self.restart();
 
-                    // Abort this event loop, and start a new one.
+                    // Abort this event loop, the `run` method will start a new one.
+                    // We can't just write `return self.run()` here because Rust
+                    // does not perform tail call optimization, and we would
+                    // thus potentially blow up the stack after many restarts.
                     return;
                 }
             }

--- a/relayer/src/event/monitor.rs
+++ b/relayer/src/event/monitor.rs
@@ -320,8 +320,16 @@ impl EventMonitor {
                 Err(e) => {
                     error!(chain.id = %self.chain_id, "failed to collect events: {}", e);
 
-                    // Restart the event monitor
+                    // Restart the event monitor, reconnect to the WebSocket endpoint,
+                    // and subscribe again to the queries.
                     self.restart();
+
+                    // Restart the event loop.
+                    self.run();
+
+                    // This will never be reached, but indicates that this event loop can
+                    // be considered to have stopped.
+                    return;
                 }
             }
         }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1026

## Description

Restart the event monitor event loop to reinitialize the subscriptions `Stream` after a restart.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.