### PR TITLE
Add `Protobuf` impl for `ics03_connection::connection::Counterparty`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1247-add-missing-protobuf-impl.md
+++ b/.changelog/unreleased/bug-fixes/1247-add-missing-protobuf-impl.md
@@ -1,0 +1,3 @@
+- Add missing `Protobuf` impl for `ics03_connection::connection::Counterparty` ([#1247])
+
+[#1247]: https://github.com/informalsystems/ibc-rs/issues/1247

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## UNRELEASED
+
+### BUG FIXES
+
+- [ibc]
+  - Add Protobuf for Counterparty ([#1247])
+
 ## v0.6.1
 *July 22nd, 2021*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # CHANGELOG
 
-## UNRELEASED
-
-### BUG FIXES
-
-- [ibc]
-  - Add Protobuf for Counterparty ([#1247])
-
 ## v0.6.1
 *July 22nd, 2021*
 

--- a/modules/src/ics03_connection/connection.rs
+++ b/modules/src/ics03_connection/connection.rs
@@ -251,6 +251,8 @@ impl Default for Counterparty {
     }
 }
 
+impl Protobuf<RawCounterparty> for Counterparty {}
+
 // Converts from the wire format RawCounterparty. Typically used from the relayer side
 // during queries for response validation and to extract the Counterparty structure.
 impl TryFrom<RawCounterparty> for Counterparty {


### PR DESCRIPTION
Closes: #1247 

## Description
Added Protobuf for Counterparty.
Counterparty can be encoded/decoded by Protobuf.


______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
