### PR TITLE
Add `host` parameter to `telemetry` config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,7 @@ log_level = 'info'
 
 [telemetry]
 enabled = true
+host = '127.0.0.1'
 port = 3001
 
 [[chains]]

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -26,7 +26,8 @@ fn spawn_supervisor(config: Config) -> Supervisor {
     let state = ibc_telemetry::new_state();
 
     if config.telemetry.enabled {
-        ibc_telemetry::spawn(config.telemetry.port, state.clone());
+        let address = (config.telemetry.host.clone(), config.telemetry.port);
+        ibc_telemetry::spawn(address, state.clone());
     }
 
     Supervisor::spawn(config, state)

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use abscissa_core::{Command, Options, Runnable};
 
 use ibc_relayer::config::Config;
@@ -13,28 +15,39 @@ impl Runnable for StartCmd {
     fn run(&self) {
         let config = app_config();
 
-        let supervisor = spawn_supervisor(config.clone());
-        match supervisor.run() {
+        match spawn_supervisor(config.clone()).and_then(|s| s.run()) {
             Ok(()) => Output::success_msg("done").exit(),
-            Err(e) => Output::error(e).exit(),
+            Err(e) => Output::error(format!("Hermes failed to start, last error: {}", e)).exit(),
         }
     }
 }
 
 #[cfg(feature = "telemetry")]
-fn spawn_supervisor(config: Config) -> Supervisor {
+fn spawn_supervisor(config: Config) -> Result<Supervisor, Box<dyn Error + Send + Sync>> {
     let state = ibc_telemetry::new_state();
 
     if config.telemetry.enabled {
         let address = (config.telemetry.host.clone(), config.telemetry.port);
-        ibc_telemetry::spawn(address, state.clone());
+
+        match ibc_telemetry::spawn(address, state.clone()) {
+            Ok((addr, _)) => {
+                info!(
+                    "telemetry service running, exposing metrics at {}/metrics",
+                    addr
+                );
+            }
+            Err(e) => {
+                error!("telemetry service failed to start: {}", e);
+                return Err(e);
+            }
+        }
     }
 
-    Supervisor::spawn(config, state)
+    Ok(Supervisor::spawn(config, state))
 }
 
 #[cfg(not(feature = "telemetry"))]
-fn spawn_supervisor(config: Config) -> Supervisor {
+fn spawn_supervisor(config: Config) -> Result<Supervisor, Box<dyn Error + Send + Sync>> {
     if config.telemetry.enabled {
         warn!(
             "telemetry enabled in the config but Hermes was built without telemetry support, \
@@ -43,5 +56,5 @@ fn spawn_supervisor(config: Config) -> Supervisor {
     }
 
     let telemetry = ibc_relayer::telemetry::TelemetryDisabled;
-    Supervisor::spawn(config, telemetry)
+    Ok(Supervisor::spawn(config, telemetry))
 }

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -92,6 +92,7 @@ impl Default for GlobalConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TelemetryConfig {
     pub enabled: bool,
+    pub host: String,
     pub port: u16,
 }
 
@@ -99,6 +100,7 @@ impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            host: "127.0.0.1".to_string(),
             port: 3001,
         }
     }

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod server;
 pub mod state;
 
-use std::{sync::Arc, thread::JoinHandle};
+use std::{net::ToSocketAddrs, sync::Arc, thread::JoinHandle};
 
 pub use crate::state::TelemetryState;
 
@@ -9,6 +9,9 @@ pub fn new_state() -> Arc<TelemetryState> {
     Arc::new(TelemetryState::default())
 }
 
-pub fn spawn(port: u16, state: Arc<TelemetryState>) -> JoinHandle<()> {
-    std::thread::spawn(move || server::run(state, port))
+pub fn spawn<A>(address: A, state: Arc<TelemetryState>) -> JoinHandle<()>
+where
+    A: ToSocketAddrs + Send + 'static,
+{
+    std::thread::spawn(move || server::run(address, state))
 }

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -1,7 +1,12 @@
 pub mod server;
 pub mod state;
 
-use std::{net::ToSocketAddrs, sync::Arc, thread::JoinHandle};
+use std::{
+    error::Error,
+    net::{SocketAddr, ToSocketAddrs},
+    sync::Arc,
+    thread::JoinHandle,
+};
 
 pub use crate::state::TelemetryState;
 
@@ -9,9 +14,22 @@ pub fn new_state() -> Arc<TelemetryState> {
     Arc::new(TelemetryState::default())
 }
 
-pub fn spawn<A>(address: A, state: Arc<TelemetryState>) -> JoinHandle<()>
+pub fn spawn<A>(
+    address: A,
+    state: Arc<TelemetryState>,
+) -> Result<(SocketAddr, JoinHandle<()>), Box<dyn Error + Send + Sync>>
 where
     A: ToSocketAddrs + Send + 'static,
 {
-    std::thread::spawn(move || server::run(address, state))
+    let server = server::listen(address, state);
+
+    match server {
+        Ok(server) => {
+            let address = server.server_addr();
+            let handle = std::thread::spawn(move || server.run());
+
+            Ok((address, handle))
+        }
+        Err(e) => Err(e),
+    }
 }

--- a/telemetry/src/server.rs
+++ b/telemetry/src/server.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{net::ToSocketAddrs, sync::Arc};
 
 use prometheus::{Encoder, TextEncoder};
 use rouille::Request;
@@ -20,8 +20,8 @@ impl Route {
     }
 }
 
-pub fn run(telemetry_state: Arc<TelemetryState>, port: u16) {
-    rouille::start_server(("0.0.0.0", port), move |request| {
+pub fn run(address: impl ToSocketAddrs, telemetry_state: Arc<TelemetryState>) {
+    rouille::start_server(address, move |request| {
         match Route::from_request(request) {
             // The prometheus endpoint
             Route::Metrics => {

--- a/telemetry/src/server.rs
+++ b/telemetry/src/server.rs
@@ -21,7 +21,7 @@ impl Route {
 }
 
 pub fn run(telemetry_state: Arc<TelemetryState>, port: u16) {
-    rouille::start_server(("localhost", port), move |request| {
+    rouille::start_server(("0.0.0.0", port), move |request| {
         match Route::from_request(request) {
             // The prometheus endpoint
             Route::Metrics => {


### PR DESCRIPTION
Closes: #1032 

## Description

Add `host` parameter to `telemetry` config section, to allow access from a different machine in the network (eg. by using `0.0.0.0` as the host).

_____

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.