### PR TITLE
Disable target in tracing output and enable colored output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### IMPROVEMENTS
 
+- [ibc-relayer-cli]
+  - Minor log output improvements: color enabled, reduced redundant information ([#1100])
+
 - [ibc-relayer]
   - Update the on-chain IBC client with supporting headers when light client verification
     does bisection when verifying a header for a client update or a misbehaviour detection ([#673])
@@ -38,6 +41,7 @@
 [#1049]: https://github.com/informalsystems/ibc-rs/issues/1049
 [#1050]: https://github.com/informalsystems/ibc-rs/issues/1050
 [#1064]: https://github.com/informalsystems/ibc-rs/issues/1064
+[#1100]: https://github.com/informalsystems/ibc-rs/issues/1100
 
 ## v0.4.0
 *June 3rd, 2021*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ version = "0.4.0"
 dependencies = [
  "abscissa_core",
  "anomaly",
+ "atty",
  "crossbeam-channel 0.5.1",
  "dirs-next",
  "futures",

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -46,6 +46,7 @@ crossbeam-channel = "0.5.1"
 subtle-encoding = "0.5"
 dirs-next = "2.0.0"
 itertools = "0.10.1"
+atty = "0.2.14"
 
 [dependencies.tendermint-proto]
 version = "=0.19.0"

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -44,6 +44,7 @@ impl JsonTracing {
             .with_target(false)
             .with_env_filter(filter)
             .with_writer(std::io::stderr as StdWriter)
+            // Note: JSON output is currently un-affected by ANSI 'color' option.
             .with_ansi(COLORED_OUTPUT)
             .json()
             .with_filter_reloading();

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -19,8 +19,6 @@ type JsonFormatter = TracingFormatter<JsonFields, Format<Json, SystemTime>, StdW
 type PrettyFormatter = TracingFormatter<DefaultFields, Format<Full, SystemTime>, StdWriter>;
 type StdWriter = fn() -> io::Stderr;
 
-pub const COLORED_OUTPUT: bool = true;
-
 /// A custom component for parametrizing `tracing` in the relayer.
 /// Primarily used for:
 ///
@@ -37,14 +35,15 @@ impl JsonTracing {
     #[allow(trivial_casts)]
     pub fn new(cfg: GlobalConfig) -> Result<Self, FrameworkError> {
         let filter = build_tracing_filter(cfg.log_level);
+        // Note: JSON formatter is un-affected by ANSI 'color' option. Set to 'false'.
+        let use_color = false;
 
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
             .with_target(false)
             .with_env_filter(filter)
             .with_writer(std::io::stderr as StdWriter)
-            // Note: JSON output is currently un-affected by ANSI 'color' option.
-            .with_ansi(COLORED_OUTPUT)
+            .with_ansi(use_color)
             .json()
             .with_filter_reloading();
 
@@ -67,13 +66,14 @@ impl PrettyTracing {
     #[allow(trivial_casts)]
     pub fn new(cfg: GlobalConfig) -> Result<Self, FrameworkError> {
         let filter = build_tracing_filter(cfg.log_level);
+        let use_color = true;
 
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
             .with_target(false)
             .with_env_filter(filter)
             .with_writer(std::io::stderr as StdWriter)
-            .with_ansi(COLORED_OUTPUT)
+            .with_ansi(use_color)
             .with_filter_reloading();
 
         let filter_handle = builder.reload_handle();

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -3,7 +3,7 @@ use std::io;
 use abscissa_core::{Component, FrameworkError};
 use tracing_subscriber::{
     fmt::{
-        format::{Format, Json, JsonFields},
+        format::{Format, Json, JsonFields, DefaultFields, Full},
         time::SystemTime,
         Formatter as TracingFormatter,
     },
@@ -13,12 +13,14 @@ use tracing_subscriber::{
 };
 
 use ibc_relayer::config::GlobalConfig;
-use tracing_subscriber::fmt::format::{DefaultFields, Full};
 
 /// Custom types to simplify the `Tracing` definition below
 type JsonFormatter = TracingFormatter<JsonFields, Format<Json, SystemTime>, StdWriter>;
 type PrettyFormatter = TracingFormatter<DefaultFields, Format<Full, SystemTime>, StdWriter>;
 type StdWriter = fn() -> io::Stderr;
+
+pub const COLORED_OUTPUT: bool = true;
+
 
 /// A custom component for parametrizing `tracing` in the relayer.
 /// Primarily used for:
@@ -36,13 +38,13 @@ impl JsonTracing {
     #[allow(trivial_casts)]
     pub fn new(cfg: GlobalConfig) -> Result<Self, FrameworkError> {
         let filter = build_tracing_filter(cfg.log_level);
-        let use_color = false;
 
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
+            .with_target(false)
             .with_env_filter(filter)
             .with_writer(std::io::stderr as StdWriter)
-            .with_ansi(use_color)
+            .with_ansi(COLORED_OUTPUT)
             .json()
             .with_filter_reloading();
 
@@ -65,13 +67,13 @@ impl PrettyTracing {
     #[allow(trivial_casts)]
     pub fn new(cfg: GlobalConfig) -> Result<Self, FrameworkError> {
         let filter = build_tracing_filter(cfg.log_level);
-        let use_color = false;
 
         // Construct a tracing subscriber with the supplied filter and enable reloading.
         let builder = FmtSubscriber::builder()
+            .with_target(false)
             .with_env_filter(filter)
             .with_writer(std::io::stderr as StdWriter)
-            .with_ansi(use_color)
+            .with_ansi(COLORED_OUTPUT)
             .with_filter_reloading();
 
         let filter_handle = builder.reload_handle();

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -3,7 +3,7 @@ use std::io;
 use abscissa_core::{Component, FrameworkError};
 use tracing_subscriber::{
     fmt::{
-        format::{Format, Json, JsonFields, DefaultFields, Full},
+        format::{DefaultFields, Format, Full, Json, JsonFields},
         time::SystemTime,
         Formatter as TracingFormatter,
     },
@@ -20,7 +20,6 @@ type PrettyFormatter = TracingFormatter<DefaultFields, Format<Full, SystemTime>,
 type StdWriter = fn() -> io::Stderr;
 
 pub const COLORED_OUTPUT: bool = true;
-
 
 /// A custom component for parametrizing `tracing` in the relayer.
 /// Primarily used for:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1100

## Description


Two slight improvements to reading the Hermes log:

1. Disabled the 'target' field.
    - the target was usually a string such as `ibc_relayer::event::monitor:` or `ibc_relayer::link:`
    - the `ibc_relayer` part was superflous (everything was either `ibc_relayer` or `ibc_relayer_cli`)
    - the rest of the target, e.g., `event::monitor:` or `link` is usually obvious from the rest of the output

### Log lines before:

- pretty:
```
Jun 17 10:39:24.126 TRACE ibc_relayer::event::monitor: subscribing to query: tm.event = 'NewBlock' chain.id=cosmoshub-4
Jun 17 10:39:24.142 TRACE ibc_relayer::event::monitor: subscribed to all queries chain.id=cosmoshub-4
Jun 17 10:39:24.142 DEBUG ibc_relayer::event::monitor: starting event monitor chain.id=cosmoshub-4
Jun 17 10:39:24.770 DEBUG ibc_relayer::link: [informal-testnet-1:transfer/channel-2 -> cosmoshub-4] packets that still have commitments on informal-testnet-1: [18, 19, 20, 21, 22, 23, 24]
```
- json:

```
{"timestamp":"Jun 17 10:39:35.224","level":"TRACE","fields":{"message":"subscribed to all queries","chain.id":"informal-testnet-1"},"target":"ibc_relayer::event::monitor"}
```

### Log lines after this PR:

- pretty: 
```
Jun 17 10:44:46.285 TRACE subscribing to query: tm.event = 'NewBlock' chain.id=cosmoshub-4
Jun 17 10:44:46.299 TRACE subscribed to all queries chain.id=cosmoshub-4
Jun 17 10:44:46.299 DEBUG starting event monitor chain.id=cosmoshub-4
Jun 17 10:44:46.905 DEBUG [informal-testnet-1:transfer/channel-2 -> cosmoshub-4] packets that still have commitments on informal-testnet-1: [18, 19, 20, 21, 22, 23, 24]
```

- json:

```json
{"timestamp":"Jun 17 10:45:24.265","level":"DEBUG","fields":{"message":"starting event monitor","chain.id":"cosmoshub-4"}}
{"timestamp":"Jun 17 10:45:24.875","level":"DEBUG","fields":{"message":"[informal-testnet-1:transfer/channel-2 -> cosmoshub-4] packets that still have commitments on informal-testnet-1: [18, 19, 20, 21, 22, 23, 24]"}}
{"timestamp":"Jun 17 10:45:24.903","level":"DEBUG","fields":{"message":"[informal-testnet-1:transfer/channel-2 -> cosmoshub-4] recv packets to send out to cosmoshub-4 of the ones with commitments on source informal-testnet-1: [Sequence(21), Sequence(22), Sequence(23), Sequence(24)]"}}
```

2. Enabled colored output. 
    - Only the level (TRACE/INFO/ERROR etc.) is colored.
    - This does not affect Hermes when invoked with the `--json` formatter


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.