### PR TITLE
Nixify ibc-proto-compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+@JonathanLorimer added a nix expression to `ibc-proto-compiler` ([#1170])
+
 Many thanks to Fraccaroli Gianmarco (@Fraccaman) for helping us improve the
 reliability of Hermes ([#697]).
 

--- a/proto-compiler/README.md
+++ b/proto-compiler/README.md
@@ -15,7 +15,7 @@ $ nix-shell # you can run "nix develop" if you have experimental support for fla
 $ compile
 ```
 
-### Clone the Cosmos SDK
+### Using Cargo
 
 From within the `proto-compiler` directory, compile the binary using the `--locked` flag:
 

--- a/proto-compiler/README.md
+++ b/proto-compiler/README.md
@@ -4,6 +4,17 @@ The `ibc-proto-compiler` is a simple command-line tool to automate the compilati
 
 ## Usage
 
+### Nix Shell
+
+There is a script wrapper provided by nix that takes care of the `protoc` dependency imposed by `prost-build` and provides a shell wrapper that handles cloning the cosmos go dependencies.
+
+Instruaction on how to install nix can be found [here](https://nixos.org/download.html)
+
+```shell
+$ nix-shell # nix develop if you have experimental support for flakes
+$ compile
+```
+
 ### Clone the Cosmos SDK
 
 From within the `proto-compiler` directory, compile the binary using the `--locked` flag:
@@ -41,5 +52,5 @@ Note: the `--ibc` option is not mandatory; if omitted, then the IBC .proto files
 Additionally, this command will output the commit hash at which the Cosmos SDK is checked out into `$out/COSMOS_SDK_COMMIT` and
 similarly the commit hash for IBC-go is saved into `$out/COSMOS_IBC_VERSION`.
 
-The two commit values are exposed via the `ibc_proto::COSMOS_SDK_VERSION` and `ibc_proto::COSMOS_IBC_VERSION` 
+The two commit values are exposed via the `ibc_proto::COSMOS_SDK_VERSION` and `ibc_proto::COSMOS_IBC_VERSION`
 constants in the `ibc-proto` library.

--- a/proto-compiler/README.md
+++ b/proto-compiler/README.md
@@ -8,10 +8,10 @@ The `ibc-proto-compiler` is a simple command-line tool to automate the compilati
 
 There is a script wrapper provided by nix that takes care of the `protoc` dependency imposed by `prost-build` and provides a shell wrapper that handles cloning the cosmos go dependencies.
 
-Instruaction on how to install nix can be found [here](https://nixos.org/download.html)
+Instruction on how to install nix can be found [here](https://nixos.org/download.html)
 
 ```shell
-$ nix-shell # nix develop if you have experimental support for flakes
+$ nix-shell # you can run "nix develop" if you have experimental support for flakes
 $ compile
 ```
 

--- a/proto-compiler/README.md
+++ b/proto-compiler/README.md
@@ -10,9 +10,14 @@ There is a script wrapper provided by nix that takes care of the `protoc` depend
 
 Instruction on how to install nix can be found [here](https://nixos.org/download.html)
 
-```shell
-$ nix-shell # you can run "nix develop" if you have experimental support for flakes
-$ compile
+```
+nix-shell --run "compile"
+```
+
+Or if you have experimental nix with support for flakes
+
+```
+nix develop -c "compile"
 ```
 
 ### Using Cargo

--- a/proto-compiler/default.nix
+++ b/proto-compiler/default.nix
@@ -1,0 +1,12 @@
+# This file exists for legacy Nix installs (nix-build & nix-env)
+# https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix
+# You generally do *not* have to modify this ever.
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/proto-compiler/flake.lock
+++ b/proto-compiler/flake.lock
@@ -1,0 +1,128 @@
+{
+  "nodes": {
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608814925,
+        "narHash": "sha256-GdFBG2LmpbY4C1OJBFfWLMKXzGyFq4mJBK+SVMNNE+8=",
+        "owner": "balsoft",
+        "repo": "crate2nix",
+        "rev": "68be3d90f31bf0bfd525da77e0ae6e89f48abd24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "balsoft",
+        "ref": "tools-nix-version-comparison",
+        "repo": "crate2nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1614513358,
+        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1625697353,
+        "narHash": "sha256-/v85RkZ0Z+lxipkG2sjYNRINktc8VySbLQmPbirY0hQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "87807e64a5ef5206b745a40af118c7be8db73681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1617325113,
+        "narHash": "sha256-GksR0nvGxfZ79T91UUtWjjccxazv6Yh/MvEJ82v1Xmw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "54c1e44240d8a527a8f4892608c4bce5440c3ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1625883202,
+        "narHash": "sha256-2HuZT2VbLIOvG8Lz923q6UEUrPyUWvWj18703Un+rFE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3e1ae0550e448e83ef0941d60f3e6a94b810bec6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/proto-compiler/flake.nix
+++ b/proto-compiler/flake.nix
@@ -83,7 +83,7 @@
               compileScript = pkgs.writeShellScriptBin "compile" ''
                 ${self.packages.${system}.${name}}/bin/${name} clone --out /tmp/cosmos --sdk-commit ${cosmos-sdk-rev} --ibc-go-commit ${ibc-go-rev}
                 ${self.packages.${system}.${name}}/bin/${name} compile --sdk /tmp/cosmos/sdk --ibc /tmp/cosmos/ibc --out ../proto/src/prost
-                ## rm -rf /tmp/cosmos/
+                rm -rf /tmp/cosmos/
               '';
           in
             pkgs.mkShell {

--- a/proto-compiler/flake.nix
+++ b/proto-compiler/flake.nix
@@ -48,10 +48,8 @@
             src = ./.;
           }) {
             # Individual crate overrides go here
-            # Example: https://github.com/balsoft/simple-osd-daemons/blob/6f85144934c0c1382c7a4d3a2bbb80106776e270/flake.nix#L28-L50
             defaultCrateOverrides = pkgs.defaultCrateOverrides // {
-              # The ibc-proto-compiler crate itself is overriden here. Typically we
-              # configure non-Rust dependencies (see below) here.
+              # The ibc-proto-compiler crate itself is overriden here.
               ${name} = oldAttrs: {
                 nativeBuildInputs = with pkgs; [ rustc cargo pkgconfig ];
               };

--- a/proto-compiler/flake.nix
+++ b/proto-compiler/flake.nix
@@ -78,9 +78,10 @@
           devShell =
           let cosmos-sdk-rev = "7648bfca45b9d0897103ec739210607dce77c4fb";
               ibc-go-rev = "333c1f338b2a14a1928a6f8ab64c37123c0e97b6";
+              exe-path = "${self.packages.${system}.${name}}/bin/${name}";
               compileScript = pkgs.writeShellScriptBin "compile" ''
-                ${self.packages.${system}.${name}}/bin/${name} clone --out /tmp/cosmos --sdk-commit ${cosmos-sdk-rev} --ibc-go-commit ${ibc-go-rev}
-                ${self.packages.${system}.${name}}/bin/${name} compile --sdk /tmp/cosmos/sdk --ibc /tmp/cosmos/ibc --out ../proto/src/prost
+                ${exe-path} clone --out /tmp/cosmos --sdk-commit ${cosmos-sdk-rev} --ibc-go-commit ${ibc-go-rev}
+                ${exe-path} compile --sdk /tmp/cosmos/sdk --ibc /tmp/cosmos/ibc --out ../proto/src/prost
                 rm -rf /tmp/cosmos/
               '';
           in

--- a/proto-compiler/flake.nix
+++ b/proto-compiler/flake.nix
@@ -56,8 +56,8 @@
                 nativeBuildInputs = with pkgs; [ rustc cargo pkgconfig ];
               };
               prost-build = oldAttrs: {
-                buildInputs = [ pkgs.protobuf ];
-                PROTOC = "protoc";
+                buildInputs = [pkgs.protobuf];
+                PROTOC = "${pkgs.protobuf}/bin/protoc";
               };
             };
           };
@@ -83,13 +83,13 @@
               compileScript = pkgs.writeShellScriptBin "compile" ''
                 ${self.packages.${system}.${name}}/bin/${name} clone --out /tmp/cosmos --sdk-commit ${cosmos-sdk-rev} --ibc-go-commit ${ibc-go-rev}
                 ${self.packages.${system}.${name}}/bin/${name} compile --sdk /tmp/cosmos/sdk --ibc /tmp/cosmos/ibc --out ../proto/src/prost
-                rm -rf /tmp/cosmos/
+                ## rm -rf /tmp/cosmos/
               '';
           in
             pkgs.mkShell {
               packages = [ compileScript ];
               inputsFrom = builtins.attrValues self.packages.${system};
-              buildInputs = with pkgs; [ cargo cargo-watch trunk protobuf];
+              buildInputs = with pkgs; [ cargo cargo-watch trunk ];
               RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
             };
         }

--- a/proto-compiler/flake.nix
+++ b/proto-compiler/flake.nix
@@ -1,0 +1,97 @@
+{
+  description = ''
+    The ibc-proto-compiler is a simple command-line tool to automate the compilation of
+    Protocol Buffers message definitions from the Cosmos SDK and IBC-Go
+    to Rust source code with Prost, for use in the ibc-proto crate in the ibc-rs project.
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    crate2nix = {
+      url = "github:balsoft/crate2nix/tools-nix-version-comparison";
+      flake = false;
+    };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, utils, rust-overlay, crate2nix, ... }:
+    utils.lib.eachDefaultSystem
+      (system:
+       let
+          name = "ibc-proto-compiler";
+
+          # Imports
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              rust-overlay.overlay
+              (self: super: {
+                # Because rust-overlay bundles multiple rust packages into one
+                # derivation, specify that mega-bundle here, so that crate2nix
+                # will use them automatically.
+                rustc = self.rust-bin.stable.latest.default;
+                cargo = self.rust-bin.stable.latest.default;
+              })
+            ];
+          };
+          inherit (import "${crate2nix}/tools.nix" { inherit pkgs; })
+            generatedCargoNix;
+
+          # Create the cargo2nix project
+          project = pkgs.callPackage (generatedCargoNix {
+            inherit name;
+            src = ./.;
+          }) {
+            # Individual crate overrides go here
+            # Example: https://github.com/balsoft/simple-osd-daemons/blob/6f85144934c0c1382c7a4d3a2bbb80106776e270/flake.nix#L28-L50
+            defaultCrateOverrides = pkgs.defaultCrateOverrides // {
+              # The ibc-proto-compiler crate itself is overriden here. Typically we
+              # configure non-Rust dependencies (see below) here.
+              ${name} = oldAttrs: {
+                nativeBuildInputs = with pkgs; [ rustc cargo pkgconfig ];
+              };
+              prost-build = oldAttrs: {
+                buildInputs = [ pkgs.protobuf ];
+                PROTOC = "protoc";
+              };
+            };
+          };
+        in rec {
+          packages.${name} = project.rootCrate.build;
+
+          # `nix build`
+          defaultPackage = packages.${name};
+
+          # `nix run`
+          apps = {
+            ${name} = utils.lib.mkApp {
+              inherit name;
+              drv = packages.${name};
+            };
+          };
+          defaultApp = apps.${name};
+
+          # `nix develop`
+          devShell =
+          let cosmos-sdk-rev = "7648bfca45b9d0897103ec739210607dce77c4fb";
+              ibc-go-rev = "333c1f338b2a14a1928a6f8ab64c37123c0e97b6";
+              compileScript = pkgs.writeShellScriptBin "compile" ''
+                ${self.packages.${system}.${name}}/bin/${name} clone --out /tmp/cosmos --sdk-commit ${cosmos-sdk-rev} --ibc-go-commit ${ibc-go-rev}
+                ${self.packages.${system}.${name}}/bin/${name} compile --sdk /tmp/cosmos/sdk --ibc /tmp/cosmos/ibc --out ../proto/src/prost
+                rm -rf /tmp/cosmos/
+              '';
+          in
+            pkgs.mkShell {
+              packages = [ compileScript ];
+              inputsFrom = builtins.attrValues self.packages.${system};
+              buildInputs = with pkgs; [ cargo cargo-watch trunk protobuf];
+              RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+            };
+        }
+      );
+}

--- a/proto-compiler/shell.nix
+++ b/proto-compiler/shell.nix
@@ -1,0 +1,12 @@
+# This file exists for legacy nix-shell
+# https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix
+# You generally do *not* have to modify this ever.
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
## Description

Doesn't close, but gets us closer to closing #1171

This PR adds nix support for the `ibc-proto-compiler`. Originally I was going to try and just nixify everything, but I realized the PR would be rather large, so I figured I would submit PR's one sub-directory at a time.

The goal of nixifying ibc-rs is that I want to run my own IBC relayer, and the easiest way to spin up infra (IMO) is with nix. Nixifying this repo will make things a bit easier downstream (for me), will facilitate adding this software to nixpkgs, and might provide some development benefits to the development team if they choose to use nix for a development environment!

I strongly encourage the reviewer to try the new workflow! I think the fact that compiling is now a one-liner is pretty compelling `nix-shell --run "compile" `

(also removes the need to clutter your global environment with `protoc`, a dependency which wasn't mentioned in the `Usage` instructions :wink: )
______

For contributor use:

- [x] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.

~~I didn't create an issue for this. Should I?~~ just read CONTRIBUTING.md

- [ ] If applicable: Unit tests written, added test to CI.

No unit tests right now, and I don't think nix-tests make sense (yet). But a nice benefit of nix is it allows you to spin up a virtualized machine and run E2E tests, so that is something I could potentially provide after nixifying the whole thing!

- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
