### PR TITLE
Add `--hd-path` option to `keys restore` and `keys add` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## Unreleased
 
-> Nothing yet.
+### FEATURES
+
+- [ibc-relayer-cli]
+  - Add `--hd-path` option to `keys restore` and `keys add` commands to specify
+    derivation path when importing keys ([#1049])
+
+### BREAKING CHANGES
+
+- [ibc-relayer-cli]
+  - Removed `--coin-type` option from `keys restore` command. Use `--hd-path` instead. ([#1049])
+
+[#868]: https://github.com/informalsystems/ibc-rs/issues/1049
 
 ## v0.4.0
 *June 3rd, 2021*
@@ -93,7 +104,7 @@ Docker images to Docker Hub.
 
 - [ibc-relayer]
   - Add support for multiple keys to the keyring ([#963])
-  
+
 - [release]
   - Released the official [Hermes image][hermes-docker] on Docker Hub ([#894])
   - Automatically deploy Docker Hub image during release ([#967])

--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -80,7 +80,7 @@ pub fn add_key(config: &ChainConfig, key_name: &str, file: &Path) -> Result<KeyE
     let mut keyring = KeyRing::new(Store::Test, &config.account_prefix, &config.id)?;
 
     let key_contents = fs::read_to_string(file).map_err(|_| "error reading the key file")?;
-    let key = keyring.key_from_seed_file(&key_contents)?;
+    let key = keyring.key_from_seed_file(&key_contents, None)?;
 
     keyring.add_key(key_name, key.clone())?;
     Ok(key)

--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    str::FromStr,
 };
 
 use abscissa_core::{Command, Options, Runnable};
@@ -9,7 +10,7 @@ use anomaly::BoxError;
 use ibc::ics24_host::identifier::ChainId;
 use ibc_relayer::{
     config::{ChainConfig, Config},
-    keyring::{KeyEntry, KeyRing, Store},
+    keyring::{HDPath, KeyEntry, KeyRing, Store},
 };
 
 use crate::application::app_config;
@@ -28,6 +29,13 @@ pub struct KeysAddCmd {
         help = "name of the key (defaults to the `key_name` defined in the config)"
     )]
     name: Option<String>,
+
+    #[options(
+        short = "p",
+        help = "derivation path for this key",
+        default = "m/44'/118'/0'/0/0"
+    )]
+    hd_path: String,
 }
 
 impl KeysAddCmd {
@@ -36,13 +44,19 @@ impl KeysAddCmd {
             .find_chain(&self.chain_id)
             .ok_or_else(|| format!("chain '{}' not found in configuration file", self.chain_id))?;
 
+        let name = self
+            .name
+            .clone()
+            .unwrap_or_else(|| chain_config.key_name.clone());
+
+        let hd_path = HDPath::from_str(&self.hd_path)
+            .map_err(|_| format!("invalid derivation path: {}", self.hd_path))?;
+
         Ok(KeysAddOptions {
             config: chain_config.clone(),
             file: self.file.clone(),
-            name: self
-                .name
-                .clone()
-                .unwrap_or_else(|| chain_config.key_name.clone()),
+            name,
+            hd_path,
         })
     }
 }
@@ -52,6 +66,7 @@ pub struct KeysAddOptions {
     pub name: String,
     pub config: ChainConfig,
     pub file: PathBuf,
+    pub hd_path: HDPath,
 }
 
 impl Runnable for KeysAddCmd {
@@ -63,7 +78,7 @@ impl Runnable for KeysAddCmd {
             Ok(result) => result,
         };
 
-        let key = add_key(&opts.config, &opts.name, &opts.file);
+        let key = add_key(&opts.config, &opts.name, &opts.file, &opts.hd_path);
 
         match key {
             Ok(key) => Output::success_msg(format!(
@@ -76,11 +91,16 @@ impl Runnable for KeysAddCmd {
     }
 }
 
-pub fn add_key(config: &ChainConfig, key_name: &str, file: &Path) -> Result<KeyEntry, BoxError> {
+pub fn add_key(
+    config: &ChainConfig,
+    key_name: &str,
+    file: &Path,
+    hd_path: &HDPath,
+) -> Result<KeyEntry, BoxError> {
     let mut keyring = KeyRing::new(Store::Test, &config.account_prefix, &config.id)?;
 
     let key_contents = fs::read_to_string(file).map_err(|_| "error reading the key file")?;
-    let key = keyring.key_from_seed_file(&key_contents, None)?;
+    let key = keyring.key_from_seed_file(&key_contents, hd_path)?;
 
     keyring.add_key(key_name, key.clone())?;
     Ok(key)

--- a/relayer-cli/src/commands/keys/restore.rs
+++ b/relayer-cli/src/commands/keys/restore.rs
@@ -21,17 +21,17 @@ pub struct KeyRestoreCmd {
     mnemonic: String,
 
     #[options(
+        short = "n",
+        help = "name of the key (defaults to the `key_name` defined in the config)"
+    )]
+    name: Option<String>,
+
+    #[options(
         short = "p",
         help = "derivation path for this key",
         default = "m/44'/118'/0'/0/0"
     )]
     hd_path: String,
-
-    #[options(
-        short = "n",
-        help = "name of the key (defaults to the `key_name` defined in the config)"
-    )]
-    name: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/relayer-cli/src/commands/keys/restore.rs
+++ b/relayer-cli/src/commands/keys/restore.rs
@@ -1,10 +1,12 @@
+use std::str::FromStr;
+
 use abscissa_core::{Command, Options, Runnable};
 use anomaly::BoxError;
 
 use ibc::ics24_host::identifier::ChainId;
 use ibc_relayer::{
     config::{ChainConfig, Config},
-    keyring::{CoinType, KeyEntry, KeyRing, Store},
+    keyring::{HDPath, KeyEntry, KeyRing, Store},
 };
 
 use crate::application::app_config;
@@ -19,11 +21,11 @@ pub struct KeyRestoreCmd {
     mnemonic: String,
 
     #[options(
-        short = "t",
-        help = "coin type of the key to restore, default: 118 (Atom)",
-        default_expr = "CoinType::ATOM"
+        short = "p",
+        help = "derivation path for this key",
+        default = "m/44'/118'/0'/0/0"
     )]
-    coin_type: CoinType,
+    hd_path: String,
 
     #[options(
         short = "n",
@@ -36,7 +38,7 @@ pub struct KeyRestoreCmd {
 pub struct KeysRestoreOptions {
     pub mnemonic: String,
     pub config: ChainConfig,
-    pub coin_type: CoinType,
+    pub hd_path: HDPath,
     pub key_name: String,
 }
 
@@ -46,14 +48,19 @@ impl KeyRestoreCmd {
             .find_chain(&self.chain_id)
             .ok_or_else(|| format!("chain '{}' not found in configuration file", self.chain_id))?;
 
+        let hd_path = HDPath::from_str(&self.hd_path)
+            .map_err(|_| format!("invalid derivation path: {}", self.hd_path))?;
+
+        let key_name = self
+            .name
+            .clone()
+            .unwrap_or_else(|| chain_config.key_name.clone());
+
         Ok(KeysRestoreOptions {
             mnemonic: self.mnemonic.clone(),
             config: chain_config.clone(),
-            coin_type: self.coin_type,
-            key_name: self
-                .name
-                .clone()
-                .unwrap_or_else(|| chain_config.key_name.clone()),
+            hd_path,
+            key_name,
         })
     }
 }
@@ -67,13 +74,12 @@ impl Runnable for KeyRestoreCmd {
             Ok(result) => result,
         };
 
-        let chain_id = opts.config.id.clone();
-        let key = restore_key(&opts.mnemonic, &opts.key_name, opts.coin_type, opts.config);
+        let key = restore_key(&opts.mnemonic, &opts.key_name, &opts.hd_path, &opts.config);
 
         match key {
             Ok(key) => Output::success_msg(format!(
                 "Restored key '{}' ({}) on chain {}",
-                opts.key_name, key.account, chain_id
+                opts.key_name, key.account, opts.config.id
             ))
             .exit(),
             Err(e) => Output::error(format!("{}", e)).exit(),
@@ -84,11 +90,11 @@ impl Runnable for KeyRestoreCmd {
 pub fn restore_key(
     mnemonic: &str,
     key_name: &str,
-    coin_type: CoinType,
-    config: ChainConfig,
+    hdpath: &HDPath,
+    config: &ChainConfig,
 ) -> Result<KeyEntry, BoxError> {
     let mut keyring = KeyRing::new(Store::Test, &config.account_prefix, &config.id)?;
-    let key_entry = keyring.key_from_mnemonic(mnemonic, coin_type)?;
+    let key_entry = keyring.key_from_mnemonic(mnemonic, hdpath)?;
 
     keyring.add_key(&key_name, key_entry.clone())?;
     Ok(key_entry)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1049

## Description

- [x] Remove `--coin-type` option from `keys restore` command, use `--hd-path` command instead.
- [x] Add `--hd-path` option to `keys restore` command to specify derivation path.

```
USAGE:
    hermes keys restore <OPTIONS>

DESCRIPTION:
    restore a key to a configured chain using a mnemonic

POSITIONAL ARGUMENTS:
    chain_id                  identifier of the chain

FLAGS:
    -m, --mnemonic MNEMONIC   mnemonic to restore the key from
    -n, --name NAME           name of the key (defaults to the `key_name` defined in the config)
    -p, --hd-path HD-PATH     derivation path for this key (default: m/44'/118'/0'/0/0)
```

- [x] Add `--hd-path` option to `keys add` command to specify derivation path.

```
USAGE:
    hermes keys add <OPTIONS>

DESCRIPTION:
    Adds a key to a configured chain

POSITIONAL ARGUMENTS:
    chain_id                  identifier of the chain

FLAGS:
    -f, --file FILE           path to the key file
    -n, --name NAME           name of the key (defaults to the `key_name` defined in the config)
    -p, --hd-path HD-PATH     derivation path for this key (default: m/44'/118'/0'/0/0)
```

**Note:** This change is backward compatible with previously imported keys.

## Tested with

From the instructions at https://github.com/informalsystems/ibc-rs/issues/1049#issuecomment-855913656.

1. Generate a key with a non-default HD path using `gaiad`

```
$ gaiad keys add mycustomkey --hd-path "44'/394'/0'/0/1" --keyring-backend test

- name: mycustomkey
  type: local
  address: cosmos1fq3eqetyhvtmwu4m4e5d8u3x3l8e7ukg5jp2rx
  pubkey: cosmospub1addwnpepq0u7wkfpwyg93pfpsp7g8h2dg422d8qlv8vznelq9ly973ewnpgww6zqqcu
  mnemonic: ""
  threshold: 0
  pubkeys: []


**Important** write this mnemonic phrase in a safe place.
It is the only way to recover your account if you ever forget your password.

nasty parrot leisure firm spike butter doll artwork improve crowd effort rival fix just stairs best code lazy panel slide accident goose phone foot
```

2. Import the key into Hermes with `hermes keys restore`

```
$ hermes keys restore ibc-0 -n mycustomkey -p "m/44'/394'/0'/0/1" -m "nasty parrot leisure firm spike butter doll artwork improve crowd effort rival fix just stairs best code lazy panel slide accident goose phone foot"
Success: Restored key 'mycustomkey' (cosmos1fq3eqetyhvtmwu4m4e5d8u3x3l8e7ukg5jp2rx) on chain ibc-0
```

3. Note that both keys match (`cosmos1fq3eqetyhvtmwu4m4e5d8u3x3l8e7ukg5jp2rx`).

______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.