### PR TITLE
Release Hermes v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ being closed under its feet by Tendermint.
 
 Upgrading from version `0.6.0` to `0.6.1` requires no explicit steps.
 
-> **WARNING:** Due to a regression ([#1229]), the `upgrade client`
-> and `tx raw upgrade-chain` commands have been temporarily disabled
-> in this version. They will be re-enabled in the next version.
+> **WARNING:** Due to a regression ([#1229]), the `upgrade client`,
+> `tx raw upgrade-clients`, and `tx raw upgrade-chain` commands have
+> been temporarily disabled in this version.
+> These commands will be re-enabled in the next version.
 
 ### FEATURES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@
 ## v0.6.1
 *July 22nd, 2021*
 
-This minor release adds a new `upgrade-clients` command to Hermes
-to upgrade multiple IBC clients at once, and improves the reliability
-of the relayer by ensuring that pending packets are cleared on start,
+This minor release mainly improves the reliability of the relayer
+by ensuring that pending packets are cleared on start,
 and that Hermes can recover from the WebSocket subscriptions
 being closed under its feet by Tendermint.
 
@@ -21,9 +20,6 @@ Upgrading from version `0.6.0` to `0.6.1` requires no explicit steps.
   - Enable `pub` access to verification methods of ICS 03 & 04 ([#1198])
   - Add `ics26_routing::handler::decode` function ([#1194])
   - Add a pseudo root to `MockConsensusState` ([#1215])
-
-- [ibc-relayer-cli]
-  - Added `upgrade clients` CLI ([#763])
 
 ### IMPROVEMENTS
 
@@ -136,7 +132,6 @@ The full list of changes is described below.
 [#69]: https://github.com/informalsystems/ibc-rs/issues/69
 [#600]: https://github.com/informalsystems/ibc-rs/issues/600
 [#697]: https://github.com/informalsystems/ibc-rs/issues/697
-[#763]: https://github.com/informalsystems/ibc-rs/issues/763
 [#1062]: https://github.com/informalsystems/ibc-rs/issues/1062
 [#1117]: https://github.com/informalsystems/ibc-rs/issues/1117
 [#1057]: https://github.com/informalsystems/ibc-rs/issues/1057

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ being closed under its feet by Tendermint.
 
 Upgrading from version `0.6.0` to `0.6.1` requires no explicit steps.
 
+> **WARNING:** Due to a regression ([#1229]), the `upgrade client`
+> and `tx raw upgrade-chain` commands have been temporarily disabled
+> in this version. They will be re-enabled in the next version.
+
 ### FEATURES
 
 - [ibc]
@@ -46,6 +50,7 @@ Upgrading from version `0.6.0` to `0.6.1` requires no explicit steps.
 [#1198]: https://github.com/informalsystems/ibc-rs/issues/1198
 [#1200]: https://github.com/informalsystems/ibc-rs/issues/1200
 [#1215]: https://github.com/informalsystems/ibc-rs/issues/1215
+[#1229]: https://github.com/informalsystems/ibc-rs/issues/1229
 
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Upgrading from version `0.6.0` to `0.6.1` requires no explicit steps.
   - Add a pseudo root to `MockConsensusState` ([#1215])
 
 - [ibc-relayer-cli]
-  - Added `upgrade-clients` CLI ([#763])
+  - Added `upgrade clients` CLI ([#763])
 
 ### IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ of the relayer by ensuring that pending packets are cleared on start,
 and that Hermes can recover from the WebSocket subscriptions
 being closed under its feet by Tendermint.
 
+Upgrading from version `0.6.0` to `0.6.1` requires no explicit steps.
+
 ### FEATURES
 
 - [ibc]
@@ -47,6 +49,7 @@ being closed under its feet by Tendermint.
 [#1196]: https://github.com/informalsystems/ibc-rs/issues/1196
 [#1198]: https://github.com/informalsystems/ibc-rs/issues/1198
 [#1200]: https://github.com/informalsystems/ibc-rs/issues/1200
+[#1215]: https://github.com/informalsystems/ibc-rs/issues/1215
 
 
 ## v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## UNRELEASED
+## Unreleased
+
+> Nothing yet
+
+## v0.6.1
+*July 22nd, 2021*
+
+This minor release adds a new `upgrade-clients` command to Hermes
+to upgrade multiple IBC clients at once, and improves the reliability
+of the relayer by ensuring that pending packets are cleared on start,
+and that Hermes can recover from the WebSocket subscriptions
+being closed under its feet by Tendermint.
 
 ### FEATURES
 
@@ -25,7 +36,7 @@
   - Align `as_str` and `from_str` behavior in `ClientType` ([#1192])
 
 - [ibc-relayer]
-  - Fixed: Hermes does not clear packets on start ([#1200])
+  - Ensure pending packets are cleared on start ([#1200])
   - Recover from missed RPC events after WebSocket subscription is closed by Tendermint ([#1196])
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anomaly",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,27 +215,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
-
-[[package]]
-name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
-
-[[package]]
-name = "bitcoin"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6742ec672d3f12506f4ac5c0d853926ff1f94e675f60ffd3224039972bf663f1"
-dependencies = [
- "bech32 0.7.3",
- "bitcoin_hashes 0.9.7",
- "secp256k1",
- "serde",
-]
 
 [[package]]
 name = "bitcoin"
@@ -243,17 +225,9 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a427b27dae305157520d86673f2393b3eb08d880609abfcffc6e3c3c820e764"
 dependencies = [
- "bech32 0.8.1",
- "bitcoin_hashes 0.10.0",
+ "bech32",
+ "bitcoin_hashes",
  "secp256k1",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
-dependencies = [
  "serde",
 ]
 
@@ -262,6 +236,9 @@ name = "bitcoin_hashes"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1140,7 +1117,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72adf5a17a0952ecfcddf8d46d071271d5ee52e78443f07ba0b2dcfe3063a132"
 dependencies = [
- "bitcoin 0.27.0",
+ "bitcoin",
  "byteorder",
 ]
 
@@ -1385,8 +1362,8 @@ dependencies = [
  "anomaly",
  "async-stream",
  "async-trait",
- "bech32 0.8.1",
- "bitcoin 0.26.2",
+ "bech32",
+ "bitcoin",
  "bytes",
  "crossbeam-channel 0.5.1",
  "dirs-next",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anomaly",
  "bytes",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-relayer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anomaly",
  "async-stream",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-relayer-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "abscissa_core",
  "anomaly",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-telemetry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "ibc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,9 +232,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6742ec672d3f12506f4ac5c0d853926ff1f94e675f60ffd3224039972bf663f1"
 dependencies = [
  "bech32 0.7.3",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.9.7",
  "secp256k1",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a427b27dae305157520d86673f2393b3eb08d880609abfcffc6e3c3c820e764"
+dependencies = [
+ "bech32 0.8.1",
+ "bitcoin_hashes 0.10.0",
+ "secp256k1",
 ]
 
 [[package]]
@@ -245,6 +256,12 @@ checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
 
 [[package]]
 name = "bitflags"
@@ -1123,7 +1140,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72adf5a17a0952ecfcddf8d46d071271d5ee52e78443f07ba0b2dcfe3063a132"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.27.0",
  "byteorder",
 ]
 
@@ -1248,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1350,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anomaly",
  "bytes",
@@ -1369,7 +1386,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bech32 0.8.1",
- "bitcoin",
+ "bitcoin 0.26.2",
  "bytes",
  "crossbeam-channel 0.5.1",
  "dirs-next",
@@ -2910,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3219,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3234,9 +3251,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",

--- a/guide/README.md
+++ b/guide/README.md
@@ -11,7 +11,7 @@ mdBook is a utility to create modern online books from Markdown files.
 This guide should be permanently deployed at its latest stable version at 
 [hermes.informal.systems](https://hermes.informal.systems).
 
-Current version: `0.6.0`.
+Current version: `0.6.1`.
 
 The version of this guide is aligned with the [versioning of the ibc crates](../README.md).
 

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-# Hermes (v0.6.0)
+# Hermes (v0.6.1)
 
 ---
 - [Introduction](./index.md)

--- a/guide/src/commands/global.md
+++ b/guide/src/commands/global.md
@@ -3,7 +3,7 @@
 Hermes accepts global options which affect all commands.
 
 ```shell
-hermes 0.6.0
+hermes 0.6.1
 Informal Systems <hello@informal.systems>
 Implementation of `hermes`, an IBC Relayer developed in Rust.
 

--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -27,7 +27,7 @@ The configuration file must have one `global` section, and one `chains` section 
 > **Note:** As of 0.6.0, the Hermes configuration file is self-documented.
 > This section of the guide which discusses each parameter in turn is no
 > longer maintained, and we may remove it soon. Please read the configuration
-> file [`config.toml`](https://github.com/informalsystems/ibc-rs/blob/v0.6.0/config.toml) itself for the most up-to-date documentation of parameters.
+> file [`config.toml`](https://github.com/informalsystems/ibc-rs/blob/v0.6.1/config.toml) itself for the most up-to-date documentation of parameters.
 
 ### `[global]`
 
@@ -183,10 +183,10 @@ trust_threshold = { numerator = '1', denominator = '3' }
 
 ## Update the configuration without restarting Hermes
 
-Before Hermes 0.6.0, the only way to get Hermes to pick up a change in the
+Before Hermes 0.6.1, the only way to get Hermes to pick up a change in the
 configuration was to stop and restart Hermes.
 
-As of version 0.6.0, Hermes will react to receiving a `SIGHUP` signal
+As of version 0.6.1, Hermes will react to receiving a `SIGHUP` signal
 by reloading the `[chains]` section of the configuration, and
 stopping, starting or restarting the affected workers.
 

--- a/guide/src/help.md
+++ b/guide/src/help.md
@@ -39,7 +39,7 @@ hermes help create
 will provide details about all the valid invocations of the `create` CLI command.
 
 ```
-hermes 0.6.0
+hermes 0.6.1
 Informal Systems <hello@informal.systems>
 Hermes is an IBC Relayer written in Rust.
 
@@ -63,7 +63,7 @@ hermes help create channel
 ```
 
 ```
-hermes 0.6.0
+hermes 0.6.1
 Informal Systems <hello@informal.systems>
 Hermes is an IBC Relayer written in Rust.
 

--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -1,4 +1,4 @@
-# Hermes Guide (v0.6.0)
+# Hermes Guide (v0.6.1)
 
 This guide can help you setup, configure, and operate Hermes to transfer
 packets between two IBC enabled chains.

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -14,8 +14,8 @@ There are two main approaches for obtaining Hermes:
 
 Simply head to the GitHub [Releases][releases] page and download the latest
 version of Hermes binary matching your platform:
-- MacOS: `hermes-v0.6.0-x86_64-apple-darwin.tar.gz` (or .zip),
-- Linux: `hermes-v0.6.0-x86_64-unknown-linux-gnu.tar.gz` (or .zip).
+- MacOS: `hermes-v0.6.1-x86_64-apple-darwin.tar.gz` (or .zip),
+- Linux: `hermes-v0.6.1-x86_64-unknown-linux-gnu.tar.gz` (or .zip).
 
 The step-by-step instruction below should carry you through the whole process:
  
@@ -47,7 +47,7 @@ hermes version
 ```
 
 ```
-hermes 0.6.0
+hermes 0.6.1
 ```
 
 ## Install via Cargo
@@ -81,7 +81,7 @@ hermes version
 ```
 
 ```
-hermes 0.6.0
+hermes 0.6.1
 ```
 
 ## Build from source
@@ -103,10 +103,10 @@ cd ibc-rs
 
 Go to the [ibc-rs releases](https://github.com/informalsystems/ibc-rs/releases) page to see what is the most recent release.
 
-Then checkout the release, for example if the most recent release is `v0.6.0` then execute the command:
+Then checkout the release, for example if the most recent release is `v0.6.1` then execute the command:
 
 ```shell
-git checkout v0.6.0
+git checkout v0.6.1
 ```
 
 ### Building with `cargo build`
@@ -151,7 +151,7 @@ If you run the `hermes` without any additional parameters you should see the usa
 ```
 
 ```
-hermes 0.6.0
+hermes 0.6.1
 Informal Systems <hello@informal.systems>
 
 USAGE:

--- a/guide/src/tutorials/local-chains/start.md
+++ b/guide/src/tutorials/local-chains/start.md
@@ -8,7 +8,7 @@ To this end, clone the `ibc-rs` repository and check out the current version:
 ```bash
 git clone git@github.com:informalsystems/ibc-rs.git
 cd ibc-rs
-git checkout v0.6.0
+git checkout v0.6.1
 ```
 
 ### Stop existing `gaiad` processes

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -20,7 +20,7 @@ mocks = [ "tendermint-testgen", "sha2" ]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.8.0", path = "../proto" }
+ibc-proto = { version = "0.9.0", path = "../proto" }
 ics23 = "0.6.5"
 anomaly = "0.2.0"
 chrono = "0.4.19"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "ibc"
-version    = "0.6.0"
+version    = "0.6.1"
 edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "ibc-proto"
-version    = "0.8.3"
+version    = "0.9.0"
 authors    = ["Informal Systems <hello@informal.systems>"]
 edition    = "2018"
 license    = "Apache-2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "ibc-proto"
-version    = "0.8.2"
+version    = "0.8.3"
 authors    = ["Informal Systems <hello@informal.systems>"]
 edition    = "2018"
 license    = "Apache-2.0"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -24,7 +24,7 @@ telemetry = ["ibc-relayer/telemetry", "ibc-telemetry"]
 [dependencies]
 ibc           = { version = "0.6.1", path = "../modules" }
 ibc-relayer   = { version = "0.6.1", path = "../relayer" }
-ibc-proto     = { version = "0.8.3", path = "../proto" }
+ibc-proto     = { version = "0.9.0", path = "../proto" }
 ibc-telemetry = { version = "0.6.1", path = "../telemetry", optional = true }
 
 anomaly = "0.2.0"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -24,7 +24,7 @@ telemetry = ["ibc-relayer/telemetry", "ibc-telemetry"]
 [dependencies]
 ibc           = { version = "0.6.1", path = "../modules" }
 ibc-relayer   = { version = "0.6.1", path = "../relayer" }
-ibc-proto     = { version = "0.8.2", path = "../proto" }
+ibc-proto     = { version = "0.8.3", path = "../proto" }
 ibc-telemetry = { version = "0.6.1", path = "../telemetry", optional = true }
 
 anomaly = "0.2.0"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "ibc-relayer-cli"
-version    = "0.6.0"
+version    = "0.6.1"
 edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -22,10 +22,10 @@ profiling = ["ibc-relayer/profiling"]
 telemetry = ["ibc-relayer/telemetry", "ibc-telemetry"]
 
 [dependencies]
-ibc           = { version = "0.6.0", path = "../modules" }
-ibc-relayer   = { version = "0.6.0", path = "../relayer" }
+ibc           = { version = "0.6.1", path = "../modules" }
+ibc-relayer   = { version = "0.6.1", path = "../relayer" }
 ibc-proto     = { version = "0.8.2", path = "../proto" }
-ibc-telemetry = { version = "0.6.0", path = "../telemetry", optional = true }
+ibc-telemetry = { version = "0.6.1", path = "../telemetry", optional = true }
 
 anomaly = "0.2.0"
 gumdrop = { version = "0.7", features = ["default_expr"] }

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -187,7 +187,15 @@ pub struct TxUpgradeClientsCmd {
 }
 
 impl Runnable for TxUpgradeClientsCmd {
+    #[allow(unreachable_code)]
     fn run(&self) {
+        tracing::error!("This command is currently disabled due to a regression in Hermes v0.6.1.");
+        tracing::error!("Please track the following issue for background and progress:");
+        tracing::error!("");
+        tracing::error!("    https://github.com/informalsystems/ibc-rs/issues/1229");
+
+        std::process::exit(1);
+
         let config = app_config();
         let src_chain = match spawn_chain_runtime(&config, &self.src_chain_id) {
             Ok(handle) => handle,

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -131,7 +131,15 @@ pub struct TxUpgradeClientCmd {
 }
 
 impl Runnable for TxUpgradeClientCmd {
+    #[allow(unreachable_code)]
     fn run(&self) {
+        tracing::error!("This command is currently disabled due to a regression in Hermes v0.6.1.");
+        tracing::error!("Please track the following issue for background and progress:");
+        tracing::error!("");
+        tracing::error!("    https://github.com/informalsystems/ibc-rs/issues/1229");
+
+        std::process::exit(1);
+
         let config = app_config();
 
         let dst_chain = match spawn_chain_runtime(&config, &self.chain_id) {

--- a/relayer-cli/src/commands/tx/upgrade.rs
+++ b/relayer-cli/src/commands/tx/upgrade.rs
@@ -64,7 +64,15 @@ impl TxUpgradeChainCmd {
 }
 
 impl Runnable for TxUpgradeChainCmd {
+    #[allow(unreachable_code)]
     fn run(&self) {
+        tracing::error!("This command is currently disabled due to a regression in Hermes v0.6.1.");
+        tracing::error!("Please track the following issue for background and progress:");
+        tracing::error!("");
+        tracing::error!("    https://github.com/informalsystems/ibc-rs/issues/1229");
+
+        std::process::exit(1);
+
         let config = app_config();
 
         let opts = match self.validate_options(&config) {

--- a/relayer-cli/src/commands/upgrade.rs
+++ b/relayer-cli/src/commands/upgrade.rs
@@ -2,7 +2,7 @@
 
 use abscissa_core::{Command, Help, Options, Runnable};
 
-use crate::commands::tx::client::{TxUpgradeClientCmd, TxUpgradeClientsCmd};
+use crate::commands::tx::client::TxUpgradeClientCmd;
 
 #[derive(Command, Debug, Options, Runnable)]
 pub enum UpgradeCmds {
@@ -13,8 +13,10 @@ pub enum UpgradeCmds {
     /// Subcommand for upgrading a `client`
     #[options(help = "Upgrade an IBC client")]
     Client(TxUpgradeClientCmd),
-
-    /// Subcommand for upgrading all `client`s that target specified chain
-    #[options(help = "Upgrade all IBC clients that target a specific chain")]
-    Clients(TxUpgradeClientsCmd),
+    //
+    // NOTE: This command is disabled until https://github.com/informalsystems/ibc-rs/issues/1229 is fixed.
+    //
+    // /// Subcommand for upgrading all `client`s that target specified chain
+    // #[options(help = "Upgrade all IBC clients that target a specific chain")]
+    // Clients(TxUpgradeClientsCmd),
 }

--- a/relayer-cli/src/error.rs
+++ b/relayer-cli/src/error.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 pub type Error = anomaly::Error<Kind>;
 
 /// Kinds of errors
-#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum Kind {
     /// Error in configuration file
     #[error("config error")]
@@ -16,6 +16,10 @@ pub enum Kind {
     /// Input/output error
     #[error("I/O error")]
     Io,
+
+    /// Input/output error
+    #[error("CLI argument error: {0}")]
+    CliArg(String),
 
     /// Error during network query
     #[error("query error")]

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -18,7 +18,7 @@ telemetry = ["ibc-telemetry"]
 
 [dependencies]
 ibc           = { version = "0.6.1", path = "../modules" }
-ibc-proto     = { version = "0.8.3", path = "../proto" }
+ibc-proto     = { version = "0.9.0", path = "../proto" }
 ibc-telemetry = { version = "0.6.1", path = "../telemetry", optional = true }
 
 subtle-encoding = "0.5"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -43,7 +43,7 @@ k256 = { version = "0.9.5", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
 bitcoin = { version = "=0.26", features = ["use-serde"] }
 tiny-bip39 = "0.8.0"
-hdpath = { version = "0.6.1", features = ["with-bitcoin"] }
+hdpath = { version = "0.6.0", features = ["with-bitcoin"] }
 sha2 = "0.9.3"
 ripemd160 = "0.9.1"
 bech32 = "0.8.1"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "ibc-relayer"
-version    = "0.6.0"
+version    = "0.6.1"
 edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -17,9 +17,9 @@ profiling = []
 telemetry = ["ibc-telemetry"]
 
 [dependencies]
-ibc           = { version = "0.6.0", path = "../modules" }
+ibc           = { version = "0.6.1", path = "../modules" }
 ibc-proto     = { version = "0.8.2", path = "../proto" }
-ibc-telemetry = { version = "0.6.0", path = "../telemetry", optional = true }
+ibc-telemetry = { version = "0.6.1", path = "../telemetry", optional = true }
 
 subtle-encoding = "0.5"
 anomaly = "0.2.0"
@@ -43,7 +43,7 @@ k256 = { version = "0.9.5", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
 bitcoin = { version = "=0.26", features = ["use-serde"] }
 tiny-bip39 = "0.8.0"
-hdpath = { version = "0.6.0", features = ["with-bitcoin"] }
+hdpath = { version = "0.6.1", features = ["with-bitcoin"] }
 sha2 = "0.9.3"
 ripemd160 = "0.9.1"
 bech32 = "0.8.1"
@@ -72,7 +72,7 @@ features = ["unstable"]
 version = "=0.21.0"
 
 [dev-dependencies]
-ibc = { version = "0.6.0", path = "../modules", features = ["mocks"] }
+ibc = { version = "0.6.1", path = "../modules", features = ["mocks"] }
 serial_test = "0.5.0"
 env_logger = "0.9.0"
 tracing-subscriber = "0.2.19"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -41,7 +41,7 @@ futures = "0.3.14"
 crossbeam-channel = "0.5.1"
 k256 = { version = "0.9.5", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
-bitcoin = { version = "=0.26", features = ["use-serde"] }
+bitcoin = { version = "=0.27", features = ["use-serde"] }
 tiny-bip39 = "0.8.0"
 hdpath = { version = "0.6.0", features = ["with-bitcoin"] }
 sha2 = "0.9.3"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -18,7 +18,7 @@ telemetry = ["ibc-telemetry"]
 
 [dependencies]
 ibc           = { version = "0.6.1", path = "../modules" }
-ibc-proto     = { version = "0.8.2", path = "../proto" }
+ibc-proto     = { version = "0.8.3", path = "../proto" }
 ibc-telemetry = { version = "0.6.1", path = "../telemetry", optional = true }
 
 subtle-encoding = "0.5"

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -536,7 +536,10 @@ impl Supervisor {
 
         let result = match batch.unwrap_or_clone() {
             Ok(batch) => self.process_batch(chain, batch),
-            Err(EventError::SubscriptionCancelled(_)) => self.clear_pending_packets(&chain_id),
+            Err(EventError::SubscriptionCancelled(_)) => {
+                warn!(chain.id = %chain_id, "event subscription was cancelled, clearing pending packets");
+                self.clear_pending_packets(&chain_id)
+            }
             Err(e) => Err(e.into()),
         };
 

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "ibc-telemetry"
-version    = "0.6.0"
+version    = "0.6.1"
 edition    = "2018"
 license    = "Apache-2.0"
 readme     = "README.md"
@@ -13,7 +13,7 @@ description = """
 """
 
 [dependencies]
-ibc = { version = "0.6.0", path = "../modules" }
+ibc = { version = "0.6.1", path = "../modules" }
 
 crossbeam-channel        = "0.5.1"
 once_cell                = "1.8.0"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1224

## Guide updates

- [ ] #1077 (@romac)

> Postponed due to #1229 

- [X] Fix for `unwrap` in the `query tx events` CLI (@adizere)

####  Problem with `unwrap` in the `query tx events` CLI 

This unwrap can provoke a panic in case an invalid hash is provided to the CLI:

https://github.com/informalsystems/ibc-rs/blob/47899196c271f523a1db395202d77072beaa0593/relayer-cli/src/commands/query/tx/events.rs#L48

Example:

> $ hermes query tx events ibc-0 bb
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: Context { kind: Parse, source: Some("hash length"), backtrace: Some(   0: backtrace::backtrace::libunwind::trace
...
Location: relayer-cli/src/commands/query/tx/events.rs:48

After fix (ec9c7050fc68c6ff0e11f45245278e276cc4502f):

> $ hermes query tx events ibc-0 bb
Error: CLI argument error: could not parse 'bb' into a valid hash: parse error: hash length