### PR TITLE
Add `LegacyError` type to replace `Box<dyn std::error::Error>` in `no-std` mode

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,6 +17,7 @@ description = """
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
 mocks = [ "tendermint-testgen", "sha2" ]
+test_no_std = []
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,7 +17,7 @@ description = """
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
 mocks = [ "tendermint-testgen", "sha2" ]
-test_no_std = []
+std_err = []
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -1,5 +1,70 @@
 use crate::ics24_host::error::ValidationError;
 use flex_error::{define_error, DisplayOnly, TraceError};
+use std::fmt::Display;
+
+#[derive(Debug)]
+pub struct StdError {
+    inner: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl StdError {
+    pub fn new(value: Box<dyn std::error::Error + Send + Sync>) -> Self  {
+        Self {
+            inner: value
+        }
+    }
+
+}
+
+impl From<String> for StdError {
+    fn from(value: String) -> Self {
+        Self {
+            inner: value.into()
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum LegacyError {
+    InnerBox(StdError),
+    #[cfg(feature = "test_no_std")]
+    InnerString(String),
+}
+
+impl LegacyError {
+    fn as_str(&self) -> String {
+        match self {
+            LegacyError::InnerBox(val) => {
+                val.inner.to_string()
+            }
+            #[cfg(feature = "test_no_std")]
+            LegacyError::InnerString(val) => {
+                val.clone()
+            }
+        }
+    }
+}
+
+impl Display for LegacyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "LegacyError: {}", self.as_str())
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Box<dyn std::error::Error + Send + Sync>> for LegacyError {
+    fn from(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        LegacyError::InnerBox(StdError::new(value))
+    }
+
+}
+
+#[cfg(feature = "test_no_std")]
+impl From<Box<dyn std::error::Error + Send + Sync>> for LegacyError {
+    fn from(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        LegacyError::InnerString(value.to_string())
+    }
+}
 
 define_error! {
     Error {
@@ -16,7 +81,7 @@ define_error! {
 
         InvalidHeader
             { reason: String }
-            [ DisplayOnly<Box<dyn std::error::Error + Send + Sync>> ]
+            [ DisplayOnly<LegacyError> ]
             | _ | { "invalid header, failed basic validation" },
 
         MissingSignedHeader
@@ -80,7 +145,7 @@ define_error! {
             | _ | { "invalid raw client consensus state" },
 
         InvalidRawHeader
-            [ DisplayOnly<Box<dyn std::error::Error + Send + Sync>> ]
+            [ DisplayOnly<LegacyError> ]
             | _ | { "invalid raw header" },
 
         InvalidRawMisbehaviour

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -51,7 +51,7 @@ impl Display for LegacyError {
     }
 }
 
-#[cfg(feature = "std")]
+// #[cfg(feature = "std")]
 impl From<Box<dyn std::error::Error + Send + Sync>> for LegacyError {
     fn from(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
         LegacyError::InnerBox(StdError::new(value))

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -20,18 +20,14 @@ impl Display for LegacyError {
 #[cfg(feature = "std_err")]
 impl From<Box<dyn std::error::Error + Send + Sync>> for LegacyError {
     fn from(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        Self {
-            error: value,
-        }
+        Self { error: value }
     }
 }
 
 #[cfg(not(feature = "std_err"))]
 impl From<String> for LegacyError {
     fn from(value: String) -> Self {
-        Self {
-            error: value,
-        }
+        Self { error: value }
     }
 }
 

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -3,66 +3,35 @@ use flex_error::{define_error, DisplayOnly, TraceError};
 use std::fmt::Display;
 
 #[derive(Debug)]
-pub struct StdError {
-    inner: Box<dyn std::error::Error + Send + Sync>,
-}
+pub struct LegacyError {
+    #[cfg(feature = "std_err")]
+    error: Box<dyn std::error::Error + Send + Sync>,
 
-impl StdError {
-    pub fn new(value: Box<dyn std::error::Error + Send + Sync>) -> Self  {
-        Self {
-            inner: value
-        }
-    }
-
-}
-
-impl From<String> for StdError {
-    fn from(value: String) -> Self {
-        Self {
-            inner: value.into()
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum LegacyError {
-    InnerBox(StdError),
-    #[cfg(feature = "test_no_std")]
-    InnerString(String),
-}
-
-impl LegacyError {
-    fn as_str(&self) -> String {
-        match self {
-            LegacyError::InnerBox(val) => {
-                val.inner.to_string()
-            }
-            #[cfg(feature = "test_no_std")]
-            LegacyError::InnerString(val) => {
-                val.clone()
-            }
-        }
-    }
+    #[cfg(not(feature = "std_err"))]
+    error: String,
 }
 
 impl Display for LegacyError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "LegacyError: {}", self.as_str())
+        write!(f, "LegacyError: {}", self.to_string())
     }
 }
 
-// #[cfg(feature = "std")]
+#[cfg(feature = "std_err")]
 impl From<Box<dyn std::error::Error + Send + Sync>> for LegacyError {
     fn from(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        LegacyError::InnerBox(StdError::new(value))
+        Self {
+            error: value,
+        }
     }
-
 }
 
-#[cfg(feature = "test_no_std")]
-impl From<Box<dyn std::error::Error + Send + Sync>> for LegacyError {
-    fn from(value: Box<dyn std::error::Error + Send + Sync>) -> Self {
-        LegacyError::InnerString(value.to_string())
+#[cfg(not(feature = "std_err"))]
+impl From<String> for LegacyError {
+    fn from(value: String) -> Self {
+        Self {
+            error: value,
+        }
     }
 }
 

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -94,6 +94,7 @@ impl TryFrom<RawHeader> for Header {
                 .signed_header
                 .ok_or_else(error::missing_signed_header_error)?
                 .try_into()
+                .map_err(|val : Box<dyn std::error::Error + Send + Sync> | val.into())
                 .map_err(|e| {
                     error::invalid_header_error("signed header conversion".to_string(), e)
                 })?,
@@ -101,6 +102,7 @@ impl TryFrom<RawHeader> for Header {
                 .validator_set
                 .ok_or_else(error::missing_validator_set_error)?
                 .try_into()
+                .map_err(|val : Box<dyn std::error::Error + Send + Sync> | val.into())
                 .map_err(error::invalid_raw_header_error)?,
             trusted_height: raw
                 .trusted_height
@@ -110,6 +112,7 @@ impl TryFrom<RawHeader> for Header {
                 .trusted_validators
                 .ok_or_else(error::missing_trusted_validator_set_error)?
                 .try_into()
+                .map_err(|val : Box<dyn std::error::Error + Send + Sync> | val.into())
                 .map_err(error::invalid_raw_header_error)?,
         })
     }

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -94,14 +94,16 @@ impl TryFrom<RawHeader> for Header {
                 .signed_header
                 .ok_or_else(error::missing_signed_header_error)?
                 .try_into()
-                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | {
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync>| {
                     error::invalid_header_error("signed header conversion".to_string(), e.into())
                 })?,
             validator_set: raw
                 .validator_set
                 .ok_or_else(error::missing_validator_set_error)?
                 .try_into()
-                .map_err(|e: Box<dyn std::error::Error + Send + Sync> |error::invalid_raw_header_error(e.into()))?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync>| {
+                    error::invalid_raw_header_error(e.into())
+                })?,
             trusted_height: raw
                 .trusted_height
                 .ok_or_else(error::missing_trusted_height_error)?
@@ -110,7 +112,9 @@ impl TryFrom<RawHeader> for Header {
                 .trusted_validators
                 .ok_or_else(error::missing_trusted_validator_set_error)?
                 .try_into()
-                .map_err(|e: Box<dyn std::error::Error + Send + Sync> |error::invalid_raw_header_error(e.into()))?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync>| {
+                    error::invalid_raw_header_error(e.into())
+                })?,
         })
     }
 }

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -94,16 +94,14 @@ impl TryFrom<RawHeader> for Header {
                 .signed_header
                 .ok_or_else(error::missing_signed_header_error)?
                 .try_into()
-                .map_err(|val : Box<dyn std::error::Error + Send + Sync> | val.into())
-                .map_err(|e| {
-                    error::invalid_header_error("signed header conversion".to_string(), e)
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | {
+                    error::invalid_header_error("signed header conversion".to_string(), e.into())
                 })?,
             validator_set: raw
                 .validator_set
                 .ok_or_else(error::missing_validator_set_error)?
                 .try_into()
-                .map_err(|val : Box<dyn std::error::Error + Send + Sync> | val.into())
-                .map_err(error::invalid_raw_header_error)?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync> |error::invalid_raw_header_error(e.into()))?,
             trusted_height: raw
                 .trusted_height
                 .ok_or_else(error::missing_trusted_height_error)?
@@ -112,8 +110,7 @@ impl TryFrom<RawHeader> for Header {
                 .trusted_validators
                 .ok_or_else(error::missing_trusted_validator_set_error)?
                 .try_into()
-                .map_err(|val : Box<dyn std::error::Error + Send + Sync> | val.into())
-                .map_err(error::invalid_raw_header_error)?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync> |error::invalid_raw_header_error(e.into()))?,
         })
     }
 }


### PR DESCRIPTION
> Use a wrapper struct for Box<dyn std::error::Error> for remaining errors not updated by Use flex-error to define errors #988.

> PR Use flex-error to define errors #988 has removed most of the uses of Box<dyn std::error::Error>, however, there are still a few places remaining that are still using std::error::Error.
PR Enable IBC to Support no-std #1109 attempts to polyfill std::error::Error by aliasing it to a DummyError struct in no-std mode. However doing so does not prevent dependencies from constructing Box<dyn std::error::Error>, which would prevent no-std from being supported. On the other hand, if we have control of all places that produce Box<dyn std::error::Error>, we can also modify them to return something other than Box<dyn std::error::Error>.
I'd propose that we define a type like LegacyError, which is either a newtype wrapper to Box<dyn std::error::Error> in std mode or a newtype wrapper to String in no-std mode. By always using a newtype wrapper, we can avoid accidental implicit coercion from Box<dyn std::error::Error> to LegacyError in std mode, which will prevent no-std mode to work.
There should be a Cargo separate feature flag to switch between the two modes to LegacyError. The purpose is to be able to test the two modes of LegacyError without fully activating no-std.
This change can be done inside Enable IBC to Support no-std #1109 Use flex-error to define errors #988, or a follow-up PR to Enable IBC to Support no-std #1109 Use flex-error to define errors #988. It is also possible to make this change against the master, although there will be much more changes needed.

I deine a `LegacyError` replace `Box<dyn std::error::Error>`.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.