### PR TITLE
Add LegacyError type to replace BoxError in no-std mode

### DIFF
--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -16,10 +16,11 @@ description = """
 [features]
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
-default = ["std", "eyre_tracer"]
+default = ["std", "eyre_tracer", "std_err"]
 std = [
     "flex-error/std"
 ]
+std_err = []
 eyre_tracer = ["flex-error/eyre_tracer"]
 mocks = [ "tendermint-testgen", "sha2" ]
 

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -112,7 +112,7 @@ pub struct LegacyError {
 
 impl Display for LegacyError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "LegacyError: {}", self.to_string())
+        write!(f, "LegacyError: {}", self.error.to_string())
     }
 }
 

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -94,12 +94,12 @@ impl TryFrom<RawHeader> for Header {
                 .signed_header
                 .ok_or_else(Error::missing_signed_header)?
                 .try_into()
-                .map_err(|e| Error::invalid_header("signed header conversion".to_string(), e))?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | Error::invalid_header("signed header conversion".to_string(), e.into()))?,
             validator_set: raw
                 .validator_set
                 .ok_or_else(Error::missing_validator_set)?
                 .try_into()
-                .map_err(Error::invalid_raw_header)?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | Error::invalid_raw_header(e.into()))?,
             trusted_height: raw
                 .trusted_height
                 .ok_or_else(Error::missing_trusted_height)?
@@ -108,7 +108,7 @@ impl TryFrom<RawHeader> for Header {
                 .trusted_validators
                 .ok_or_else(Error::missing_trusted_validator_set)?
                 .try_into()
-                .map_err(Error::invalid_raw_header)?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | Error::invalid_raw_header(e.into()))?,
         })
     }
 }

--- a/modules/src/ics07_tendermint/header.rs
+++ b/modules/src/ics07_tendermint/header.rs
@@ -94,12 +94,16 @@ impl TryFrom<RawHeader> for Header {
                 .signed_header
                 .ok_or_else(Error::missing_signed_header)?
                 .try_into()
-                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | Error::invalid_header("signed header conversion".to_string(), e.into()))?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync>| {
+                    Error::invalid_header("signed header conversion".to_string(), e.into())
+                })?,
             validator_set: raw
                 .validator_set
                 .ok_or_else(Error::missing_validator_set)?
                 .try_into()
-                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | Error::invalid_raw_header(e.into()))?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync>| {
+                    Error::invalid_raw_header(e.into())
+                })?,
             trusted_height: raw
                 .trusted_height
                 .ok_or_else(Error::missing_trusted_height)?
@@ -108,7 +112,9 @@ impl TryFrom<RawHeader> for Header {
                 .trusted_validators
                 .ok_or_else(Error::missing_trusted_validator_set)?
                 .try_into()
-                .map_err(|e: Box<dyn std::error::Error + Send + Sync> | Error::invalid_raw_header(e.into()))?,
+                .map_err(|e: Box<dyn std::error::Error + Send + Sync>| {
+                    Error::invalid_raw_header(e.into())
+                })?,
         })
     }
 }


### PR DESCRIPTION
> I'd propose that we define a type like LegacyError, which is either a newtype wrapper to Box<dyn std::error::Error> in std mode, or a newtype wrapper to String in no-std mode. By always using a newtype wrapper, we can avoid accidental implicit coercion from Box<dyn std::error::Error> to LegacyError in std mode, which will prevent no-std mode to work.

Relate issue: https://github.com/informalsystems/ibc-rs/issues/1158
Relate Pr: https://github.com/informalsystems/ibc-rs/pull/1167
