### PR TITLE
Clear packets on hermes start

### DIFF
--- a/e2e/run.py
+++ b/e2e/run.py
@@ -84,16 +84,6 @@ def passive_packets(
     sleep(10.0)
 
     # 6. verify that there are no pending packets
-    # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
-    packet.packet_send(c, src=ibc1, dst=ibc0 , src_port=port_id,
-                       src_channel=ibc1_channel_id, amount=10000, height_offset=1000, number_msgs=3)
-
-    # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
-    packet.packet_send(c, src=ibc0, dst=ibc1, src_port=port_id,
-                       src_channel=ibc0_channel_id, amount=10000, height_offset=1000, number_msgs=4)
-
-    sleep(10.0)
-
     # hermes query packet unreceived-packets ibc-1 transfer channel-1
     unreceived = packet.query_unreceived_packets(
         c, chain=ibc1, port=port_id, channel=ibc1_channel_id)
@@ -122,7 +112,45 @@ def passive_packets(
     assert (len(unreceived) == 0), (unreceived,
                                     "unreceived acks mismatch (expected 0)")
 
-    # 7.Stop the relayer
+    # 7. send some packets
+    # hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-1 10000 1000 -n 3
+    packet.packet_send(c, src=ibc1, dst=ibc0 , src_port=port_id,
+                       src_channel=ibc1_channel_id, amount=10000, height_offset=1000, number_msgs=3)
+
+    # hermes tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 10000 1000 -n 4
+    packet.packet_send(c, src=ibc0, dst=ibc1, src_port=port_id,
+                       src_channel=ibc0_channel_id, amount=10000, height_offset=1000, number_msgs=4)
+
+    sleep(10.0)
+    # 8. verify that there are no pending packets
+    # hermes query packet unreceived-packets ibc-1 transfer channel-1
+    unreceived = packet.query_unreceived_packets(
+        c, chain=ibc1, port=port_id, channel=ibc1_channel_id)
+
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived packets mismatch (expected 0)")
+
+    # hermes query packet unreceived-acks ibc-1 transfer channel-1
+    unreceived = packet.query_unreceived_acks(
+        c, chain=ibc1, port=port_id, channel=ibc1_channel_id)
+
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived acks mismatch (expected 0)")
+
+    # hermes query packet unreceived-packets ibc-0 transfer channel-0
+    unreceived = packet.query_unreceived_packets(
+        c, chain=ibc0 , port=port_id, channel=ibc0_channel_id)
+
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived packets mismatch (expected 0)")
+
+    # hermes query packet unreceived-acks ibc-0 transfer channel-0
+    unreceived = packet.query_unreceived_acks(
+        c, chain=ibc0 , port=port_id, channel=ibc0_channel_id)
+
+    assert (len(unreceived) == 0), (unreceived,
+                                    "unreceived acks mismatch (expected 0)")
+    # 9.Stop the relayer
     proc.kill()
 
 
@@ -215,7 +243,6 @@ def main():
 
     passive_packets(config, ibc0, ibc1, port_id, ibc0_chan_id, ibc1_chan_id)
     sleep(2.0)
-
 
     connection.passive_connection_init_then_start(config, ibc1, ibc0, ibc1_client_id, ibc0_client_id)
     sleep(2.0)

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -261,12 +261,16 @@ impl RelayPath {
         Err(LinkError::OldPacketClearingFailed)
     }
 
+    pub fn clear_packets(&self) -> bool {
+        self.clear_packets
+    }
+
     /// Queries the source chain at the given [`Height`]
     /// to find any packets or acknowledgements that are pending,
     /// and fetches the relevant packet event data. Finally, this
     /// method also schedules the corresponding operational data,
     /// so that the relayer will later relay the pending packets.
-    pub fn clear_packets(&mut self, above_height: Height) -> Result<(), LinkError> {
+    pub fn do_clear_packets(&mut self, above_height: Height) -> Result<(), LinkError> {
         info!(
             "[{}] clearing pending packets from events before height {}",
             self, above_height
@@ -294,7 +298,7 @@ impl RelayPath {
     pub fn update_schedule(&mut self, batch: EventBatch) -> Result<(), LinkError> {
         // With the first batch of events, also trigger the clearing of old packets.
         if self.clear_packets {
-            self.clear_packets(batch.height)?;
+            self.do_clear_packets(batch.height)?;
 
             // Disable further clearing of old packet.
             // Clearing will happen separately, upon new blocks.

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -109,12 +109,13 @@ impl PacketWorker {
                     height,
                     new_block: _,
                 } => {
-                    // Schedule the clearing of pending packets
+                    // Schedule the clearing of pending packets at start and
                     // at predefined block intervals.
-                    if self.clear_packets_interval != 0
-                        && height.revision_height % self.clear_packets_interval == 0
+                    if link.a_to_b.clear_packets()
+                        || self.clear_packets_interval != 0
+                            && height.revision_height % self.clear_packets_interval == 0
                     {
-                        link.a_to_b.clear_packets(height)
+                        link.a_to_b.do_clear_packets(height)
                     } else {
                         Ok(())
                     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1200
Partially closes: #1196

## Description
Hermes does not clear packets on start if there are no IBC events and no `clear_packets_interval` trigger.
The e2e script masks this error because it sends some packets, starts hermes and then sends more packets (issue masked here because this triggers packet clearing) before checking that all packets are cleared. 

- [x] Fixed script to catch the bug
- [x] Fixed the bug

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.