### PR TITLE
Add health checkup mechanism 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 
+Many thanks to Fraccaroli Gianmarco (@Fraccaman) for helping us improve the
+reliability of Hermes ([#697]).
+
 ### FEATURES
 
 - [ibc-relayer-cli]
   - Added `config validate` CLI to Hermes ([#600])
   - Added basic channel filter ([#1140])
   - Added `query channel ends` CLI command ([#1062])
+  - Added a health checkup mechanism for Hermes ([#697, #1057])
 
 ### IMPROVEMENTS
 
@@ -15,7 +19,9 @@
 - Add inline documentation to config.toml ([#1127])
 
 [#600]: https://github.com/informalsystems/ibc-rs/issues/600
+[#697]: https://github.com/informalsystems/ibc-rs/issues/697
 [#1062]: https://github.com/informalsystems/ibc-rs/issues/1062
+[#1057]: https://github.com/informalsystems/ibc-rs/issues/1057
 [#1125]: https://github.com/informalsystems/ibc-rs/issues/1125
 [#1127]: https://github.com/informalsystems/ibc-rs/issues/1127
 [#1140]: https://github.com/informalsystems/ibc-rs/issues/1140

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "once_cell",
  "regex",
  "secrecy",
- "semver",
+ "semver 0.9.0",
  "serde",
  "signal-hook",
  "termcolor",
@@ -1388,6 +1388,7 @@ dependencies = [
  "prost-types",
  "retry",
  "ripemd160",
+ "semver 1.0.3",
  "serde",
  "serde_cbor",
  "serde_derive",
@@ -2378,7 +2379,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2514,6 +2515,12 @@ dependencies = [
  "semver-parser",
  "serde",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -62,6 +62,11 @@ pub mod cosmos {
         pub mod v1beta1 {
             include!("prost/cosmos.base.v1beta1.rs");
         }
+        pub mod tendermint {
+            pub mod v1beta1 {
+                include!("prost/cosmos.base.tendermint.v1beta1.rs");
+            }
+        }
     }
     pub mod crypto {
         pub mod multisig {

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -55,6 +55,7 @@ dyn-clone = "1.0.3"
 retry = { version = "1.2.1", default-features = false }
 async-stream = "0.3.2"
 fraction = {version = "0.8.0", default-features = false }
+semver = "1.0"
 
 [dependencies.tendermint]
 version = "=0.20.0"

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -113,11 +113,11 @@ pub struct CosmosSdkChain {
 }
 
 impl CosmosSdkChain {
-    /// Does multiple RPC calls the full node, and ensures
-    /// reachability and some basic functions are available.
+    /// Does multiple RPC calls to the full node, to check for
+    /// reachability and that some basic APIs are available.
     ///
-    /// Currently this method does the following checks:
-    ///     - that the node responds OK to `/health` RPC call;
+    /// Currently this checks that:
+    ///     - the node responds OK to `/health` RPC call;
     ///     - the node has transaction indexing enabled;
     ///     - the SDK version is supported.
     ///

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -197,8 +197,8 @@ impl CosmosSdkChain {
         }
 
         fn report_potential_problem(k: Kind) {
-            error!("{:?}", k);
-            error!("Some Hermes features may not work in this mode");
+            error!("{}", k);
+            error!("some Hermes features may not work in this mode!");
         }
     }
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -20,7 +20,7 @@ use tendermint::consensus::Params;
 use tendermint_light_client::types::LightBlock as TMLightBlock;
 use tendermint_proto::Protobuf;
 use tendermint_rpc::endpoint::tx::Response as ResultTx;
-use tendermint_rpc::query::Query;
+use tendermint_rpc::query::{EventType, Query};
 use tendermint_rpc::{endpoint::broadcast::tx_sync::Response, Client, HttpClient, Order};
 use tokio::runtime::Runtime as TokioRuntime;
 use tonic::codegen::http::Uri;
@@ -145,7 +145,13 @@ impl CosmosSdkChain {
             // Checkup on transaction indexing
             chain
                 .rpc_client
-                .tx_search(Query::default(), false, 1, 1, Order::Ascending)
+                .tx_search(
+                    Query::from(EventType::NewBlock),
+                    false,
+                    1,
+                    1,
+                    Order::Ascending,
+                )
                 .await
                 .map_err(|e| Kind::HealthCheckJsonRpc {
                     chain_id: chain_id.clone(),

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -24,7 +24,7 @@ use tendermint_rpc::query::{EventType, Query};
 use tendermint_rpc::{endpoint::broadcast::tx_sync::Response, Client, HttpClient, Order};
 use tokio::runtime::Runtime as TokioRuntime;
 use tonic::codegen::http::Uri;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, trace, warn};
 
 use ibc::downcast;
 use ibc::events::{from_tx_response_event, IbcEvent};

--- a/relayer/src/chain/cosmos/compatibility.rs
+++ b/relayer/src/chain/cosmos/compatibility.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use ibc_proto::cosmos::base::tendermint::v1beta1::VersionInfo;
 
-/// Specifies the SDK module name, as it is expected to appear
+/// Specifies the SDK module path, as it is expected to appear
 /// in the application version information.
 ///
 /// The module identification is captured in a [`Module`]
@@ -20,8 +20,7 @@ const SDK_MODULE_NAME: &str = "cosmos/cosmos-sdk";
 
 /// Specifies the SDK module version requirement.
 ///
-/// Maintain this consistently with the [features] page
-/// in the guide.
+/// # Note: Should be consistent with [features] guide page.
 ///
 /// [features]: https://hermes.informal.systems/features.html
 const SDK_MODULE_VERSION_REQ: &str = ">=0.41.3, <=0.42.6";
@@ -45,6 +44,7 @@ impl std::fmt::Display for AppInfo {
 pub enum Diagnostic {
     #[error("no SDK module '{pattern}' was found for application {app}")]
     SdkModuleNotFound { pattern: String, app: AppInfo },
+
     #[error("failed parsing the SDK module ('{module_path}') version number '{raw_version}' into a semver for application {app}; cause: {cause}")]
     VersionParsingFailed {
         module_path: String,
@@ -62,7 +62,7 @@ pub enum Diagnostic {
 }
 
 /// Runs a diagnostic check on the provided [`VersionInfo`]
-/// to ensure that the sdk module version matches the
+/// to ensure that the Sdk module version matches the
 /// predefined requirements.
 ///
 /// Returns `None` upon success, or a [`Diagnostic`] upon

--- a/relayer/src/chain/cosmos/compatibility.rs
+++ b/relayer/src/chain/cosmos/compatibility.rs
@@ -24,7 +24,7 @@ const SDK_MODULE_NAME: &str = "cosmos/cosmos-sdk";
 /// in the guide.
 ///
 /// [features]: https://hermes.informal.systems/features.html
-const SDK_MODULE_VERSION_REQ: &str = ">=0.41.3, <=0.42.4";
+const SDK_MODULE_VERSION_REQ: &str = ">=0.41.3, <=0.42.6";
 
 /// Helper struct to capture all the reported information of an
 /// IBC application, e.g., `gaiad`.

--- a/relayer/src/chain/cosmos/compatibility.rs
+++ b/relayer/src/chain/cosmos/compatibility.rs
@@ -94,8 +94,11 @@ pub(crate) fn run_diagnostic(v: VersionInfo) -> Option<Diagnostic> {
             app: app_info,
         }),
         Some(sdk_module) => {
+            // The raw version number has a leading 'v', trim it out;
+            let plain_version = sdk_module.version.trim_start_matches('v');
+
             // Parse the module version
-            match semver::Version::parse(&*sdk_module.version).map_err(|e| {
+            match semver::Version::parse(plain_version).map_err(|e| {
                 Diagnostic::VersionParsingFailed {
                     module_path: sdk_module.path.clone(),
                     raw_version: sdk_module.version.clone(),

--- a/relayer/src/chain/cosmos/compatibility.rs
+++ b/relayer/src/chain/cosmos/compatibility.rs
@@ -1,0 +1,119 @@
+//! Cosmos-SDK compatibility constants and helper methods.
+
+use thiserror::Error;
+
+use ibc_proto::cosmos::base::tendermint::v1beta1::VersionInfo;
+
+/// Specifies the SDK module name, as it is expected to appear
+/// in the application version information.
+///
+/// The module identification is captured in a [`Module`]
+/// with the following structure as an example:
+/// ```json,ignore
+/// Module {
+///    path: "github.com/cosmos/cosmos-sdk",
+///    version: "v0.42.4",
+///    sum: "h1:yaD4PyOx0LnyfiWasC5egg1U76lT83GRxjJjupPo7Gk=",
+/// },
+/// ```
+const SDK_MODULE_NAME: &str = "cosmos/cosmos-sdk";
+
+/// Specifies the SDK module version requirement.
+///
+/// Maintain this consistently with the [features] page
+/// in the guide.
+///
+/// [features]: https://hermes.informal.systems/features.html
+const SDK_MODULE_VERSION_REQ: &str = ">=0.41.3, <=0.42.4";
+
+/// Helper struct to capture all the reported information of an
+/// IBC application, e.g., `gaiad`.
+#[derive(Clone, Debug)]
+pub struct AppInfo {
+    app_name: String,
+    version: String,
+    git_commit: String,
+}
+
+impl std::fmt::Display for AppInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}-{}", self.app_name, self.version, self.git_commit)
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum Diagnostic {
+    #[error("no SDK module '{pattern}' was found for application {app}")]
+    SdkModuleNotFound { pattern: String, app: AppInfo },
+    #[error("failed parsing the SDK module ('{module_path}') version number '{raw_version}' into a semver for application {app}; cause: {cause}")]
+    VersionParsingFailed {
+        module_path: String,
+        raw_version: String,
+        cause: String,
+        app: AppInfo,
+    },
+
+    #[error("SDK module at version '{found}' does not meet compatibility requirements {requirements} for application {app}")]
+    MismatchingSdkModuleVersion {
+        requirements: String,
+        found: String,
+        app: AppInfo,
+    },
+}
+
+/// Runs a diagnostic check on the provided [`VersionInfo`]
+/// to ensure that the sdk module version matches the
+/// predefined requirements.
+///
+/// Returns `None` upon success, or a [`Diagnostic`] upon
+/// an error.
+///
+/// Relies on the constant [`SDK_MODULE_NAME`] to find the
+/// Sdk module by name, as well as the constant
+/// [`SDK_MODULE_VERSION_REQ`] for version compatibility
+/// requirements.
+pub(crate) fn run_diagnostic(v: VersionInfo) -> Option<Diagnostic> {
+    let app_info = AppInfo {
+        app_name: v.app_name,
+        version: v.version,
+        git_commit: v.git_commit,
+    };
+
+    // Parse the requirements into a semver
+    let reqs = semver::VersionReq::parse(SDK_MODULE_VERSION_REQ)
+        .expect("parsing the SDK module requirements into semver");
+
+    // Find the Cosmos SDK module
+    match v
+        .build_deps
+        .iter()
+        .find(|&m| m.path.contains(SDK_MODULE_NAME))
+    {
+        None => Some(Diagnostic::SdkModuleNotFound {
+            pattern: SDK_MODULE_NAME.to_string(),
+            app: app_info,
+        }),
+        Some(sdk_module) => {
+            // Parse the module version
+            match semver::Version::parse(&*sdk_module.version).map_err(|e| {
+                Diagnostic::VersionParsingFailed {
+                    module_path: sdk_module.path.clone(),
+                    raw_version: sdk_module.version.clone(),
+                    cause: e.to_string(),
+                    app: app_info.clone(),
+                }
+            }) {
+                // Finally, check the version requirements
+                Ok(v) => match reqs.matches(&v) {
+                    true => None,
+                    false => Some(Diagnostic::MismatchingSdkModuleVersion {
+                        requirements: SDK_MODULE_VERSION_REQ.to_string(),
+                        found: v.to_string(),
+                        app: app_info,
+                    }),
+                },
+                Err(d) => Some(d),
+            }
+        }
+    }
+}

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -201,7 +201,7 @@ pub enum Kind {
         got: ClientType,
     },
 
-    #[error("Hermes health check failed for endpoint {endpoint} on the Json RPC interface of chain {chain_id}:{address}; reported error: {cause}")]
+    #[error("Hermes health check failed for endpoint {endpoint} on the Json RPC interface of chain {chain_id}:{address}; caused by: {cause}")]
     HealthCheckJsonRpc {
         chain_id: ChainId,
         address: String,
@@ -209,7 +209,7 @@ pub enum Kind {
         cause: tendermint_rpc::error::Error,
     },
 
-    #[error("Hermes health check failed for service {endpoint} on the gRPC interface of chain {chain_id}:{address}; reported error: {cause}")]
+    #[error("Hermes health check failed for service {endpoint} on the gRPC interface of chain {chain_id}:{address}; caused by: {cause}")]
     HealthCheckGrpc {
         chain_id: ChainId,
         address: String,

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -201,7 +201,7 @@ pub enum Kind {
         got: ClientType,
     },
 
-    #[error("Hermes health check failed for endpoint {endpoint} on the Json RPC interface; reported error: {cause}")]
+    #[error("Hermes health check failed for endpoint {endpoint} on the Json RPC interface of chain {chain_id}:{address}; reported error: {cause}")]
     HealthCheckJsonRpc {
         chain_id: ChainId,
         address: String,
@@ -209,7 +209,7 @@ pub enum Kind {
         cause: tendermint_rpc::error::Error,
     },
 
-    #[error("Hermes health check failed for service {endpoint} on the gRPC interface; reported error: {cause}")]
+    #[error("Hermes health check failed for service {endpoint} on the gRPC interface of chain {chain_id}:{address}; reported error: {cause}")]
     HealthCheckGrpc {
         chain_id: ChainId,
         address: String,
@@ -217,7 +217,7 @@ pub enum Kind {
         cause: String,
     },
 
-    #[error("Hermes health check failed while verifying the application")]
+    #[error("Hermes health check failed while verifying the application compatibility for chain {chain_id}:{address}; caused by: {cause}")]
     SdkModuleVersion {
         chain_id: ChainId,
         address: String,

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -203,17 +203,26 @@ pub enum Kind {
 
     #[error("Hermes health check failed for endpoint {endpoint} on the Json RPC interface; reported error: {cause}")]
     HealthCheckJsonRpc {
+        chain_id: ChainId,
+        address: String,
         endpoint: String,
         cause: tendermint_rpc::error::Error,
     },
 
     #[error("Hermes health check failed for service {endpoint} on the gRPC interface; reported error: {cause}")]
     HealthCheckGrpc {
+        chain_id: ChainId,
+        address: String,
         endpoint: String,
         cause: String,
-    }
+    },
 
-
+    #[error("Hermes health check failed while verifying the application")]
+    SdkModuleVersion {
+        chain_id: ChainId,
+        address: String,
+        cause: String,
+    },
 }
 
 impl Kind {

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -200,6 +200,20 @@ pub enum Kind {
         expected: ClientType,
         got: ClientType,
     },
+
+    #[error("Hermes health check failed for endpoint {endpoint} on the Json RPC interface; reported error: {cause}")]
+    HealthCheckJsonRpc {
+        endpoint: String,
+        cause: tendermint_rpc::error::Error,
+    },
+
+    #[error("Hermes health check failed for service {endpoint} on the gRPC interface; reported error: {cause}")]
+    HealthCheckGrpc {
+        endpoint: String,
+        cause: String,
+    }
+
+
 }
 
 impl Kind {

--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -133,7 +133,6 @@ else
   sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
   sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
   sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
-  sed -i '' 's/indexer = "kv"/indexer = "null"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
   # sed -i '' 's/min-retain-blocks = 0/min-retain-blocks = 100/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
   # sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
   # sed -i '' 's/error/debug/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml

--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -133,6 +133,7 @@ else
   sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
   sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
   sed -i '' 's/index_all_keys = false/index_all_keys = true/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
+  sed -i '' 's/indexer = "kv"/indexer = "null"/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml
   # sed -i '' 's/min-retain-blocks = 0/min-retain-blocks = 100/g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
   # sed -i '' 's#index-events = \[\]#index-events = \["message.action","send_packet.packet_src_channel","send_packet.packet_sequence"\]#g' $CHAIN_DIR/$CHAIN_ID/config/app.toml
   # sed -i '' 's/error/debug/g' $CHAIN_DIR/$CHAIN_ID/config/config.toml


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #697 
Closes: #1057 

__Needs guide update for the SDK compatibility range.__

Testing instructions:

- to reproduce 697:
    - apply [this patch](https://gist.github.com/adizere/2c8d53920b7fed8f28e6195405a18458) then run `dev-env` to produce two gaia instances, both of which will have transaction indexing disabled
    - then run `hermes query clients ibc-0`
    - you should see a WARN log

> Jul 02 15:36:03.226 WARN Hermes health check failed for endpoint /tx_search on the Json RPC interface of chain ibc-0:http://127.0.0.1:26657/; reported error: Internal error: transaction indexing is disabled (code: -32603)
Jul 02 15:36:03.226 WARN some Hermes features may not work in this mode!

- to test the warning against a non-healthy full node:
    - just kill your gaiad instances using `killall gaiad`
    - run `hermes query clients ibc-0`

> Jul 02 16:26:51.212  WARN Hermes health check failed for endpoint /health on the Json RPC interface of chain ibc-0:http://127.0.0.1:26657/; caused by: error trying to connect: tcp connect error: Connection refused (os error 61) (code: 0)
Jul 02 16:26:51.212  WARN some Hermes features may not work in this mode!
Error: query error: GRPC error: transport error: error trying to connect: tcp connect error: Connection refused (os error 61)


- to test other warnings:
    - install a gaia version that is unsupported
    - `cd $GAIA_DIR ; git co colin/upgrade-testing`
    - `make install` to update your gaia to this new version, which builds on unsupported SDK 0.43+
    - run `dev-env` to start two gaia instances
    - then run `hermes query clients ibc-0`
    - you should see a WARN log

> Jul 03 10:45:17.899  WARN Hermes health check failed for endpoint /tx_search on the Json RPC interface of chain ibc-0:http://127.0.0.1:26657/; caused by: Internal error:
parse error near Unknown (line 1 symbol 1 - line 1 symbol 1):
""
 (code: -32603)
Jul 03 10:45:17.899  WARN some Hermes features may not work in this mode!


## TODO

-  [x] test with gaia v5 to make sure the SDK is supported

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.