### PR TITLE
Omit git branch name in the Hermes version

### DIFF
--- a/relayer-cli/build.rs
+++ b/relayer-cli/build.rs
@@ -20,8 +20,6 @@ fn version() -> String {
         if let Some(git) = GitHandle::new() {
             println!("cargo:rustc-rerun-if-changed=.git/HEAD");
             vers.push('+');
-            vers.push_str(&git.branch());
-            vers.push('-');
             vers.push_str(&git.last_commit_hash());
             if git.is_dirty() {
                 vers.push_str("-dirty");
@@ -52,24 +50,6 @@ mod git {
             } else {
                 None
             }
-        }
-
-        // Returns the current branch as a string - if the branch name has a '/' returns part after
-        // the last '/'
-        pub fn branch(&self) -> String {
-            let branch = Self::command(&["rev-parse", "--abbrev-ref", "HEAD"]);
-            let branch_str = String::from_utf8_lossy(&branch.stdout);
-            branch_str
-                .contains('/')
-                .then(|| {
-                    branch_str
-                        .split('/')
-                        .collect::<Vec<&str>>()
-                        .last()
-                        .unwrap()
-                        .to_string()
-                })
-                .unwrap_or_else(|| branch_str.into())
         }
 
         // Returns the short hash of the last git commit


### PR DESCRIPTION
Closes: #XXX

## Description

Running the `help` command when on a Git branch which contains invalid [build metadata as per semver](https://docs.rs/semver/1.0.3/semver/struct.BuildMetadata.html#syntax) triggers the following error:

```
$ cargo run --bin hermes -- -c ~/.hermes/config.toml help
   Compiling ibc-relayer v0.6.0 (/Users/ancaz/rust/ibc-rs/relayer)
   Compiling ibc-relayer-cli v0.6.0 (/Users/ancaz/rust/ibc-rs/relayer-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 23.85s
     Running `target/debug/hermes -c /Users/ancaz/.hermes/config.toml help`
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: ParseError("Extra junk after valid version: _on_start-872a5030")
Location: relayer-cli/src/components.rs:61
Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Since not all branch names are valid build metadata identifiers, let's remove the branch name from the version altogether and only keep the commit hash and the `-dirty` suffix.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.