### PR TITLE
Prevent race condition when updating the workers after config reload

### DIFF
--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     sync::{Arc, RwLock},
     time::Duration,
 };
@@ -358,19 +358,9 @@ impl Supervisor {
     /// Dump the state of the supervisor into a [`SupervisorState`] value,
     /// and send it back through the given channel.
     fn dump_state(&self, reply_to: Sender<SupervisorState>) -> CmdEffect {
-        let mut chains = self.registry.chains().map(|c| c.id()).collect_vec();
-        chains.sort();
-
-        let workers = self
-            .workers
-            .objects()
-            .cloned()
-            .into_group_map_by(|o| o.object_type())
-            .into_iter()
-            .update(|(_, os)| os.sort_by_key(Object::short_name))
-            .collect::<BTreeMap<_, _>>();
-
-        let _ = reply_to.try_send(SupervisorState::new(chains, workers));
+        let chains = self.registry.chains().map(|c| c.id()).collect_vec();
+        let state = SupervisorState::new(chains, self.workers.objects());
+        let _ = reply_to.try_send(state);
 
         CmdEffect::Nothing
     }
@@ -479,8 +469,8 @@ impl Supervisor {
     /// Process the given [`WorkerMsg`] sent by a worker.
     fn handle_worker_msg(&mut self, msg: WorkerMsg) {
         match msg {
-            WorkerMsg::Stopped(object) => {
-                self.workers.remove_stopped(&object);
+            WorkerMsg::Stopped(id, object) => {
+                self.workers.remove_stopped(id, object);
             }
         }
     }

--- a/relayer/src/supervisor/dump_state.rs
+++ b/relayer/src/supervisor/dump_state.rs
@@ -5,16 +5,43 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::object::{Object, ObjectType};
+use crate::{
+    object::{Object, ObjectType},
+    worker::WorkerId,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerDesc {
+    pub id: WorkerId,
+    pub object: Object,
+}
+
+impl WorkerDesc {
+    pub fn new(id: WorkerId, object: Object) -> Self {
+        Self { id, object }
+    }
+}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SupervisorState {
     pub chains: Vec<ChainId>,
-    pub workers: BTreeMap<ObjectType, Vec<Object>>,
+    pub workers: BTreeMap<ObjectType, Vec<WorkerDesc>>,
 }
 
 impl SupervisorState {
-    pub fn new(chains: Vec<ChainId>, workers: BTreeMap<ObjectType, Vec<Object>>) -> Self {
+    pub fn new<'a>(
+        mut chains: Vec<ChainId>,
+        workers: impl Iterator<Item = (WorkerId, &'a Object)>,
+    ) -> Self {
+        chains.sort();
+
+        let workers = workers
+            .map(|(id, o)| WorkerDesc::new(id, o.clone()))
+            .into_group_map_by(|desc| desc.object.object_type())
+            .into_iter()
+            .update(|(_, os)| os.sort_by_key(|desc| desc.object.short_name()))
+            .collect::<BTreeMap<_, _>>();
+
         Self { chains, workers }
     }
 
@@ -31,8 +58,8 @@ impl fmt::Display for SupervisorState {
         writeln!(f, "* Chains: {}", self.chains.iter().join(", "))?;
         for (tpe, objects) in &self.workers {
             writeln!(f, "* {:?} workers:", tpe)?;
-            for object in objects {
-                writeln!(f, "  - {}", object.short_name())?;
+            for desc in objects {
+                writeln!(f, "  - {} (id: {})", desc.object.short_name(), desc.id)?;
             }
         }
 

--- a/relayer/src/worker.rs
+++ b/relayer/src/worker.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crossbeam_channel::Sender;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info};
 
 use crate::{chain::handle::ChainHandlePair, config::Config, object::Object, telemetry::Telemetry};
@@ -28,17 +29,37 @@ pub use channel::ChannelWorker;
 mod uni_chan_path;
 pub use uni_chan_path::PacketWorker;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct WorkerId(u64);
+
+impl WorkerId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+impl fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WorkerMsg {
-    Stopped(Object),
+    Stopped(WorkerId, Object),
 }
 
 /// A worker processes batches of events associated with a given [`Object`].
 pub enum Worker {
-    Client(ClientWorker),
-    Connection(ConnectionWorker),
-    Channel(ChannelWorker),
-    Packet(PacketWorker),
+    Client(WorkerId, ClientWorker),
+    Connection(WorkerId, ConnectionWorker),
+    Channel(WorkerId, ChannelWorker),
+    Packet(WorkerId, PacketWorker),
 }
 
 impl fmt::Display for Worker {
@@ -51,6 +72,7 @@ impl Worker {
     /// Spawn a worker which relays events pertaining to an [`Object`] between two `chains`.
     pub fn spawn(
         chains: ChainHandlePair,
+        id: WorkerId,
         object: Object,
         msg_tx: Sender<WorkerMsg>,
         telemetry: Telemetry,
@@ -60,46 +82,53 @@ impl Worker {
 
         debug!("spawning worker for object {}", object.short_name(),);
 
-        let worker = match object {
-            Object::Client(client) => {
-                Self::Client(ClientWorker::new(client, chains, cmd_rx, telemetry))
-            }
-            Object::Connection(connection) => {
-                Self::Connection(ConnectionWorker::new(connection, chains, cmd_rx, telemetry))
-            }
-            Object::Channel(channel) => {
-                Self::Channel(ChannelWorker::new(channel, chains, cmd_rx, telemetry))
-            }
-            Object::Packet(path) => Self::Packet(PacketWorker::new(
-                path,
-                chains,
-                cmd_rx,
-                telemetry,
-                config.global.clear_packets_interval,
-            )),
+        let worker = match &object {
+            Object::Client(client) => Self::Client(
+                id,
+                ClientWorker::new(client.clone(), chains, cmd_rx, telemetry),
+            ),
+            Object::Connection(connection) => Self::Connection(
+                id,
+                ConnectionWorker::new(connection.clone(), chains, cmd_rx, telemetry),
+            ),
+            Object::Channel(channel) => Self::Channel(
+                id,
+                ChannelWorker::new(channel.clone(), chains, cmd_rx, telemetry),
+            ),
+            Object::Packet(path) => Self::Packet(
+                id,
+                PacketWorker::new(
+                    path.clone(),
+                    chains,
+                    cmd_rx,
+                    telemetry,
+                    config.global.clear_packets_interval,
+                ),
+            ),
         };
 
         let thread_handle = std::thread::spawn(move || worker.run(msg_tx));
-        WorkerHandle::new(cmd_tx, thread_handle)
+        WorkerHandle::new(id, object, cmd_tx, thread_handle)
     }
 
     /// Run the worker event loop.
     fn run(self, msg_tx: Sender<WorkerMsg>) {
+        let id = self.id();
         let object = self.object();
-        let name = object.short_name();
+        let name = format!("{}#{}", object.short_name(), id);
 
         let result = match self {
-            Self::Client(w) => w.run(),
-            Self::Connection(w) => w.run(),
-            Self::Channel(w) => w.run(),
-            Self::Packet(w) => w.run(),
+            Self::Client(_, w) => w.run(),
+            Self::Connection(_, w) => w.run(),
+            Self::Channel(_, w) => w.run(),
+            Self::Packet(_, w) => w.run(),
         };
 
         if let Err(e) = result {
             error!("[{}] worker aborted with error: {}", name, e);
         }
 
-        if let Err(e) = msg_tx.send(WorkerMsg::Stopped(object)) {
+        if let Err(e) = msg_tx.send(WorkerMsg::Stopped(id, object)) {
             error!(
                 "[{}] failed to notify supervisor that worker stopped: {}",
                 name, e
@@ -109,21 +138,30 @@ impl Worker {
         info!("[{}] worker stopped", name);
     }
 
+    fn id(&self) -> WorkerId {
+        match self {
+            Self::Client(id, _) => *id,
+            Self::Connection(id, _) => *id,
+            Self::Channel(id, _) => *id,
+            Self::Packet(id, _) => *id,
+        }
+    }
+
     fn chains(&self) -> &ChainHandlePair {
         match self {
-            Self::Client(w) => &w.chains(),
-            Self::Connection(w) => w.chains(),
-            Self::Channel(w) => w.chains(),
-            Self::Packet(w) => w.chains(),
+            Self::Client(_, w) => &w.chains(),
+            Self::Connection(_, w) => w.chains(),
+            Self::Channel(_, w) => w.chains(),
+            Self::Packet(_, w) => w.chains(),
         }
     }
 
     fn object(&self) -> Object {
         match self {
-            Worker::Client(w) => w.object().clone().into(),
-            Worker::Connection(w) => w.object().clone().into(),
-            Worker::Channel(w) => w.object().clone().into(),
-            Worker::Packet(w) => w.object().clone().into(),
+            Worker::Client(_, w) => w.object().clone().into(),
+            Worker::Connection(_, w) => w.object().clone().into(),
+            Worker::Channel(_, w) => w.object().clone().into(),
+            Worker::Packet(_, w) => w.object().clone().into(),
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug @adizere found today, where the supervisor would attempt to shutdown a worker
that had already been shutdown and replaced with a new worker. As the new worker was not
instructed to shutdown, the supervisor would hang waiting for it to exit.

In more details:

- Say we have a packet worker A for object O between ibc-0 and ibc-1
- After updating the config of ibc-0, we trigger a config reload
- The supervisor first shuts down worker A, and waits for its event loop to exit
- Worker A exits, and sends a `Stopped(O)` message to the supervisor
- The supervisor now spawns a new worker B for object O
- The supervisor now processes the `Stopped(O)` message previously sent by worker A,
   and waits for the worker associated with object O, ie. now worker B, to finish
- As worker B has never been instructed to shutdown, nor should it, the supervisor hangs
  waiting for it to exit.

This PR solves this issue by:
- introducing unique identifiers for each worker (currently an incrementing `u64`)
- sending the worker id alongside the object in the `Stopped` message
- only acting on worker `ID` when receiving a `Stopped(ID, OBJECT)` message

Additionally, the `SIGUSR1` signal will now also show the worker's ids when dumping the supervisor state.
