### PR TITLE
Disable dependabot for proto-compiler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,11 @@ updates:
     schedule:
       interval: "weekly"
 
-## Disable dependabot for `proto-compiler`
-## Reason: we'll maintain the dependencies for proto-compiler
-##    manually, so that we update the binary only when we also
-##    regenerate Rust types from the .proto files.
+## Disable dependabot for `proto-compiler`.
+## Rationale: we maintain the dependencies for proto-compiler
+##    manually, so that we update the proto-compiler binary
+##    (and the Cargo.lock file) only when we regenerate
+##    Rust types from the .proto files.
 #  - package-ecosystem: "cargo"
 #    directory: "proto-compiler"
 #    schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,10 +21,14 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "cargo"
-    directory: "proto-compiler"
-    schedule:
-      interval: "weekly"
+## Disable dependabot for `proto-compiler`
+## Reason: we'll maintain the dependencies for proto-compiler
+##    manually, so that we update the binary only when we also
+##    regenerate Rust types from the .proto files.
+#  - package-ecosystem: "cargo"
+#    directory: "proto-compiler"
+#    schedule:
+#      interval: "weekly"
 
   - package-ecosystem: "cargo"
     directory: "relayer"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description

Disables the dependabot for proto-compiler.

As detailed in the PR, we'll try to maintain `proto-compiler/Cargo.lock` file manually. We'll update this file when we actually use the proto-compiler binary.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.