### PR TITLE
Fix mistake in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,6 @@ Docker images to Docker Hub.
 
 - [ibc-relayer]
   - Add support for multiple keys to the keyring ([#963])
-  - Add telemetry and Prometheus endpoint ([#868])
   
 - [release]
   - Released the official [Hermes image][hermes-docker] on Docker Hub ([#894])


### PR DESCRIPTION
Remove an item from v0.3.2 which was actually release in 0.4.0 (and is already included in the notes there)