### PR TITLE
Increase sleep time in end-to-end test to wait for relaying unreceived packets

### DIFF
--- a/e2e/run.py
+++ b/e2e/run.py
@@ -81,7 +81,7 @@ def passive_packets(
     proc = relayer.start(c)
 
     # 5. wait for the relayer to initialize and pick up pending packets
-    sleep(10.0)
+    sleep(20.0)
 
     # 6. verify that there are no pending packets
     # hermes query packet unreceived-packets ibc-1 transfer channel-1


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1216

## Description

This increases the sleep time from 10 seconds to 20 seconds, which hopefully provides enough time for the relayer to relay all packets during the CI end-to-end tests.

______

For contributor use:

- [ ] Updated the __Unreleased__ section of [CHANGELOG.md](https://github.com/informalsystems/ibc-rs/blob/master/CHANGELOG.md) with the issue.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.