### PR TITLE
Implement query channel ends command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [ibc-relayer-cli]
   - Added `config validate` CLI to Hermes ([#600])
   - Added basic channel filter ([#1140])
+  - Added `query channel ends` CLI command ([#1062])
 
 ### IMPROVEMENTS
 
@@ -14,6 +15,7 @@
 - Add inline documentation to config.toml ([#1127])
 
 [#600]: https://github.com/informalsystems/ibc-rs/issues/600
+[#1062]: https://github.com/informalsystems/ibc-rs/issues/1062
 [#1125]: https://github.com/informalsystems/ibc-rs/issues/1125
 [#1127]: https://github.com/informalsystems/ibc-rs/issues/1127
 [#1140]: https://github.com/informalsystems/ibc-rs/issues/1140

--- a/e2e/e2e/channel.py
+++ b/e2e/e2e/channel.py
@@ -272,7 +272,7 @@ class QueryChannelEnd(Cmd[ChannelEnd]):
     def process(self, result: Any) -> ChannelEnd:
         return from_dict(ChannelEnd, result)
 
-@ cmd("query channel ends -s")
+@ cmd("query channel ends")
 @ dataclass
 class QueryChannelEnds(Cmd[ChannelEnds]):
     chain_id: ChainId

--- a/e2e/e2e/channel.py
+++ b/e2e/e2e/channel.py
@@ -244,6 +244,20 @@ class ChannelEnd:
     state: str
     version: str
 
+@ dataclass
+class ChannelEnds:
+    chain_id: str
+    client_id: str
+    connection_id: str
+    channel_id: str
+    port_id: str
+
+    counterparty_chain_id: str
+    counterparty_client_id: str
+    counterparty_connection_id: str
+    counterparty_channel_id: str
+    counterparty_port_id: str
+
 
 @ cmd("query channel end")
 @ dataclass
@@ -258,6 +272,18 @@ class QueryChannelEnd(Cmd[ChannelEnd]):
     def process(self, result: Any) -> ChannelEnd:
         return from_dict(ChannelEnd, result)
 
+@ cmd("query channel ends -s")
+@ dataclass
+class QueryChannelEnds(Cmd[ChannelEnds]):
+    chain_id: ChainId
+    port_id: PortId
+    channel_id: ChannelId
+
+    def args(self) -> List[str]:
+        return [self.chain_id, self.port_id, self.channel_id]
+
+    def process(self, result: Any) -> ChannelEnds:
+        return from_dict(ChannelEnds, result)
 
 # =============================================================================
 # CHANNEL handshake
@@ -463,6 +489,9 @@ def handshake(
             f'Channel end with id {b_chan_id} on chain {side_b} is not in Open state, got: {b_chan_end.state}')
         exit(1)
 
+    a_chan_ends = query_channel_ends(c, side_a, port_id, a_chan_id)
+    l.debug(f'query channel ends result: {a_chan_ends}')
+
     return a_chan_id, b_chan_id
 
 
@@ -476,6 +505,19 @@ def query_channel_end(c: Config, chain_id: ChainId, port: PortId, chan_id: Chann
     res = cmd.run(c).success()
 
     l.debug(f'Status of channel end {chan_id}: {res}')
+
+    return res
+
+
+# =============================================================================
+# CHANNEL ENDS query
+# =============================================================================
+
+def query_channel_ends(c: Config, chain_id: ChainId, port: PortId, chan_id: ChannelId) -> ChannelEnd:
+    cmd = QueryChannelEnds(chain_id, port, chan_id)
+    res = cmd.run(c).success()
+
+    l.debug(f'Status of channel ends {chan_id}: {res}')
 
     return res
 

--- a/e2e/e2e/channel.py
+++ b/e2e/e2e/channel.py
@@ -492,6 +492,29 @@ def handshake(
     a_chan_ends = query_channel_ends(c, side_a, port_id, a_chan_id)
     l.debug(f'query channel ends result: {a_chan_ends}')
 
+    assert a_chan_ends.chain_id == side_a
+    assert a_chan_ends.connection_id == conn_a
+    assert a_chan_ends.port_id == port_id
+    assert a_chan_ends.channel_id == a_chan_id
+
+    assert a_chan_ends.counterparty_chain_id == side_b
+    assert a_chan_ends.counterparty_connection_id == conn_b
+    assert a_chan_ends.counterparty_port_id == port_id
+    assert a_chan_ends.counterparty_channel_id == b_chan_id
+
+    b_chan_ends = query_channel_ends(c, side_b, port_id, b_chan_id)
+    l.debug(f'query channel ends result: {a_chan_ends}')
+
+    assert b_chan_ends.chain_id == side_b
+    assert b_chan_ends.connection_id == conn_b
+    assert b_chan_ends.port_id == port_id
+    assert b_chan_ends.channel_id == b_chan_id
+
+    assert b_chan_ends.counterparty_chain_id == side_a
+    assert b_chan_ends.counterparty_connection_id == conn_a
+    assert b_chan_ends.counterparty_port_id == port_id
+    assert b_chan_ends.counterparty_channel_id == a_chan_id
+
     return a_chan_id, b_chan_id
 
 

--- a/e2e/e2e/channel.py
+++ b/e2e/e2e/channel.py
@@ -503,7 +503,7 @@ def handshake(
     assert a_chan_ends.counterparty_channel_id == b_chan_id
 
     b_chan_ends = query_channel_ends(c, side_b, port_id, b_chan_id)
-    l.debug(f'query channel ends result: {a_chan_ends}')
+    l.debug(f'query channel ends result: {b_chan_ends}')
 
     assert b_chan_ends.chain_id == side_b
     assert b_chan_ends.connection_id == conn_b

--- a/e2e/run.py
+++ b/e2e/run.py
@@ -224,7 +224,7 @@ def main():
     sleep(2.0)
 
     connection.passive_connection_try_then_start(config, ibc1, ibc0, ibc1_client_id, ibc0_client_id)
-    sleep(2.0) 
+    sleep(2.0)
 
     channel.passive_channel_start_then_init(config, ibc1, ibc0, ibc1_conn_id, port_id)
     sleep(2.0)

--- a/relayer-cli/src/commands/query.rs
+++ b/relayer-cli/src/commands/query.rs
@@ -87,7 +87,7 @@ pub enum QueryChannelCmds {
     End(channel::QueryChannelEndCmd),
 
     /// The `query channel ends` subcommand
-    #[options(help = "Query the channel ends and associated IDs on a given chain")]
+    #[options(help = "Query channel ends and underlying connection and client objects")]
     Ends(QueryChannelEndsCmd),
 }
 

--- a/relayer-cli/src/commands/query.rs
+++ b/relayer-cli/src/commands/query.rs
@@ -3,6 +3,7 @@
 use abscissa_core::{Command, Options, Runnable};
 
 use crate::commands::query::channels::QueryChannelsCmd;
+use crate::commands::query::trace::QueryTraceCmd;
 
 mod channel;
 mod channels;
@@ -11,6 +12,7 @@ mod clients;
 mod connection;
 mod connections;
 mod packet;
+mod trace;
 mod tx;
 
 /// `query` subcommand
@@ -38,6 +40,10 @@ pub enum QueryCmd {
     /// The `query channels` subcommand
     #[options(help = "Query the identifiers of all channels on a given chain")]
     Channels(QueryChannelsCmd),
+
+    /// The `query trace` subcommand
+    #[options(help = "Query the trace of channels on a given chain")]
+    Trace(QueryTraceCmd),
 
     /// The `query packet` subcommand
     #[options(help = "Query information about packets")]

--- a/relayer-cli/src/commands/query.rs
+++ b/relayer-cli/src/commands/query.rs
@@ -42,7 +42,9 @@ pub enum QueryCmd {
     Channels(QueryChannelsCmd),
 
     /// The `query trace` subcommand
-    #[options(help = "Query the trace of channels on a given chain")]
+    #[options(
+        help = "Query the trace of clients, channels, connections associated with a given port channel on a given chain"
+    )]
     Trace(QueryTraceCmd),
 
     /// The `query packet` subcommand

--- a/relayer-cli/src/commands/query.rs
+++ b/relayer-cli/src/commands/query.rs
@@ -2,17 +2,17 @@
 
 use abscissa_core::{Command, Options, Runnable};
 
+use crate::commands::query::channel_ends::QueryChannelEndsCmd;
 use crate::commands::query::channels::QueryChannelsCmd;
-use crate::commands::query::trace::QueryTraceCmd;
 
 mod channel;
+mod channel_ends;
 mod channels;
 mod client;
 mod clients;
 mod connection;
 mod connections;
 mod packet;
-mod trace;
 mod tx;
 
 /// `query` subcommand
@@ -40,12 +40,6 @@ pub enum QueryCmd {
     /// The `query channels` subcommand
     #[options(help = "Query the identifiers of all channels on a given chain")]
     Channels(QueryChannelsCmd),
-
-    /// The `query trace` subcommand
-    #[options(
-        help = "Query the trace of clients, channels, connections associated with a given port channel on a given chain"
-    )]
-    Trace(QueryTraceCmd),
 
     /// The `query packet` subcommand
     #[options(help = "Query information about packets")]
@@ -91,6 +85,10 @@ pub enum QueryChannelCmds {
     /// The `query channel end` subcommand
     #[options(help = "Query channel end")]
     End(channel::QueryChannelEndCmd),
+
+    /// The `query channel ends` subcommand
+    #[options(help = "Query the channel ends and associated IDs on a given chain")]
+    Ends(QueryChannelEndsCmd),
 }
 
 #[derive(Command, Debug, Options, Runnable)]

--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -71,8 +71,10 @@ fn do_run(cmd: &QueryChannelEndsCmd) -> Result<(), Box<dyn std::error::Error>> {
         .find_chain(&chain_id)
         .ok_or_else(|| format!("chain '{}' not found in configuration file", chain_id))?;
 
-    let rt = Arc::new(TokioRuntime::new().unwrap());
+    let rt = Arc::new(TokioRuntime::new()?);
     let chain = CosmosSdkChain::bootstrap(chain_config.clone(), rt.clone())?;
+
+    // let chain = spawn_chain_runtime(&config, &chain_id)?;
 
     let chain_height = match cmd.height {
         Some(height) => Height::new(chain.id().version(), height),
@@ -84,7 +86,7 @@ fn do_run(cmd: &QueryChannelEndsCmd) -> Result<(), Box<dyn std::error::Error>> {
     let connection_id = channel_end
         .connection_hops
         .first()
-        .ok_or_else(|| format!("missing connection_hops"))?
+        .ok_or_else(|| format!("missing connection_hops for channel {}", channel_id))?
         .clone();
 
     let connection_end = chain.query_connection(&connection_id, chain_height)?;
@@ -123,7 +125,7 @@ fn do_run(cmd: &QueryChannelEndsCmd) -> Result<(), Box<dyn std::error::Error>> {
         )
     })?;
 
-    let counterparty_chain = CosmosSdkChain::bootstrap(chain_config_b.clone(), rt).unwrap();
+    let counterparty_chain = CosmosSdkChain::bootstrap(chain_config_b.clone(), rt)?;
 
     let counterparty_chain_height = counterparty_chain.query_latest_height()?;
 

--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -16,7 +16,7 @@ use crate::conclude::Output;
 use crate::prelude::*;
 
 #[derive(Clone, Command, Debug, Options)]
-pub struct QueryTraceCmd {
+pub struct QueryChannelEndsCmd {
     #[options(free, required, help = "identifier of the chain to query")]
     chain_id: ChainId,
 
@@ -58,7 +58,7 @@ pub struct TraceSummary {
     counterparty_port_id: PortId,
 }
 
-fn do_run(cmd: &QueryTraceCmd) -> Result<(), Box<dyn std::error::Error>> {
+fn do_run(cmd: &QueryChannelEndsCmd) -> Result<(), Box<dyn std::error::Error>> {
     debug!("Options: {:?}", cmd);
 
     let config = app_config();
@@ -172,7 +172,7 @@ fn do_run(cmd: &QueryTraceCmd) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-impl Runnable for QueryTraceCmd {
+impl Runnable for QueryChannelEndsCmd {
     fn run(&self) {
         match do_run(self) {
             Ok(()) => {}

--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -130,10 +130,10 @@ fn do_run(cmd: &QueryChannelEndsCmd) -> Result<(), Box<dyn std::error::Error>> {
     let counterparty_connection_end = counterparty_chain
         .query_connection(&counterparty_connection_id, counterparty_chain_height)?;
 
-    let counterparty_client_state =
-        chain.query_client_state(&counterparty_client_id, counterparty_chain_height)?;
+    let counterparty_client_state = counterparty_chain
+        .query_client_state(&counterparty_client_id, counterparty_chain_height)?;
 
-    let counterparty_channel_end = chain.query_channel(
+    let counterparty_channel_end = counterparty_chain.query_channel(
         &counterparty_port_id,
         &counterparty_channel_id,
         counterparty_chain_height,

--- a/relayer-cli/src/commands/query/trace.rs
+++ b/relayer-cli/src/commands/query/trace.rs
@@ -8,7 +8,7 @@ use ibc::ics03_connection::connection::ConnectionEnd;
 use ibc::ics04_channel::channel::ChannelEnd;
 use ibc::ics07_tendermint::client_state::ClientState;
 use ibc::ics24_host::identifier::ChainId;
-use ibc::ics24_host::identifier::{ChannelId, PortId};
+use ibc::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
 use ibc::Height;
 use ibc_relayer::chain::{Chain, CosmosSdkChain};
 
@@ -28,98 +28,154 @@ pub struct QueryTraceCmd {
 
     #[options(help = "height of the state to query", short = "h")]
     height: Option<u64>,
+
+    #[options(help = "display result in summary form", short = "s")]
+    summary: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CmdResult {
-    pub channel_end_a: ChannelEnd,
-    pub connection_end_a: ConnectionEnd,
-    pub client_state_a: ClientState,
-
-    pub channel_end_b: ChannelEnd,
-    pub connection_end_b: ConnectionEnd,
-    pub client_state_b: ClientState,
+pub struct TraceResult {
+    channel_end: ChannelEnd,
+    connection_end: ConnectionEnd,
+    client_state: ClientState,
+    counterparty_channel_end: ChannelEnd,
+    counterparty_connection_end: ConnectionEnd,
+    counterparty_client_state: ClientState,
 }
 
-fn do_run(cmd: &QueryTraceCmd) -> Result<CmdResult, Box<dyn std::error::Error>> {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TraceSummary {
+    chain_id: ChainId,
+    client_id: ClientId,
+    connection_id: ConnectionId,
+    channel_id: ChannelId,
+    port_id: PortId,
+
+    counterparty_chain_id: ChainId,
+    counterparty_client_id: ClientId,
+    counterparty_connection_id: ConnectionId,
+    counterparty_channel_id: ChannelId,
+    counterparty_port_id: PortId,
+}
+
+fn do_run(cmd: &QueryTraceCmd) -> Result<(), Box<dyn std::error::Error>> {
     debug!("Options: {:?}", cmd);
 
     let config = app_config();
 
-    let chain_id_a = cmd.chain_id.clone();
-    let port_id_a = cmd.port_id.clone();
-    let channel_id_a = cmd.channel_id.clone();
+    let chain_id = cmd.chain_id.clone();
+    let port_id = cmd.port_id.clone();
+    let channel_id = cmd.channel_id.clone();
 
-    let chain_a_config = config
-        .find_chain(&chain_id_a)
-        .ok_or_else(|| format!("chain '{}' not found in configuration file", chain_id_a))?;
+    let chain_config = config
+        .find_chain(&chain_id)
+        .ok_or_else(|| format!("chain '{}' not found in configuration file", chain_id))?;
 
     let rt = Arc::new(TokioRuntime::new().unwrap());
-    let chain_a = CosmosSdkChain::bootstrap(chain_a_config.clone(), rt.clone())?;
+    let chain = CosmosSdkChain::bootstrap(chain_config.clone(), rt.clone())?;
 
-    let height = ibc::Height::new(chain_a.id().version(), cmd.height.unwrap_or(0_u64));
+    let chain_height = match cmd.height {
+        Some(height) => Height::new(chain.id().version(), height),
+        None => chain.query_latest_height()?,
+    };
 
-    let channel_end_a = chain_a.query_channel(&port_id_a, &channel_id_a, height)?;
+    let channel_end = chain.query_channel(&port_id, &channel_id, chain_height)?;
 
-    let connection_id_a = channel_end_a
+    let connection_id = channel_end
         .connection_hops
         .first()
-        .ok_or_else(|| format!("missing connection_hops"))?;
+        .ok_or_else(|| format!("missing connection_hops"))?
+        .clone();
 
-    let connection_end_a = chain_a.query_connection(connection_id_a, height)?;
+    let connection_end = chain.query_connection(&connection_id, chain_height)?;
 
-    let client_state_a = chain_a.query_client_state(&connection_end_a.client_id(), height)?;
+    let client_id = connection_end.client_id().clone();
 
-    let channel_counterparty = channel_end_a.counterparty().clone();
-    let connection_counterparty = connection_end_a.counterparty().clone();
+    let client_state = chain.query_client_state(&client_id, chain_height)?;
 
-    let client_id_b = connection_counterparty.client_id().clone();
+    let channel_counterparty = channel_end.counterparty().clone();
+    let connection_counterparty = connection_end.counterparty().clone();
 
-    let connection_id_b = connection_counterparty.connection_id.ok_or_else(|| {
+    let counterparty_client_id = connection_counterparty.client_id().clone();
+
+    let counterparty_connection_id = connection_counterparty.connection_id.ok_or_else(|| {
         format!(
             "connection end do not have counterparty connection id: {:?}",
-            connection_end_a
+            connection_end
         )
     })?;
 
-    let port_id_b = channel_counterparty.port_id().clone();
+    let counterparty_port_id = channel_counterparty.port_id().clone();
 
-    let channel_id_b = channel_counterparty.channel_id.ok_or_else(|| {
+    let counterparty_channel_id = channel_counterparty.channel_id.ok_or_else(|| {
         format!(
             "channel end do not have counterparty channel id: {:?}",
-            channel_end_a
+            channel_end
         )
     })?;
 
-    let chain_id_b = client_state_a.chain_id.clone();
+    let counterparty_chain_id = client_state.chain_id.clone();
 
-    let chain_config_b = config
-        .find_chain(&chain_id_b)
-        .ok_or_else(|| format!("chain '{}' not found in configuration file", chain_id_b))?;
+    let chain_config_b = config.find_chain(&counterparty_chain_id).ok_or_else(|| {
+        format!(
+            "chain '{}' not found in configuration file",
+            counterparty_chain_id
+        )
+    })?;
 
-    let chain_b = CosmosSdkChain::bootstrap(chain_config_b.clone(), rt).unwrap();
+    let counterparty_chain = CosmosSdkChain::bootstrap(chain_config_b.clone(), rt).unwrap();
 
-    let connection_end_b = chain_b.query_connection(&connection_id_b, height)?;
+    let counterparty_chain_height = counterparty_chain.query_latest_height()?;
 
-    let client_state_b = chain_a.query_client_state(&client_id_b, Height::zero())?;
+    let counterparty_connection_end = counterparty_chain
+        .query_connection(&counterparty_connection_id, counterparty_chain_height)?;
 
-    let channel_end_b = chain_a.query_channel(&port_id_b, &channel_id_b, Height::zero())?;
+    let counterparty_client_state =
+        chain.query_client_state(&counterparty_client_id, counterparty_chain_height)?;
 
-    Ok(CmdResult {
-        channel_end_a,
-        connection_end_a,
-        client_state_a,
+    let counterparty_channel_end = chain.query_channel(
+        &counterparty_port_id,
+        &counterparty_channel_id,
+        counterparty_chain_height,
+    )?;
 
-        channel_end_b,
-        connection_end_b,
-        client_state_b,
-    })
+    if cmd.summary {
+        let res = TraceSummary {
+            chain_id,
+            client_id,
+            connection_id,
+            channel_id,
+            port_id,
+
+            counterparty_chain_id,
+            counterparty_client_id,
+            counterparty_connection_id,
+            counterparty_channel_id,
+            counterparty_port_id,
+        };
+
+        Output::success(res).exit();
+    } else {
+        let res = TraceResult {
+            channel_end,
+            connection_end,
+            client_state,
+
+            counterparty_channel_end,
+            counterparty_connection_end,
+            counterparty_client_state,
+        };
+
+        Output::success(res).exit();
+    }
+
+    Ok(())
 }
 
 impl Runnable for QueryTraceCmd {
     fn run(&self) {
         match do_run(self) {
-            Ok(res) => Output::success(res).exit(),
+            Ok(()) => {}
             Err(e) => Output::error(format!("{}", e)).exit(),
         }
     }

--- a/relayer-cli/src/commands/query/trace.rs
+++ b/relayer-cli/src/commands/query/trace.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+
+use abscissa_core::{Command, Options, Runnable};
+use serde::{Deserialize, Serialize};
+use tokio::runtime::Runtime as TokioRuntime;
+
+use ibc::ics03_connection::connection::ConnectionEnd;
+use ibc::ics04_channel::channel::ChannelEnd;
+use ibc::ics07_tendermint::client_state::ClientState;
+use ibc::ics24_host::identifier::ChainId;
+use ibc::ics24_host::identifier::{ChannelId, PortId};
+use ibc::Height;
+use ibc_relayer::chain::{Chain, CosmosSdkChain};
+
+use crate::conclude::Output;
+use crate::prelude::*;
+
+#[derive(Clone, Command, Debug, Options)]
+pub struct QueryTraceCmd {
+    #[options(free, required, help = "identifier of the chain to query")]
+    chain_id: ChainId,
+
+    #[options(free, required, help = "identifier of the port to query")]
+    port_id: PortId,
+
+    #[options(free, required, help = "identifier of the channel to query")]
+    channel_id: ChannelId,
+
+    #[options(help = "height of the state to query", short = "h")]
+    height: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CmdResult {
+    pub channel_end_a: ChannelEnd,
+    pub connection_end_a: ConnectionEnd,
+    pub client_state_a: ClientState,
+
+    pub channel_end_b: ChannelEnd,
+    pub connection_end_b: ConnectionEnd,
+    pub client_state_b: ClientState,
+}
+
+fn do_run(cmd: &QueryTraceCmd) -> Result<CmdResult, Box<dyn std::error::Error>> {
+    debug!("Options: {:?}", cmd);
+
+    let config = app_config();
+
+    let chain_id_a = cmd.chain_id.clone();
+    let port_id_a = cmd.port_id.clone();
+    let channel_id_a = cmd.channel_id.clone();
+
+    let chain_a_config = config
+        .find_chain(&chain_id_a)
+        .ok_or_else(|| format!("chain '{}' not found in configuration file", chain_id_a))?;
+
+    let rt = Arc::new(TokioRuntime::new().unwrap());
+    let chain_a = CosmosSdkChain::bootstrap(chain_a_config.clone(), rt.clone())?;
+
+    let height = ibc::Height::new(chain_a.id().version(), cmd.height.unwrap_or(0_u64));
+
+    let channel_end_a = chain_a.query_channel(&port_id_a, &channel_id_a, height)?;
+
+    let connection_id_a = channel_end_a
+        .connection_hops
+        .first()
+        .ok_or_else(|| format!("missing connection_hops"))?;
+
+    let connection_end_a = chain_a.query_connection(connection_id_a, height)?;
+
+    let client_state_a = chain_a.query_client_state(&connection_end_a.client_id(), height)?;
+
+    let channel_counterparty = channel_end_a.counterparty().clone();
+    let connection_counterparty = connection_end_a.counterparty().clone();
+
+    let client_id_b = connection_counterparty.client_id().clone();
+
+    let connection_id_b = connection_counterparty.connection_id.ok_or_else(|| {
+        format!(
+            "connection end do not have counterparty connection id: {:?}",
+            connection_end_a
+        )
+    })?;
+
+    let port_id_b = channel_counterparty.port_id().clone();
+
+    let channel_id_b = channel_counterparty.channel_id.ok_or_else(|| {
+        format!(
+            "channel end do not have counterparty channel id: {:?}",
+            channel_end_a
+        )
+    })?;
+
+    let chain_id_b = client_state_a.chain_id.clone();
+
+    let chain_config_b = config
+        .find_chain(&chain_id_b)
+        .ok_or_else(|| format!("chain '{}' not found in configuration file", chain_id_b))?;
+
+    let chain_b = CosmosSdkChain::bootstrap(chain_config_b.clone(), rt).unwrap();
+
+    let connection_end_b = chain_b.query_connection(&connection_id_b, height)?;
+
+    let client_state_b = chain_a.query_client_state(&client_id_b, Height::zero())?;
+
+    let channel_end_b = chain_a.query_channel(&port_id_b, &channel_id_b, Height::zero())?;
+
+    Ok(CmdResult {
+        channel_end_a,
+        connection_end_a,
+        client_state_a,
+
+        channel_end_b,
+        connection_end_b,
+        client_state_b,
+    })
+}
+
+impl Runnable for QueryTraceCmd {
+    fn run(&self) {
+        match do_run(self) {
+            Ok(res) => Output::success(res).exit(),
+            Err(e) => Output::error(format!("{}", e)).exit(),
+        }
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1062

## Description


In contrast to the the description & acceptance criteria in the linked issue, we ended up deciding on the following

- CLI is `query channel ends CHAIN-ID PORT-ID CHAN-ID [-v/--verbose]
- the output has the same structure as in the issue description, but slightly different names:
    - for `-v` option: `ChannelEnds { ... }`
    - without `-v`, default: `ChannelEndsSummary { .. }`


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [x] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.