### PR TITLE
Propagate LightClient errors except IO as recoverable error all the way up to update client command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,6 +1464,7 @@ dependencies = [
  "once_cell",
  "prost",
  "prost-types",
+ "retry",
  "serde",
  "serde_derive",
  "serde_json",

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -46,6 +46,7 @@ crossbeam-channel = "0.5.1"
 subtle-encoding = "0.5"
 dirs-next = "2.0.0"
 itertools = "0.10.1"
+retry = { version = "1.2.1", default-features = false }
 
 [dependencies.tendermint-proto]
 version = "=0.19.0"

--- a/relayer-cli/src/cli_utils.rs
+++ b/relayer-cli/src/cli_utils.rs
@@ -39,15 +39,16 @@ pub fn spawn_chain_runtime(
     config: &Config,
     chain_id: &ChainId,
 ) -> Result<Box<dyn ChainHandle>, Error> {
-    let chain_config = config
-        .find_chain(chain_id)
-        .cloned()
-        .ok_or_else(|| format!("missing chain for id ({}) in configuration file", chain_id))
-        .map_err(|e| Kind::Config.context(e))?;
+    let chain_config = config.find_chain(chain_id).cloned().ok_or_else(|| {
+        Kind::Config.context(format!(
+            "missing chain for id ({}) in configuration file",
+            chain_id
+        ))
+    })?;
 
     let rt = Arc::new(TokioRuntime::new().unwrap());
     let chain_res = ChainRuntime::<CosmosSdkChain>::spawn(chain_config, rt)
-        .map_err(|e| Kind::Runtime.context(e));
+        .map_err(|e| Kind::Relayer(e.kind().clone()).context(e));
 
     let handle = chain_res.map(|(handle, _)| handle)?;
 

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -4,6 +4,7 @@ use ibc::events::IbcEvent;
 use ibc::ics02_client::client_state::ClientState;
 use ibc::ics24_host::identifier::{ChainId, ClientId};
 use ibc_relayer::foreign_client::ForeignClient;
+use ibc_relayer::util::retry::retry_recoverable_with_index;
 
 use crate::application::app_config;
 use crate::cli_utils::{spawn_chain_runtime, ChainHandlePair};
@@ -65,54 +66,79 @@ pub struct TxUpdateClientCmd {
 
     #[options(help = "the trusted height of the client update", short = "t")]
     trusted_height: Option<u64>,
+
+    #[options(
+        help = "retry the operation if fails with recoverable error",
+        short = "r"
+    )]
+    retry: bool,
 }
 
 impl Runnable for TxUpdateClientCmd {
     fn run(&self) {
-        let config = app_config();
+        mod retry_strategy {
+            use ibc_relayer::util::retry::clamp_total;
+            use retry::delay::Fibonacci;
+            use std::time::Duration;
 
-        let dst_chain = match spawn_chain_runtime(&config, &self.dst_chain_id) {
-            Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
-        };
+            // Default parameters for the retrying mechanism
+            const MAX_DELAY: Duration = Duration::from_secs(10); // 10 seconds
+            const MAX_TOTAL_DELAY: Duration = Duration::from_secs(60); // 1 minute
+            const INITIAL_DELAY: Duration = Duration::from_secs(1); // 1 second
 
-        let src_chain_id =
-            match dst_chain.query_client_state(&self.dst_client_id, ibc::Height::zero()) {
-                Ok(cs) => cs.chain_id(),
-                Err(e) => {
-                    return Output::error(format!(
-                        "Query of client '{}' on chain '{}' failed with error: {}",
-                        self.dst_client_id, self.dst_chain_id, e
-                    ))
-                    .exit()
-                }
+            pub fn default() -> impl Iterator<Item = Duration> {
+                clamp_total(Fibonacci::from(INITIAL_DELAY), MAX_DELAY, MAX_TOTAL_DELAY)
+            }
+        }
+
+        fn do_run(ctx: &TxUpdateClientCmd) -> Result<Vec<IbcEvent>, Error> {
+            let config = app_config();
+
+            let dst_chain = spawn_chain_runtime(&config, &ctx.dst_chain_id)?;
+
+            let src_chain_id = dst_chain
+                .query_client_state(&ctx.dst_client_id, ibc::Height::zero())
+                .map_err(|e| Kind::Relayer(e.kind().clone()).context(e))?
+                .chain_id();
+
+            let src_chain = spawn_chain_runtime(&config, &src_chain_id)?;
+
+            let height = match ctx.target_height {
+                Some(height) => ibc::Height::new(src_chain.id().version(), height),
+                None => ibc::Height::zero(),
             };
 
-        let src_chain = match spawn_chain_runtime(&config, &src_chain_id) {
-            Ok(handle) => handle,
-            Err(e) => return Output::error(format!("{}", e)).exit(),
-        };
+            let trusted_height = match ctx.trusted_height {
+                Some(height) => ibc::Height::new(src_chain.id().version(), height),
+                None => ibc::Height::zero(),
+            };
 
-        let height = match self.target_height {
-            Some(height) => ibc::Height::new(src_chain.id().version(), height),
-            None => ibc::Height::zero(),
-        };
+            let client = ForeignClient::find(src_chain, dst_chain, &ctx.dst_client_id)
+                .map_err(|e| Kind::ForeignClient(e.clone()).context(e))?;
 
-        let trusted_height = match self.trusted_height {
-            Some(height) => ibc::Height::new(src_chain.id().version(), height),
-            None => ibc::Height::zero(),
-        };
+            client
+                .build_update_client_and_send(height, trusted_height)
+                .map_err(|e| Kind::ForeignClient(e.clone()).context(e).into())
+        }
 
-        let client = ForeignClient::find(src_chain, dst_chain, &self.dst_client_id)
-            .unwrap_or_else(exit_with_unrecoverable_error);
+        if self.retry {
+            let res = retry_recoverable_with_index(
+                "run_update_client",
+                retry_strategy::default(),
+                |_| do_run(self),
+            );
 
-        let res = client
-            .build_update_client_and_send(height, trusted_height)
-            .map_err(|e| Kind::Tx.context(e));
+            match res {
+                Ok(events) => Output::success(events).exit(),
+                Err(e) => Output::error(format!("{}", e)).exit(),
+            }
+        } else {
+            let res = do_run(self);
 
-        match res {
-            Ok(events) => Output::success(events).exit(),
-            Err(e) => Output::error(format!("{}", e)).exit(),
+            match res {
+                Ok(events) => Output::success(events).exit(),
+                Err(e) => Output::error(format!("{}", e)).exit(),
+            }
         }
     }
 }

--- a/relayer-cli/src/error.rs
+++ b/relayer-cli/src/error.rs
@@ -1,13 +1,16 @@
 //! Error types
 
 use anomaly::{BoxError, Context};
+use ibc_relayer::error::Kind as RelayerError;
+use ibc_relayer::foreign_client::ForeignClientError;
+use ibc_relayer::util::retry::RetryableError;
 use thiserror::Error;
 
 /// An error raised within the relayer CLI
 pub type Error = anomaly::Error<Kind>;
 
 /// Kinds of errors
-#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[derive(Clone, Debug, Error)]
 pub enum Kind {
     /// Error in configuration file
     #[error("config error")]
@@ -32,6 +35,34 @@ pub enum Kind {
     /// Error during transaction submission
     #[error("keys error")]
     Keys,
+
+    /// Fatal error
+    #[error("fatal error")]
+    Fatal,
+
+    /// Error from relayer
+    #[error("relayer error")]
+    Relayer(RelayerError),
+
+    /// Error from foreign client
+    #[error("foreign client error")]
+    ForeignClient(ForeignClientError),
+}
+
+impl RetryableError for Kind {
+    #[allow(clippy::match_like_matches_macro)]
+    fn is_retryable(&self) -> bool {
+        match self {
+            Kind::Io => true,
+            Kind::Fatal => false,
+            Kind::Config => false,
+            Kind::Relayer(e) => e.is_retryable(),
+            Kind::ForeignClient(e) => e.is_retryable(),
+
+            // TODO: actually classify the remaining variants on whether they are retryable
+            _ => true,
+        }
+    }
 }
 
 impl Kind {

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -843,6 +843,7 @@ impl RelayPath {
                 self.dst_chain().id(),
                 dst_err_ev.unwrap()
             ),
+            None,
         )))
     }
 
@@ -884,6 +885,7 @@ impl RelayPath {
                 self.src_chain().id(),
                 src_err_ev.unwrap()
             ),
+            None,
         )))
     }
 

--- a/relayer/src/util/retry.rs
+++ b/relayer/src/util/retry.rs
@@ -39,13 +39,14 @@ where
             Err(e) => {
                 if e.is_retryable() {
                     warn!(
-                        "operation {} failed with recoverable error: {}. retrying at count {}",
+                        "operation {} failed with recoverable error: {}. retrying at count {}.",
                         name,
                         e,
                         i + 1
                     );
                     RetryResult::Retry(e)
                 } else {
+                    warn!("non-recoverable error happened: {}. skipping retry.", e);
                     RetryResult::Err(e)
                 }
             }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Partial fix for #712

## Description

This is another attempt to fix PR #712 with a much more narrowed focus. The goal is:

- To classify the a single class of error, `tendermint_light_client::errors::ErrorKind`.
  - The variant `ErrorKind::Io` is recoverable.
  - All other variants such as `ErrorKind::Store`, `ErrorKind::NoPrimary`, etc are non recoverable.
 
- The retry logic is implemented at the top level in one of the command line.
  - I have implemented the retry logic in the `update client` command, as I forgot if we agreed on another command.
  - The command line have a new `-r` flag to activate the retry logic

For the retry logic to propagate, I have to modify outer error types such as `relayer::error::Kind` and `foreign_client::ForeignClientError` so that they can return the appropriate boolean when queries whether the error is retryable.

While the retry logic is working, the naive implementation of the `is_retryable` method is unfortunately not robust, as all other errors are currently being classified as being retryable. For example, the `ics02_client::error::Kind::ClientNotFound` error is by default also retryable. So when `update client` is now called with invalid client ID, the command line just naively keep retrying:

```
$ ./target/debug/hermes update client ibc-0 07-tendermint-1
Jun 10 10:06:06.202  INFO ibc_relayer_cli::commands: using default configuration from '~/.hermes/config.toml'
Jun 10 10:06:06.215 DEBUG ibc_relayer::event::monitor: starting event monitor chain.id=ibc-0
Error: relayer error: Query error occurred (failed to query for client state): error converting message type into domain type: the client state was not found
ubuntu@development:~/informal/ibc-rs$ ./target/debug/hermes update client ibc-0 07-tendermint-1 -r
Jun 10 10:06:15.709  INFO ibc_relayer_cli::commands: using default configuration from '~/.hermes/config.toml'
Jun 10 10:06:15.720 DEBUG ibc_relayer::event::monitor: starting event monitor chain.id=ibc-0
Jun 10 10:06:18.021 ERROR ibc_relayer_cli::commands::tx::client: Encounter recoverable error: relayer error: Query error occurred (failed to query for client state): error converting message type into domain type: the client state was not found. retrying update
Jun 10 10:06:19.035 DEBUG ibc_relayer::event::monitor: starting event monitor chain.id=ibc-0
Jun 10 10:06:19.042 ERROR ibc_relayer_cli::commands::tx::client: Encounter recoverable error: relayer error: Query error occurred (failed to query for client state): error converting message type into domain type: the client state was not found. retrying update
Jun 10 10:06:20.052 DEBUG ibc_relayer::event::monitor: starting event monitor chain.id=ibc-0
Jun 10 10:06:20.057 ERROR ibc_relayer_cli::commands::tx::client: Encounter recoverable error: relayer error: Query error occurred (failed to query for client state): error converting message type into domain type: the client state was not found. retrying update
...
``` 

The purpose of this PR is to demonstrate the issue of naively classifying only some errors as being retryable. As we can see in the code changes, even a limited error propagation like this is pretty non-trivial. It will also take significant effort to propagate other errors like `ics02_client::error::Kind` upward. And if we continue down the rabbit hole, we will end up with the same situation as in #950.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.