### PR TITLE
Publicly export `CreateClient` message's attributes

### DIFF
--- a/modules/src/ics02_client/events.rs
+++ b/modules/src/ics02_client/events.rs
@@ -137,7 +137,7 @@ impl std::fmt::Display for Attributes {
 
 /// CreateClient event signals the creation of a new on-chain client (IBC client).
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct CreateClient(Attributes);
+pub struct CreateClient(pub Attributes);
 
 impl CreateClient {
     pub fn client_id(&self) -> &ClientId {


### PR DESCRIPTION
Enable CreateClient Type public inner type.
Relate pr: https://github.com/octopus-network/substrate-ibc/pull/29,  used these features. 
______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.