### PR TITLE
Refactor (PortId, ChannelId) to use PortChannelId

### DIFF
--- a/modules/src/application/ics20_fungible_token_transfer/relay_application_logic/send_transfer.rs
+++ b/modules/src/application/ics20_fungible_token_transfer/relay_application_logic/send_transfer.rs
@@ -16,11 +16,9 @@ where
 {
     let port_channel_id = PortChannelId::new(msg.source_port.clone(), msg.source_channel.clone());
 
-    let source_channel_end = ctx
-        .channel_end(&port_channel_id)
-        .ok_or_else(|| {
-            Kind::ChannelNotFound(msg.source_port.clone(), msg.source_channel.clone())
-        })?;
+    let source_channel_end = ctx.channel_end(&port_channel_id).ok_or_else(|| {
+        Kind::ChannelNotFound(msg.source_port.clone(), msg.source_channel.clone())
+    })?;
 
     let destination_port = source_channel_end.counterparty().port_id().clone();
     let destination_channel = source_channel_end
@@ -31,11 +29,9 @@ where
         })?;
 
     // get the next sequence
-    let sequence = ctx
-        .get_next_sequence_send(&port_channel_id)
-        .ok_or_else(|| {
-            Kind::SequenceSendNotFound(msg.source_port.clone(), msg.source_channel.clone())
-        })?;
+    let sequence = ctx.get_next_sequence_send(port_channel_id).ok_or_else(|| {
+        Kind::SequenceSendNotFound(msg.source_port.clone(), msg.source_channel.clone())
+    })?;
 
     //TODO: Application LOGIC.
 

--- a/modules/src/application/ics20_fungible_token_transfer/relay_application_logic/send_transfer.rs
+++ b/modules/src/application/ics20_fungible_token_transfer/relay_application_logic/send_transfer.rs
@@ -5,6 +5,7 @@ use crate::handler::HandlerOutput;
 use crate::ics04_channel::handler::send_packet::send_packet;
 use crate::ics04_channel::packet::Packet;
 use crate::ics04_channel::packet::PacketResult;
+use crate::ics24_host::identifier::PortChannelId;
 
 pub(crate) fn send_transfer<Ctx>(
     ctx: &Ctx,
@@ -13,8 +14,10 @@ pub(crate) fn send_transfer<Ctx>(
 where
     Ctx: Ics20Context,
 {
+    let port_channel_id = PortChannelId::new(msg.source_port.clone(), msg.source_channel.clone());
+
     let source_channel_end = ctx
-        .channel_end(&(msg.source_port.clone(), msg.source_channel.clone()))
+        .channel_end(&port_channel_id)
         .ok_or_else(|| {
             Kind::ChannelNotFound(msg.source_port.clone(), msg.source_channel.clone())
         })?;
@@ -29,7 +32,7 @@ where
 
     // get the next sequence
     let sequence = ctx
-        .get_next_sequence_send(&(msg.source_port.clone(), msg.source_channel.clone()))
+        .get_next_sequence_send(&port_channel_id)
         .ok_or_else(|| {
             Kind::SequenceSendNotFound(msg.source_port.clone(), msg.source_channel.clone())
         })?;

--- a/modules/src/ics04_channel/context.rs
+++ b/modules/src/ics04_channel/context.rs
@@ -37,17 +37,29 @@ pub trait ChannelReader {
 
     fn authenticated_capability(&self, port_id: &PortId) -> Result<Capability, Error>;
 
-    fn get_next_sequence_send(&self, port_channel_id: &PortChannelId) -> Option<Sequence>;
+    fn get_next_sequence_send(&self, port_channel_id: PortChannelId) -> Option<Sequence>;
 
-    fn get_next_sequence_recv(&self, port_channel_id: &PortChannelId) -> Option<Sequence>;
+    fn get_next_sequence_recv(&self, port_channel_id: PortChannelId) -> Option<Sequence>;
 
-    fn get_next_sequence_ack(&self, port_channel_id: &PortChannelId) -> Option<Sequence>;
+    fn get_next_sequence_ack(&self, port_channel_id: PortChannelId) -> Option<Sequence>;
 
-    fn get_packet_commitment(&self, key: &(PortChannelId, Sequence)) -> Option<String>;
+    fn get_packet_commitment(
+        &self,
+        port_channel_id: PortChannelId,
+        sequence: Sequence,
+    ) -> Option<String>;
 
-    fn get_packet_receipt(&self, key: &(PortChannelId, Sequence)) -> Option<Receipt>;
+    fn get_packet_receipt(
+        &self,
+        port_channel_id: PortChannelId,
+        sequence: Sequence,
+    ) -> Option<Receipt>;
 
-    fn get_packet_acknowledgement(&self, key: &(PortChannelId, Sequence)) -> Option<String>;
+    fn get_packet_acknowledgement(
+        &self,
+        port_channel_id: PortChannelId,
+        sequence: Sequence,
+    ) -> Option<String>;
 
     /// A hashing function for packet commitments
     fn hash(&self, value: String) -> String;

--- a/modules/src/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/ics04_channel/handler/acknowledgement.rs
@@ -68,10 +68,10 @@ pub fn process(
 
     // Verify packet commitment
     let packet_commitment = ctx
-        .get_packet_commitment(&(
+        .get_packet_commitment(
             PortChannelId::new(packet.source_port.clone(), packet.source_channel.clone()),
             packet.sequence,
-        ))
+        )
         .ok_or(Kind::PacketCommitmentNotFound(packet.sequence))?;
 
     let input = format!(
@@ -94,7 +94,7 @@ pub fn process(
 
     let result = if source_channel_end.order_matches(&Order::Ordered) {
         let next_seq_ack = ctx
-            .get_next_sequence_ack(&port_channel_id)
+            .get_next_sequence_ack(port_channel_id)
             .ok_or(Kind::MissingNextAckSeq)?;
 
         if packet.sequence != next_seq_ack {

--- a/modules/src/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/ics04_channel/handler/chan_close_confirm.rs
@@ -9,6 +9,7 @@ use crate::ics04_channel::events::Attributes;
 use crate::ics04_channel::handler::verify::verify_channel_proofs;
 use crate::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
+use crate::ics24_host::identifier::PortChannelId;
 
 pub(crate) fn process(
     ctx: &dyn ChannelReader,
@@ -18,7 +19,10 @@ pub(crate) fn process(
 
     // Retrieve the old channel end and validate it against the message.
     let mut channel_end = ctx
-        .channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))
+        .channel_end(&PortChannelId::new(
+            msg.port_id.clone(),
+            msg.channel_id.clone(),
+        ))
         .ok_or_else(|| Kind::ChannelNotFound(msg.port_id.clone(), msg.channel_id().clone()))?;
 
     // Validate that the channel end is in a state where it can be closed.

--- a/modules/src/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/ics04_channel/handler/chan_close_init.rs
@@ -8,6 +8,7 @@ use crate::ics04_channel::error::{Error, Kind};
 use crate::ics04_channel::events::Attributes;
 use crate::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
+use crate::ics24_host::identifier::PortChannelId;
 
 pub(crate) fn process(
     ctx: &dyn ChannelReader,
@@ -17,7 +18,10 @@ pub(crate) fn process(
 
     // Unwrap the old channel end and validate it against the message.
     let mut channel_end = ctx
-        .channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))
+        .channel_end(&PortChannelId::new(
+            msg.port_id().clone(),
+            msg.channel_id().clone(),
+        ))
         .ok_or_else(|| Kind::ChannelNotFound(msg.port_id.clone(), msg.channel_id().clone()))?;
 
     // Validate that the channel end is in a state where it can be closed.

--- a/modules/src/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/ics04_channel/handler/chan_open_ack.rs
@@ -9,6 +9,7 @@ use crate::ics04_channel::events::Attributes;
 use crate::ics04_channel::handler::verify::verify_channel_proofs;
 use crate::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::ics04_channel::msgs::chan_open_ack::MsgChannelOpenAck;
+use crate::ics24_host::identifier::PortChannelId;
 
 pub(crate) fn process(
     ctx: &dyn ChannelReader,
@@ -18,7 +19,10 @@ pub(crate) fn process(
 
     // Unwrap the old channel end and validate it against the message.
     let mut channel_end = ctx
-        .channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))
+        .channel_end(&PortChannelId::new(
+            msg.port_id().clone(),
+            msg.channel_id().clone(),
+        ))
         .ok_or_else(|| Kind::ChannelNotFound(msg.port_id.clone(), msg.channel_id().clone()))?;
 
     // Validate that the channel end is in a state where it can be ack.
@@ -121,7 +125,7 @@ mod tests {
     use crate::ics04_channel::msgs::chan_open_try::test_util::get_dummy_raw_msg_chan_open_try;
     use crate::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
     use crate::ics04_channel::msgs::ChannelMsg;
-    use crate::ics24_host::identifier::ConnectionId;
+    use crate::ics24_host::identifier::{ConnectionId, PortChannelId};
     use crate::mock::context::MockContext;
     use crate::Height;
 
@@ -222,8 +226,10 @@ mod tests {
                     )
                     .with_port_capability(msg_chan_ack.port_id().clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        PortChannelId::new(
+                            msg_chan_ack.port_id().clone(),
+                            msg_chan_ack.channel_id().clone(),
+                        ),
                         failed_chan_end,
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -240,8 +246,10 @@ mod tests {
                     )
                     .with_connection(cid.clone(), conn_end.clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        PortChannelId::new(
+                            msg_chan_ack.port_id().clone(),
+                            msg_chan_ack.channel_id().clone(),
+                        ),
                         chan_end.clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -257,8 +265,10 @@ mod tests {
                     )
                     .with_port_capability(msg_chan_ack.port_id().clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        PortChannelId::new(
+                            msg_chan_ack.port_id().clone(),
+                            msg_chan_ack.channel_id().clone(),
+                        ),
                         chan_end.clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -271,8 +281,10 @@ mod tests {
                     .with_connection(cid.clone(), conn_end.clone())
                     .with_port_capability(msg_chan_ack.port_id().clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        PortChannelId::new(
+                            msg_chan_ack.port_id().clone(),
+                            msg_chan_ack.channel_id().clone(),
+                        ),
                         chan_end.clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -288,8 +300,10 @@ mod tests {
                     .with_connection(cid, conn_end)
                     .with_port_capability(msg_chan_ack.port_id().clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        PortChannelId::new(
+                            msg_chan_ack.port_id().clone(),
+                            msg_chan_ack.channel_id().clone(),
+                        ),
                         chan_end,
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack),

--- a/modules/src/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/ics04_channel/handler/chan_open_confirm.rs
@@ -9,6 +9,7 @@ use crate::ics04_channel::events::Attributes;
 use crate::ics04_channel::handler::verify::verify_channel_proofs;
 use crate::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
+use crate::ics24_host::identifier::PortChannelId;
 
 pub(crate) fn process(
     ctx: &dyn ChannelReader,
@@ -18,7 +19,10 @@ pub(crate) fn process(
 
     // Unwrap the old channel end and validate it against the message.
     let mut channel_end = ctx
-        .channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))
+        .channel_end(&PortChannelId::new(
+            msg.port_id().clone(),
+            msg.channel_id().clone(),
+        ))
         .ok_or_else(|| Kind::ChannelNotFound(msg.port_id.clone(), msg.channel_id().clone()))?;
 
     // Validate that the channel end is in a state where it can be confirmed.
@@ -114,7 +118,7 @@ mod tests {
     use crate::ics04_channel::msgs::chan_open_confirm::test_util::get_dummy_raw_msg_chan_open_confirm;
     use crate::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
     use crate::ics04_channel::msgs::ChannelMsg;
-    use crate::ics24_host::identifier::{ClientId, ConnectionId};
+    use crate::ics24_host::identifier::{ClientId, ConnectionId, PortChannelId};
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
     use crate::Height;
@@ -165,8 +169,10 @@ mod tests {
                 .with_connection(conn_id, conn_end)
                 .with_port_capability(msg_chan_confirm.port_id().clone())
                 .with_channel(
-                    msg_chan_confirm.port_id().clone(),
-                    msg_chan_confirm.channel_id().clone(),
+                    PortChannelId::new(
+                        msg_chan_confirm.port_id().clone(),
+                        msg_chan_confirm.channel_id().clone(),
+                    ),
                     chan_end,
                 ),
             msg: ChannelMsg::ChannelOpenConfirm(msg_chan_confirm),

--- a/modules/src/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/ics04_channel/handler/recv_packet.rs
@@ -87,7 +87,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
 
     let result = if dest_channel_end.order_matches(&Order::Ordered) {
         let next_seq_recv = ctx
-            .get_next_sequence_recv(&PortChannelId::new(
+            .get_next_sequence_recv(PortChannelId::new(
                 packet.source_port.clone(),
                 packet.source_channel.clone(),
             ))
@@ -105,10 +105,10 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
             receipt: None,
         })
     } else {
-        let packet_rec = ctx.get_packet_receipt(&(
+        let packet_rec = ctx.get_packet_receipt(
             PortChannelId::new(packet.source_port.clone(), packet.source_channel.clone()),
             packet.sequence,
-        ));
+        );
 
         match packet_rec {
             Some(_receipt) => return Err(Kind::PacketAlreadyReceived(packet.sequence).into()),

--- a/modules/src/ics04_channel/handler/send_packet.rs
+++ b/modules/src/ics04_channel/handler/send_packet.rs
@@ -88,7 +88,7 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
 
     // check sequence number
     let next_seq_send = ctx
-        .get_next_sequence_send(&port_channel_id)
+        .get_next_sequence_send(port_channel_id)
         .ok_or(Kind::MissingNextSendSeq)?;
 
     if packet.sequence != next_seq_send {

--- a/modules/src/ics04_channel/handler/timeout.rs
+++ b/modules/src/ics04_channel/handler/timeout.rs
@@ -85,10 +85,10 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgTimeout) -> HandlerResult<Packet
 
     //verify packet commitment
     let packet_commitment = ctx
-        .get_packet_commitment(&(
+        .get_packet_commitment(
             PortChannelId::new(packet.source_port.clone(), packet.source_channel.clone()),
             packet.sequence,
-        ))
+        )
         .ok_or(Kind::PacketCommitmentNotFound(packet.sequence))?;
 
     let input = format!(

--- a/modules/src/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/ics04_channel/handler/timeout_on_close.rs
@@ -55,10 +55,10 @@ pub fn process(
 
     //verify the packet was sent, check the store
     let packet_commitment = ctx
-        .get_packet_commitment(&(
+        .get_packet_commitment(
             PortChannelId::new(packet.source_port.clone(), packet.source_channel.clone()),
             packet.sequence,
-        ))
+        )
         .ok_or(Kind::PacketCommitmentNotFound(packet.sequence))?;
 
     let input = format!(

--- a/modules/src/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/ics04_channel/handler/write_acknowledgement.rs
@@ -47,13 +47,13 @@ pub fn process(
     // the OnRecvPacket callback so we need to check if the acknowledgement is already
     // set on the store and return an error if so.
     if ctx
-        .get_packet_acknowledgement(&(
+        .get_packet_acknowledgement(
             PortChannelId::new(
                 packet.destination_port.clone(),
                 packet.destination_channel.clone(),
             ),
             packet.sequence,
-        ))
+        )
         .is_some()
     {
         return Err(Kind::AcknowledgementExists(packet.sequence).into());

--- a/modules/src/ics24_host/identifier.rs
+++ b/modules/src/ics24_host/identifier.rs
@@ -388,6 +388,21 @@ impl PartialEq<str> for ChannelId {
 /// A pair of [`PortId`] and [`ChannelId`] are used together for sending IBC packets.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PortChannelId {
-    pub channel_id: ChannelId,
     pub port_id: PortId,
+    pub channel_id: ChannelId,
+}
+
+impl PortChannelId {
+    pub fn new(port_id: PortId, channel_id: ChannelId) -> PortChannelId {
+        PortChannelId {
+            port_id,
+            channel_id,
+        }
+    }
+}
+
+impl Default for PortChannelId {
+    fn default() -> Self {
+        PortChannelId::new(PortId::default(), ChannelId::default())
+    }
 }

--- a/modules/src/mock/context.rs
+++ b/modules/src/mock/context.rs
@@ -464,28 +464,46 @@ impl ChannelReader for MockContext {
         }
     }
 
-    fn get_next_sequence_send(&self, port_channel_id: &PortChannelId) -> Option<Sequence> {
-        self.next_sequence_send.get(port_channel_id).cloned()
+    fn get_next_sequence_send(&self, port_channel_id: PortChannelId) -> Option<Sequence> {
+        self.next_sequence_send.get(&port_channel_id).cloned()
     }
 
-    fn get_next_sequence_recv(&self, port_channel_id: &PortChannelId) -> Option<Sequence> {
-        self.next_sequence_recv.get(port_channel_id).cloned()
+    fn get_next_sequence_recv(&self, port_channel_id: PortChannelId) -> Option<Sequence> {
+        self.next_sequence_recv.get(&port_channel_id).cloned()
     }
 
-    fn get_next_sequence_ack(&self, port_channel_id: &PortChannelId) -> Option<Sequence> {
-        self.next_sequence_ack.get(port_channel_id).cloned()
+    fn get_next_sequence_ack(&self, port_channel_id: PortChannelId) -> Option<Sequence> {
+        self.next_sequence_ack.get(&port_channel_id).cloned()
     }
 
-    fn get_packet_commitment(&self, key: &(PortChannelId, Sequence)) -> Option<String> {
-        self.packet_commitment.get(key).cloned()
+    fn get_packet_commitment(
+        &self,
+        port_channel_id: PortChannelId,
+        sequence: Sequence,
+    ) -> Option<String> {
+        self.packet_commitment
+            .get(&(port_channel_id, sequence))
+            .cloned()
     }
 
-    fn get_packet_receipt(&self, key: &(PortChannelId, Sequence)) -> Option<Receipt> {
-        self.packet_receipt.get(key).cloned()
+    fn get_packet_receipt(
+        &self,
+        port_channel_id: PortChannelId,
+        sequence: Sequence,
+    ) -> Option<Receipt> {
+        self.packet_receipt
+            .get(&(port_channel_id, sequence))
+            .cloned()
     }
 
-    fn get_packet_acknowledgement(&self, key: &(PortChannelId, Sequence)) -> Option<String> {
-        self.packet_acknowledgement.get(key).cloned()
+    fn get_packet_acknowledgement(
+        &self,
+        port_channel_id: PortChannelId,
+        sequence: Sequence,
+    ) -> Option<String> {
+        self.packet_acknowledgement
+            .get(&(port_channel_id, sequence))
+            .cloned()
     }
 
     fn hash(&self, input: String) -> String {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Partially Closes: #1001

## Description

This PR replaces the use of `(PortId, ChannelId)` to use the `PortChannelId` struct.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.