### PR TITLE
Make ChainHandle Generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,33 +694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
-name = "dyn-clonable"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
-dependencies = [
- "dyn-clonable-impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "dyn-clonable-impl"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
-
-[[package]]
 name = "ecdsa"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1313,6 @@ version = "0.6.1"
 dependencies = [
  "bytes",
  "chrono",
- "dyn-clonable",
  "env_logger",
  "flex-error",
  "ibc-proto",
@@ -1388,8 +1360,6 @@ dependencies = [
  "bytes",
  "crossbeam-channel 0.5.1",
  "dirs-next",
- "dyn-clonable",
- "dyn-clone",
  "env_logger",
  "flex-error",
  "fraction",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -36,7 +36,6 @@ tracing = "0.1.26"
 prost = "0.7"
 prost-types = "0.7"
 bytes = "1.0.0"
-dyn-clonable = "0.9.0"
 regex = "1"
 subtle-encoding = "0.5"
 sha2 = { version = "0.9.3", optional = true }

--- a/modules/src/ics02_client/client_state.rs
+++ b/modules/src/ics02_client/client_state.rs
@@ -21,7 +21,6 @@ use crate::Height;
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 
-#[dyn_clonable::clonable]
 pub trait ClientState: Clone + std::fmt::Debug + Send + Sync {
     /// Return the chain identifier which this client is serving (i.e., the client is verifying
     /// consensus states from this chain).

--- a/modules/src/ics02_client/header.rs
+++ b/modules/src/ics02_client/header.rs
@@ -15,7 +15,6 @@ pub const TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.He
 pub const MOCK_HEADER_TYPE_URL: &str = "/ibc.mock.Header";
 
 /// Abstract of consensus state update information
-#[dyn_clonable::clonable]
 pub trait Header: Clone + std::fmt::Debug + Send + Sync {
     /// The type of client (eg. Tendermint)
     fn client_type(&self) -> ClientType;

--- a/modules/src/ics02_client/misbehaviour.rs
+++ b/modules/src/ics02_client/misbehaviour.rs
@@ -19,7 +19,6 @@ pub const TENDERMINT_MISBEHAVIOR_TYPE_URL: &str = "/ibc.lightclients.tendermint.
 #[cfg(any(test, feature = "mocks"))]
 pub const MOCK_MISBEHAVIOUR_TYPE_URL: &str = "/ibc.mock.Misbehavior";
 
-#[dyn_clonable::clonable]
 pub trait Misbehaviour: Clone + std::fmt::Debug + Send + Sync {
     /// The type of client (eg. Tendermint)
     fn client_id(&self) -> &ClientId;

--- a/relayer-cli/src/cli_utils.rs
+++ b/relayer-cli/src/cli_utils.rs
@@ -3,7 +3,11 @@ use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::ics24_host::identifier::ChainId;
 use ibc_relayer::{
-    chain::{handle::ChainHandle, runtime::ChainRuntime, CosmosSdkChain},
+    chain::{
+        handle::{ChainHandle, ProdChainHandle},
+        runtime::ChainRuntime,
+        CosmosSdkChain,
+    },
     config::Config,
 };
 
@@ -11,14 +15,14 @@ use crate::error::Error;
 
 #[derive(Clone, Debug)]
 /// Pair of chain handles that are used by most CLIs.
-pub struct ChainHandlePair {
+pub struct ChainHandlePair<Chain: ChainHandle = ProdChainHandle> {
     /// Source chain handle
-    pub src: Box<dyn ChainHandle>,
+    pub src: Chain,
     /// Destination chain handle
-    pub dst: Box<dyn ChainHandle>,
+    pub dst: Chain,
 }
 
-impl ChainHandlePair {
+impl ChainHandlePair<ProdChainHandle> {
     /// Spawn the source and destination chain runtime from the configuration and chain identifiers,
     /// and return the pair of associated handles.
     pub fn spawn(
@@ -26,8 +30,8 @@ impl ChainHandlePair {
         src_chain_id: &ChainId,
         dst_chain_id: &ChainId,
     ) -> Result<Self, Error> {
-        let src = spawn_chain_runtime(config, src_chain_id)?;
-        let dst = spawn_chain_runtime(config, dst_chain_id)?;
+        let src = spawn_chain_runtime_generic(config, src_chain_id)?;
+        let dst = spawn_chain_runtime_generic(config, dst_chain_id)?;
 
         Ok(ChainHandlePair { src, dst })
     }
@@ -35,17 +39,22 @@ impl ChainHandlePair {
 
 /// Spawns a chain runtime from the configuration and given a chain identifier.
 /// Returns the corresponding handle if successful.
-pub fn spawn_chain_runtime(
+pub fn spawn_chain_runtime(config: &Config, chain_id: &ChainId) -> Result<impl ChainHandle, Error> {
+    spawn_chain_runtime_generic::<ProdChainHandle>(config, chain_id)
+}
+
+pub fn spawn_chain_runtime_generic<Chain: ChainHandle>(
     config: &Config,
     chain_id: &ChainId,
-) -> Result<Box<dyn ChainHandle>, Error> {
+) -> Result<Chain, Error> {
     let chain_config = config
         .find_chain(chain_id)
         .cloned()
         .ok_or_else(|| Error::missing_config(chain_id.clone()))?;
 
     let rt = Arc::new(TokioRuntime::new().unwrap());
-    let handle = ChainRuntime::<CosmosSdkChain>::spawn(chain_config, rt).map_err(Error::relayer)?;
+    let handle =
+        ChainRuntime::<CosmosSdkChain>::spawn::<Chain>(chain_config, rt).map_err(Error::relayer)?;
 
     Ok(handle)
 }

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -5,6 +5,7 @@ use ibc::ics03_connection::connection::IdentifiedConnectionEnd;
 use ibc::ics04_channel::channel::Order;
 use ibc::ics24_host::identifier::{ChainId, ConnectionId, PortId};
 use ibc::Height;
+use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::channel::Channel;
 use ibc_relayer::connection::Connection;
 use ibc_relayer::foreign_client::ForeignClient;

--- a/relayer-cli/src/commands/create/connection.rs
+++ b/relayer-cli/src/commands/create/connection.rs
@@ -5,6 +5,7 @@ use abscissa_core::{Command, Options, Runnable};
 use ibc::ics02_client::client_state::ClientState;
 use ibc::ics24_host::identifier::{ChainId, ClientId};
 use ibc::Height;
+use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::connection::Connection;
 use ibc_relayer::foreign_client::ForeignClient;
 

--- a/relayer-cli/src/commands/misbehaviour.rs
+++ b/relayer-cli/src/commands/misbehaviour.rs
@@ -8,7 +8,7 @@ use ibc_relayer::foreign_client::{ForeignClient, MisbehaviourResults};
 use std::ops::Deref;
 
 use crate::application::CliApp;
-use crate::cli_utils::spawn_chain_runtime;
+use crate::cli_utils::{spawn_chain_runtime, spawn_chain_runtime_generic};
 use crate::conclude::Output;
 use crate::prelude::*;
 use ibc::ics02_client::client_state::ClientState;
@@ -93,8 +93,8 @@ pub fn monitor_misbehaviour(
     Ok(None)
 }
 
-fn misbehaviour_handling(
-    chain: Box<dyn ChainHandle>,
+fn misbehaviour_handling<Chain: ChainHandle>(
+    chain: Chain,
     config: &config::Reader<CliApp>,
     client_id: ClientId,
     update: Option<UpdateClient>,
@@ -107,8 +107,8 @@ fn misbehaviour_handling(
         return Err(format!("client {} is already frozen", client_id).into());
     }
 
-    let counterparty_chain =
-        spawn_chain_runtime(config, &client_state.chain_id()).map_err(|e| {
+    let counterparty_chain = spawn_chain_runtime_generic::<Chain>(config, &client_state.chain_id())
+        .map_err(|e| {
             format!(
                 "could not spawn the chain runtime for {}: {}",
                 client_state.chain_id(),

--- a/relayer-cli/src/commands/query/packet/ack.rs
+++ b/relayer-cli/src/commands/query/packet/ack.rs
@@ -4,6 +4,7 @@ use subtle_encoding::{Encoding, Hex};
 use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
 use ibc::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc::Height;
+use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;

--- a/relayer-cli/src/commands/query/packet/acks.rs
+++ b/relayer-cli/src/commands/query/packet/acks.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use ibc::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc::Height;
 use ibc_proto::ibc::core::channel::v1::QueryPacketAcknowledgementsRequest;
+use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;

--- a/relayer-cli/src/commands/query/packet/commitment.rs
+++ b/relayer-cli/src/commands/query/packet/commitment.rs
@@ -5,6 +5,7 @@ use subtle_encoding::{Encoding, Hex};
 use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
 use ibc::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc::Height;
+use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;

--- a/relayer-cli/src/commands/query/packet/commitments.rs
+++ b/relayer-cli/src/commands/query/packet/commitments.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use ibc::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc::Height;
 use ibc_proto::ibc::core::channel::v1::QueryPacketCommitmentsRequest;
+use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;

--- a/relayer-cli/src/commands/query/packet/unreceived_acks.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_acks.rs
@@ -6,6 +6,7 @@ use ibc_proto::ibc::core::channel::v1::{
     QueryPacketAcknowledgementsRequest, QueryUnreceivedAcksRequest,
 };
 use ibc_relayer::chain::counterparty::channel_connection_client;
+use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;
@@ -41,7 +42,7 @@ impl QueryUnreceivedAcknowledgementCmd {
         let chain = spawn_chain_runtime(&config, &self.chain_id)?;
 
         let channel_connection_client =
-            channel_connection_client(chain.as_ref(), &self.port_id, &self.channel_id)
+            channel_connection_client(&chain, &self.port_id, &self.channel_id)
                 .map_err(Error::supervisor)?;
 
         let channel = channel_connection_client.channel;

--- a/relayer-cli/src/commands/query/packet/unreceived_packets.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_packets.rs
@@ -8,6 +8,7 @@ use ibc_proto::ibc::core::channel::v1::{
     QueryPacketCommitmentsRequest, QueryUnreceivedPacketsRequest,
 };
 use ibc_relayer::chain::counterparty::channel_connection_client;
+use ibc_relayer::chain::handle::ChainHandle;
 
 use crate::cli_utils::spawn_chain_runtime;
 use crate::conclude::Output;
@@ -49,7 +50,7 @@ impl QueryUnreceivedPacketsCmd {
         let chain = spawn_chain_runtime(&*config, &self.chain_id)?;
 
         let channel_connection_client =
-            channel_connection_client(chain.as_ref(), &self.port_id, &self.channel_id)
+            channel_connection_client(&chain, &self.port_id, &self.channel_id)
                 .map_err(Error::supervisor)?;
 
         let channel = channel_connection_client.channel;

--- a/relayer-cli/src/commands/query/tx/events.rs
+++ b/relayer-cli/src/commands/query/tx/events.rs
@@ -10,6 +10,7 @@ use tendermint::abci::transaction::Hash;
 use ibc::ics24_host::identifier::ChainId;
 use ibc::query::{QueryTxHash, QueryTxRequest};
 
+use ibc_relayer::chain::handle::{ChainHandle, ProdChainHandle};
 use ibc_relayer::chain::runtime::ChainRuntime;
 use ibc_relayer::chain::CosmosSdkChain;
 
@@ -43,7 +44,9 @@ impl Runnable for QueryTxEventsCmd {
         };
 
         let rt = Arc::new(TokioRuntime::new().unwrap());
-        let chain = ChainRuntime::<CosmosSdkChain>::spawn(chain_config.clone(), rt).unwrap();
+        let chain =
+            ChainRuntime::<CosmosSdkChain>::spawn::<ProdChainHandle>(chain_config.clone(), rt)
+                .unwrap();
 
         let res = Hash::from_str(self.hash.as_str())
             .map_err(|e| Error::invalid_hash(self.hash.clone(), e))

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use abscissa_core::{Command, Options, Runnable};
 use crossbeam_channel::Sender;
 
+use ibc_relayer::chain::handle::{ChainHandle, ProdChainHandle};
 use ibc_relayer::config::reload::ConfigReload;
 use ibc_relayer::config::Config;
 use ibc_relayer::supervisor::{cmd::SupervisorCmd, Supervisor};
@@ -21,10 +22,11 @@ impl Runnable for StartCmd {
         let config = (*app_config()).clone();
         let config = Arc::new(RwLock::new(config));
 
-        let (supervisor, tx_cmd) = make_supervisor(config.clone()).unwrap_or_else(|e| {
-            Output::error(format!("Hermes failed to start, last error: {}", e)).exit();
-            unreachable!()
-        });
+        let (supervisor, tx_cmd) = make_supervisor::<ProdChainHandle>(config.clone())
+            .unwrap_or_else(|e| {
+                Output::error(format!("Hermes failed to start, last error: {}", e)).exit();
+                unreachable!()
+            });
 
         match crate::config::config_path() {
             Some(config_path) => {
@@ -101,9 +103,9 @@ fn register_signals(reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Resu
 }
 
 #[cfg(feature = "telemetry")]
-fn make_supervisor(
+fn make_supervisor<Chain: ChainHandle + 'static>(
     config: Arc<RwLock<Config>>,
-) -> Result<(Supervisor, Sender<SupervisorCmd>), Box<dyn Error + Send + Sync>> {
+) -> Result<(Supervisor<Chain>, Sender<SupervisorCmd>), Box<dyn Error + Send + Sync>> {
     let state = ibc_telemetry::new_state();
 
     let telemetry = config.read().expect("poisoned lock").telemetry.clone();

--- a/relayer-cli/src/commands/tx/channel.rs
+++ b/relayer-cli/src/commands/tx/channel.rs
@@ -5,6 +5,7 @@ use ibc::ics03_connection::connection::ConnectionEnd;
 use ibc::ics04_channel::channel::Order;
 use ibc::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
 use ibc::Height;
+use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::channel::{Channel, ChannelSide};
 
 use crate::cli_utils::ChainHandlePair;

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -10,7 +10,7 @@ use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::foreign_client::ForeignClient;
 
 use crate::application::{app_config, CliApp};
-use crate::cli_utils::{spawn_chain_runtime, ChainHandlePair};
+use crate::cli_utils::{spawn_chain_runtime, spawn_chain_runtime_generic, ChainHandlePair};
 use crate::conclude::{exit_with_unrecoverable_error, Output};
 use crate::error::Error;
 
@@ -220,13 +220,13 @@ impl Runnable for TxUpgradeClientsCmd {
 }
 
 impl TxUpgradeClientsCmd {
-    fn upgrade_clients_for_chain(
+    fn upgrade_clients_for_chain<Chain: ChainHandle>(
         &self,
         config: &config::Reader<CliApp>,
-        src_chain: Box<dyn ChainHandle>,
+        src_chain: Chain,
         dst_chain_id: &ChainId,
     ) -> UpgradeClientsForChainResult {
-        let dst_chain = spawn_chain_runtime(config, dst_chain_id)?;
+        let dst_chain = spawn_chain_runtime_generic::<Chain>(config, dst_chain_id)?;
 
         let req = QueryClientStatesRequest {
             pagination: ibc_proto::cosmos::base::query::pagination::all(),
@@ -242,10 +242,10 @@ impl TxUpgradeClientsCmd {
         Ok(outputs)
     }
 
-    fn upgrade_client(
+    fn upgrade_client<Chain: ChainHandle>(
         client_id: ClientId,
-        dst_chain: Box<dyn ChainHandle>,
-        src_chain: Box<dyn ChainHandle>,
+        dst_chain: Chain,
+        src_chain: Chain,
     ) -> Result<Vec<IbcEvent>, Error> {
         let client = ForeignClient::restore(client_id, dst_chain.clone(), src_chain.clone());
         client.upgrade().map_err(Error::foreign_client)

--- a/relayer-cli/src/commands/tx/transfer.rs
+++ b/relayer-cli/src/commands/tx/transfer.rs
@@ -6,6 +6,7 @@ use ibc::{
     ics02_client::height::Height,
     ics24_host::identifier::{ChainId, ChannelId, PortId},
 };
+use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::{
     config::Config,
     transfer::{build_and_send_transfer_messages, TransferOptions},

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -52,10 +52,8 @@ sha2 = "0.9.3"
 ripemd160 = "0.9.1"
 bech32 = "0.8.1"
 itertools = "0.10.1"
-dyn-clonable = "0.9.0"
 tonic = { version = "0.4", features = ["tls", "tls-roots"] }
 dirs-next = "2.0.0"
-dyn-clone = "1.0.3"
 retry = { version = "1.2.1", default-features = false }
 async-stream = "0.3.2"
 http = "0.2.4"

--- a/relayer/src/chain/counterparty.rs
+++ b/relayer/src/chain/counterparty.rs
@@ -20,7 +20,7 @@ use crate::supervisor::Error;
 use super::handle::ChainHandle;
 
 pub fn counterparty_chain_from_connection(
-    src_chain: &dyn ChainHandle,
+    src_chain: &impl ChainHandle,
     src_connection_id: &ConnectionId,
 ) -> Result<ChainId, Error> {
     let connection_end = src_chain
@@ -42,7 +42,7 @@ pub fn counterparty_chain_from_connection(
 fn connection_on_destination(
     connection_id_on_source: &ConnectionId,
     counterparty_client_id: &ClientId,
-    counterparty_chain: &dyn ChainHandle,
+    counterparty_chain: &impl ChainHandle,
 ) -> Result<Option<ConnectionEnd>, Error> {
     let req = QueryClientConnectionsRequest {
         client_id: counterparty_client_id.to_string(),
@@ -69,7 +69,7 @@ fn connection_on_destination(
 
 pub fn connection_state_on_destination(
     connection: IdentifiedConnectionEnd,
-    counterparty_chain: &dyn ChainHandle,
+    counterparty_chain: &impl ChainHandle,
 ) -> Result<ConnectionState, Error> {
     if let Some(remote_connection_id) = connection.connection_end.counterparty().connection_id() {
         let connection_end = counterparty_chain
@@ -119,7 +119,7 @@ impl ChannelConnectionClient {
 /// Returns the [`ChannelConnectionClient`] associated with the
 /// provided port and channel id.
 pub fn channel_connection_client(
-    chain: &dyn ChainHandle,
+    chain: &impl ChainHandle,
     port_id: &PortId,
     channel_id: &ChannelId,
 ) -> Result<ChannelConnectionClient, Error> {
@@ -165,7 +165,7 @@ pub fn channel_connection_client(
 }
 
 pub fn counterparty_chain_from_channel(
-    src_chain: &dyn ChainHandle,
+    src_chain: &impl ChainHandle,
     src_channel_id: &ChannelId,
     src_port_id: &PortId,
 ) -> Result<ChainId, Error> {
@@ -176,7 +176,7 @@ pub fn counterparty_chain_from_channel(
 fn fetch_channel_on_destination(
     port_id: &PortId,
     channel_id: &ChannelId,
-    counterparty_chain: &dyn ChainHandle,
+    counterparty_chain: &impl ChainHandle,
     remote_connection_id: &ConnectionId,
 ) -> Result<Option<ChannelEnd>, Error> {
     let req = QueryConnectionChannelsRequest {
@@ -202,7 +202,7 @@ fn fetch_channel_on_destination(
 pub fn channel_state_on_destination(
     channel: &IdentifiedChannelEnd,
     connection: &IdentifiedConnectionEnd,
-    counterparty_chain: &dyn ChainHandle,
+    counterparty_chain: &impl ChainHandle,
 ) -> Result<State, Error> {
     let remote_channel = channel_on_destination(channel, connection, counterparty_chain)?;
     Ok(remote_channel.map_or_else(
@@ -214,7 +214,7 @@ pub fn channel_state_on_destination(
 pub fn channel_on_destination(
     channel: &IdentifiedChannelEnd,
     connection: &IdentifiedConnectionEnd,
-    counterparty_chain: &dyn ChainHandle,
+    counterparty_chain: &impl ChainHandle,
 ) -> Result<Option<ChannelEnd>, Error> {
     if let Some(remote_channel_id) = channel.channel_end.remote.channel_id() {
         let counterparty = counterparty_chain
@@ -243,7 +243,7 @@ pub fn channel_on_destination(
 /// expected counterparty.
 /// Returns `Ok` if the counterparty matches, and `Err` otherwise.
 pub fn check_channel_counterparty(
-    target_chain: Box<dyn ChainHandle>,
+    target_chain: impl ChainHandle,
     target_pchan: &PortChannelId,
     expected: &PortChannelId,
 ) -> Result<(), ChannelError> {

--- a/relayer/src/chain/handle/prod.rs
+++ b/relayer/src/chain/handle/prod.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use crossbeam_channel as channel;
+use serde::{Serialize, Serializer};
 
 use ibc::ics02_client::client_consensus::{AnyConsensusState, AnyConsensusStateWithHeight};
 use ibc::ics02_client::client_state::{AnyClientState, IdentifiedAnyClientState};
@@ -71,6 +72,10 @@ impl ProdChainHandle {
 }
 
 impl ChainHandle for ProdChainHandle {
+    fn new(chain_id: ChainId, sender: channel::Sender<ChainRequest>) -> Self {
+        Self::new(chain_id, sender)
+    }
+
     fn id(&self) -> ChainId {
         self.chain_id.clone()
     }
@@ -401,5 +406,14 @@ impl ChainHandle for ProdChainHandle {
 
     fn query_txs(&self, request: QueryTxRequest) -> Result<Vec<IbcEvent>, Error> {
         self.send(|reply_to| ChainRequest::QueryPacketEventData { request, reply_to })
+    }
+}
+
+impl Serialize for ProdChainHandle {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        self.id().serialize(serializer)
     }
 }

--- a/relayer/src/link.rs
+++ b/relayer/src/link.rs
@@ -26,12 +26,12 @@ pub struct LinkParameters {
     pub src_channel_id: ChannelId,
 }
 
-pub struct Link {
-    pub a_to_b: RelayPath,
+pub struct Link<Chain: ChainHandle> {
+    pub a_to_b: RelayPath<Chain>,
 }
 
-impl Link {
-    pub fn new(channel: Channel) -> Self {
+impl<Chain: ChainHandle> Link<Chain> {
+    pub fn new(channel: Channel<Chain>) -> Self {
         Self {
             a_to_b: RelayPath::new(channel),
         }
@@ -68,10 +68,10 @@ impl Link {
     }
 
     pub fn new_from_opts(
-        a_chain: Box<dyn ChainHandle>,
-        b_chain: Box<dyn ChainHandle>,
+        a_chain: Chain,
+        b_chain: Chain,
         opts: LinkParameters,
-    ) -> Result<Link, LinkError> {
+    ) -> Result<Link<Chain>, LinkError> {
         // Check that the packet's channel on source chain is Open
         let a_channel_id = &opts.src_channel_id;
         let a_channel = a_chain

--- a/relayer/src/link/operational_data.rs
+++ b/relayer/src/link/operational_data.rs
@@ -7,6 +7,7 @@ use tracing::{info, warn};
 use ibc::events::IbcEvent;
 use ibc::Height;
 
+use crate::chain::handle::ChainHandle;
 use crate::link::error::LinkError;
 use crate::link::RelayPath;
 
@@ -66,7 +67,10 @@ impl OperationalData {
 
     /// Returns all the messages in this operational data, plus prepending the client update message
     /// if necessary.
-    pub fn assemble_msgs(&self, relay_path: &RelayPath) -> Result<Vec<Any>, LinkError> {
+    pub fn assemble_msgs<Chain: ChainHandle>(
+        &self,
+        relay_path: &RelayPath<Chain>,
+    ) -> Result<Vec<Any>, LinkError> {
         if self.batch.is_empty() {
             warn!("assemble_msgs() method call on an empty OperationalData!");
             return Ok(vec![]);

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -40,8 +40,8 @@ use crate::link::relay_summary::RelaySummary;
 
 const MAX_RETRIES: usize = 5;
 
-pub struct RelayPath {
-    channel: Channel,
+pub struct RelayPath<Chain: ChainHandle> {
+    channel: Channel<Chain>,
     // Marks whether this path has already cleared pending packets.
     // Packets should be cleared once (at startup), then this
     // flag turns to `false`.
@@ -55,8 +55,8 @@ pub struct RelayPath {
     dst_operational_data: Vec<OperationalData>,
 }
 
-impl RelayPath {
-    pub fn new(channel: Channel) -> Self {
+impl<Chain: ChainHandle> RelayPath<Chain> {
+    pub fn new(channel: Channel<Chain>) -> Self {
         Self {
             channel,
             clear_packets: true,
@@ -65,13 +65,11 @@ impl RelayPath {
         }
     }
 
-    #[allow(clippy::borrowed_box)]
-    pub fn src_chain(&self) -> &Box<dyn ChainHandle> {
+    pub fn src_chain(&self) -> &Chain {
         self.channel.src_chain()
     }
 
-    #[allow(clippy::borrowed_box)]
-    pub fn dst_chain(&self) -> &Box<dyn ChainHandle> {
+    pub fn dst_chain(&self) -> &Chain {
         self.channel.dst_chain()
     }
 
@@ -111,7 +109,7 @@ impl RelayPath {
             .ok_or_else(|| LinkError::missing_channel_id(self.dst_chain().id()))
     }
 
-    pub fn channel(&self) -> &Channel {
+    pub fn channel(&self) -> &Channel<Chain> {
         &self.channel
     }
 
@@ -1394,7 +1392,7 @@ impl RelayPath {
         }
     }
 
-    fn restore_src_client(&self) -> ForeignClient {
+    fn restore_src_client(&self) -> ForeignClient<Chain> {
         ForeignClient::restore(
             self.src_client_id().clone(),
             self.src_chain().clone(),
@@ -1402,7 +1400,7 @@ impl RelayPath {
         )
     }
 
-    fn restore_dst_client(&self) -> ForeignClient {
+    fn restore_dst_client(&self) -> ForeignClient<Chain> {
         ForeignClient::restore(
             self.dst_client_id().clone(),
             self.dst_chain().clone(),
@@ -1411,7 +1409,7 @@ impl RelayPath {
     }
 }
 
-impl fmt::Display for RelayPath {
+impl<Chain: ChainHandle> fmt::Display for RelayPath<Chain> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let channel_id = self
             .src_channel_id()

--- a/relayer/src/object.rs
+++ b/relayer/src/object.rs
@@ -282,7 +282,7 @@ impl Object {
     /// Build the object associated with the given [`UpdateClient`] event.
     pub fn for_update_client(
         e: &UpdateClient,
-        dst_chain: &dyn ChainHandle,
+        dst_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let client_state = dst_chain
             .query_client_state(e.client_id(), Height::zero())
@@ -307,8 +307,8 @@ impl Object {
 
     /// Build the client object associated with the given channel event attributes.
     pub fn client_from_chan_open_events(
-        e: &Attributes,          // The attributes of the emitted event
-        chain: &dyn ChainHandle, // The chain which emitted the event
+        e: &Attributes,           // The attributes of the emitted event
+        chain: &impl ChainHandle, // The chain which emitted the event
     ) -> Result<Self, ObjectError> {
         let channel_id = e
             .channel_id()
@@ -336,7 +336,7 @@ impl Object {
     /// Build the Connection object associated with the given [`Open`] connection event.
     pub fn connection_from_conn_open_events(
         e: &ConnectionAttributes,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let connection_id = e
             .connection_id
@@ -357,7 +357,7 @@ impl Object {
     /// Build the Channel object associated with the given [`Open`] channel event.
     pub fn channel_from_chan_open_events(
         attributes: &Attributes,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let channel_id = attributes
             .channel_id()
@@ -379,7 +379,7 @@ impl Object {
     /// Build the Packet object associated with the given [`Open`] channel event.
     pub fn packet_from_chan_open_events(
         attributes: &Attributes,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let channel_id = attributes
             .channel_id()
@@ -401,7 +401,7 @@ impl Object {
     /// Build the object associated with the given [`SendPacket`] event.
     pub fn for_send_packet(
         e: &SendPacket,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let dst_chain_id = counterparty_chain_from_channel(
             src_chain,
@@ -422,7 +422,7 @@ impl Object {
     /// Build the object associated with the given [`WriteAcknowledgement`] event.
     pub fn for_write_ack(
         e: &WriteAcknowledgement,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let dst_chain_id = counterparty_chain_from_channel(
             src_chain,
@@ -443,7 +443,7 @@ impl Object {
     /// Build the object associated with the given [`TimeoutPacket`] event.
     pub fn for_timeout_packet(
         e: &TimeoutPacket,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let dst_chain_id = counterparty_chain_from_channel(
             src_chain,
@@ -464,7 +464,7 @@ impl Object {
     /// Build the object associated with the given [`CloseInit`] event.
     pub fn for_close_init_channel(
         e: &CloseInit,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
     ) -> Result<Self, ObjectError> {
         let dst_chain_id = counterparty_chain_from_channel(src_chain, e.channel_id(), e.port_id())
             .map_err(ObjectError::supervisor)?;

--- a/relayer/src/registry.rs
+++ b/relayer/src/registry.rs
@@ -18,9 +18,9 @@ use crate::{
 /// Registry for keeping track of [`ChainHandle`]s indexed by a `ChainId`.
 ///
 /// The purpose of this type is to avoid spawning multiple runtimes for a single `ChainId`.
-pub struct Registry {
+pub struct Registry<Chain: ChainHandle> {
     config: RwArc<Config>,
-    handles: HashMap<ChainId, Box<dyn ChainHandle>>,
+    handles: HashMap<ChainId, Chain>,
     rt: Arc<TokioRuntime>,
 }
 
@@ -42,7 +42,7 @@ define_error! {
     }
 }
 
-impl Registry {
+impl<Chain: ChainHandle> Registry<Chain> {
     /// Construct a new [`Registry`] using the provided [`Config`]
     pub fn new(config: RwArc<Config>) -> Self {
         Self {
@@ -58,7 +58,7 @@ impl Registry {
     }
 
     /// Return an iterator overall the chain handles managed by the registry.
-    pub fn chains(&self) -> impl Iterator<Item = &Box<dyn ChainHandle>> {
+    pub fn chains(&self) -> impl Iterator<Item = &Chain> {
         self.handles.values()
     }
 
@@ -66,7 +66,7 @@ impl Registry {
     ///
     /// If there is no handle yet, this will first spawn the runtime and then
     /// return its handle.
-    pub fn get_or_spawn(&mut self, chain_id: &ChainId) -> Result<Box<dyn ChainHandle>, SpawnError> {
+    pub fn get_or_spawn(&mut self, chain_id: &ChainId) -> Result<Chain, SpawnError> {
         self.spawn(chain_id)?;
 
         let handle = self
@@ -104,11 +104,11 @@ impl Registry {
 
 /// Spawns a chain runtime from the configuration and given a chain identifier.
 /// Returns the corresponding handle if successful.
-pub fn spawn_chain_runtime(
+pub fn spawn_chain_runtime<Chain: ChainHandle>(
     config: &RwArc<Config>,
     chain_id: &ChainId,
     rt: Arc<TokioRuntime>,
-) -> Result<Box<dyn ChainHandle>, SpawnError> {
+) -> Result<Chain, SpawnError> {
     let chain_config = config
         .read()
         .expect("poisoned lock")

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -47,16 +47,15 @@ use self::spawn::SpawnMode;
 
 type ArcBatch = Arc<event::monitor::Result<EventBatch>>;
 type Subscription = Receiver<ArcBatch>;
-type BoxHandle = Box<dyn ChainHandle>;
 
 pub type RwArc<T> = Arc<RwLock<T>>;
 
 /// The supervisor listens for events on multiple pairs of chains,
 /// and dispatches the events it receives to the appropriate
 /// worker, based on the [`Object`] associated with each event.
-pub struct Supervisor {
+pub struct Supervisor<Chain: ChainHandle> {
     config: RwArc<Config>,
-    registry: Registry,
+    registry: Registry<Chain>,
     workers: WorkerMap,
 
     cmd_rx: Receiver<SupervisorCmd>,
@@ -67,7 +66,7 @@ pub struct Supervisor {
     telemetry: Telemetry,
 }
 
-impl Supervisor {
+impl<Chain: ChainHandle + 'static> Supervisor<Chain> {
     /// Create a [`Supervisor`] which will listen for events on all the chains in the [`Config`].
     pub fn new(config: RwArc<Config>, telemetry: Telemetry) -> (Self, Sender<SupervisorCmd>) {
         let registry = Registry::new(config.clone());
@@ -177,7 +176,7 @@ impl Supervisor {
     /// and maps each [`IbcEvent`] to their corresponding [`Object`].
     pub fn collect_events(
         &self,
-        src_chain: &dyn ChainHandle,
+        src_chain: &impl ChainHandle,
         batch: &EventBatch,
     ) -> CollectedEvents {
         let mut collected = CollectedEvents::new(batch.height, batch.chain_id.clone());
@@ -341,7 +340,7 @@ impl Supervisor {
     }
 
     /// Create a new `SpawnContext` for spawning workers.
-    fn spawn_context(&mut self, mode: SpawnMode) -> SpawnContext<'_> {
+    fn spawn_context(&mut self, mode: SpawnMode) -> SpawnContext<'_, Chain> {
         SpawnContext::new(
             &self.config,
             &mut self.registry,
@@ -391,7 +390,7 @@ impl Supervisor {
     }
 
     /// Subscribe to the events emitted by the chains the supervisor is connected to.
-    fn init_subscriptions(&mut self) -> Result<Vec<(BoxHandle, Subscription)>, Error> {
+    fn init_subscriptions(&mut self) -> Result<Vec<(Chain, Subscription)>, Error> {
         let chains = &self.config.read().expect("poisoned lock").chains;
 
         let mut subscriptions = Vec::with_capacity(chains.len());
@@ -559,7 +558,7 @@ impl Supervisor {
 
     /// Process the given batch if it does not contain any errors,
     /// output the errors on the console otherwise.
-    fn handle_batch(&mut self, chain: Box<dyn ChainHandle>, batch: ArcBatch) {
+    fn handle_batch(&mut self, chain: Chain, batch: ArcBatch) {
         let chain_id = chain.id();
 
         match batch.deref() {
@@ -585,17 +584,13 @@ impl Supervisor {
     }
 
     /// Process a batch of events received from a chain.
-    fn process_batch(
-        &mut self,
-        src_chain: Box<dyn ChainHandle>,
-        batch: &EventBatch,
-    ) -> Result<(), Error> {
+    fn process_batch(&mut self, src_chain: Chain, batch: &EventBatch) -> Result<(), Error> {
         assert_eq!(src_chain.id(), batch.chain_id);
 
         let height = batch.height;
         let chain_id = batch.chain_id.clone();
 
-        let mut collected = self.collect_events(src_chain.clone().as_ref(), batch);
+        let mut collected = self.collect_events(&src_chain, batch);
 
         for (object, events) in collected.per_object.drain() {
             if !self.relay_on_object(&src_chain.id(), &object) {

--- a/relayer/src/supervisor/client_state_filter.rs
+++ b/relayer/src/supervisor/client_state_filter.rs
@@ -10,6 +10,7 @@ use ibc::ics04_channel::error::Error as ChannelError;
 use ibc::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
 use ibc::Height;
 
+use crate::chain::handle::ChainHandle;
 use crate::error::Error as RelayerError;
 use crate::object;
 use crate::registry::{Registry, SpawnError};
@@ -73,9 +74,9 @@ impl FilterPolicy {
     ///
     /// May encounter errors caused by failed queries. Any such error
     /// is propagated and nothing is cached.
-    pub fn control_connection_end_and_client(
+    pub fn control_connection_end_and_client<Chain: ChainHandle>(
         &mut self,
-        registry: &mut Registry,
+        registry: &mut Registry<Chain>,
         chain_id: &ChainId, // Chain hosting the client & connection
         client_state: &AnyClientState,
         connection: &ConnectionEnd,
@@ -182,9 +183,9 @@ impl FilterPolicy {
         permission
     }
 
-    pub fn control_client_object(
+    pub fn control_client_object<Chain: ChainHandle>(
         &mut self,
-        registry: &mut Registry,
+        registry: &mut Registry<Chain>,
         obj: &object::Client,
     ) -> Result<Permission, FilterError> {
         let identifier = CacheKey::Client(obj.dst_chain_id.clone(), obj.dst_client_id.clone());
@@ -217,9 +218,9 @@ impl FilterPolicy {
         Ok(self.control_client(&obj.dst_chain_id, &obj.dst_client_id, &client_state))
     }
 
-    pub fn control_conn_object(
+    pub fn control_conn_object<Chain: ChainHandle>(
         &mut self,
-        registry: &mut Registry,
+        registry: &mut Registry<Chain>,
         obj: &object::Connection,
     ) -> Result<Permission, FilterError> {
         let identifier =
@@ -263,9 +264,9 @@ impl FilterPolicy {
         )
     }
 
-    fn control_channel(
+    fn control_channel<Chain: ChainHandle>(
         &mut self,
-        registry: &mut Registry,
+        registry: &mut Registry<Chain>,
         chain_id: &ChainId,
         port_id: &PortId,
         channel_id: &ChannelId,
@@ -326,9 +327,9 @@ impl FilterPolicy {
         Ok(permission)
     }
 
-    pub fn control_chan_object(
+    pub fn control_chan_object<Chain: ChainHandle>(
         &mut self,
-        registry: &mut Registry,
+        registry: &mut Registry<Chain>,
         obj: &object::Channel,
     ) -> Result<Permission, FilterError> {
         self.control_channel(
@@ -339,9 +340,9 @@ impl FilterPolicy {
         )
     }
 
-    pub fn control_packet_object(
+    pub fn control_packet_object<Chain: ChainHandle>(
         &mut self,
-        registry: &mut Registry,
+        registry: &mut Registry<Chain>,
         obj: &object::Packet,
     ) -> Result<Permission, FilterError> {
         self.control_channel(

--- a/relayer/src/transfer.rs
+++ b/relayer/src/transfer.rs
@@ -64,9 +64,9 @@ pub struct TransferOptions {
     pub number_msgs: usize,
 }
 
-pub fn build_and_send_transfer_messages(
-    packet_src_chain: Box<dyn ChainHandle>, // the chain whose account is debited
-    packet_dst_chain: Box<dyn ChainHandle>, // the chain whose account eventually gets credited
+pub fn build_and_send_transfer_messages<Chain: ChainHandle>(
+    packet_src_chain: Chain, // the chain whose account is debited
+    packet_dst_chain: Chain, // the chain whose account eventually gets credited
     opts: TransferOptions,
 ) -> Result<Vec<IbcEvent>, PacketError> {
     let receiver = match &opts.receiver {

--- a/relayer/src/worker/channel.rs
+++ b/relayer/src/worker/channel.rs
@@ -6,26 +6,28 @@ use tracing::{debug, info, warn};
 use crate::channel::Channel as RelayChannel;
 use crate::telemetry::Telemetry;
 use crate::{
-    chain::handle::ChainHandlePair, object::Channel, util::retry::retry_with_index,
+    chain::handle::{ChainHandle, ChainHandlePair},
+    object::Channel,
+    util::retry::retry_with_index,
     worker::retry_strategy,
 };
 
 use super::error::RunError;
 use super::WorkerCmd;
 
-pub struct ChannelWorker {
+pub struct ChannelWorker<Chain: ChainHandle> {
     channel: Channel,
-    chains: ChainHandlePair,
+    chains: ChainHandlePair<Chain>,
     cmd_rx: Receiver<WorkerCmd>,
 
     #[allow(dead_code)]
     telemetry: Telemetry,
 }
 
-impl ChannelWorker {
+impl<Chain: ChainHandle> ChannelWorker<Chain> {
     pub fn new(
         channel: Channel,
-        chains: ChainHandlePair,
+        chains: ChainHandlePair<Chain>,
         cmd_rx: Receiver<WorkerCmd>,
         telemetry: Telemetry,
     ) -> Self {
@@ -126,7 +128,7 @@ impl ChannelWorker {
     }
 
     /// Get a reference to the uni chan path worker's chains.
-    pub fn chains(&self) -> &ChainHandlePair {
+    pub fn chains(&self) -> &ChainHandlePair<Chain> {
         &self.chains
     }
 

--- a/relayer/src/worker/client.rs
+++ b/relayer/src/worker/client.rs
@@ -6,7 +6,7 @@ use tracing::{debug, info, trace, warn};
 use ibc::{events::IbcEvent, ics02_client::events::UpdateClient};
 
 use crate::{
-    chain::handle::ChainHandlePair,
+    chain::handle::{ChainHandle, ChainHandlePair},
     foreign_client::{ForeignClient, ForeignClientErrorDetail, MisbehaviourResults},
     object::Client,
     telemetry,
@@ -16,19 +16,19 @@ use crate::{
 use super::error::RunError;
 use super::WorkerCmd;
 
-pub struct ClientWorker {
+pub struct ClientWorker<Chain: ChainHandle> {
     client: Client,
-    chains: ChainHandlePair,
+    chains: ChainHandlePair<Chain>,
     cmd_rx: Receiver<WorkerCmd>,
 
     #[allow(dead_code)]
     telemetry: Telemetry,
 }
 
-impl ClientWorker {
+impl<Chain: ChainHandle> ClientWorker<Chain> {
     pub fn new(
         client: Client,
-        chains: ChainHandlePair,
+        chains: ChainHandlePair<Chain>,
         cmd_rx: Receiver<WorkerCmd>,
         telemetry: Telemetry,
     ) -> Self {
@@ -97,7 +97,7 @@ impl ClientWorker {
         Ok(())
     }
 
-    fn process_cmd(&self, cmd: WorkerCmd, client: &ForeignClient) -> Next {
+    fn process_cmd(&self, cmd: WorkerCmd, client: &ForeignClient<Chain>) -> Next {
         match cmd {
             WorkerCmd::IbcEvents { batch } => {
                 trace!("[{}] worker received batch: {:?}", client, batch);
@@ -130,7 +130,11 @@ impl ClientWorker {
         }
     }
 
-    fn detect_misbehaviour(&self, client: &ForeignClient, update: Option<UpdateClient>) -> bool {
+    fn detect_misbehaviour(
+        &self,
+        client: &ForeignClient<Chain>,
+        update: Option<UpdateClient>,
+    ) -> bool {
         match client.detect_misbehaviour_and_submit_evidence(update) {
             MisbehaviourResults::ValidClient => false,
             MisbehaviourResults::VerificationError => {
@@ -150,7 +154,7 @@ impl ClientWorker {
     }
 
     /// Get a reference to the client worker's chains.
-    pub fn chains(&self) -> &ChainHandlePair {
+    pub fn chains(&self) -> &ChainHandlePair<Chain> {
         &self.chains
     }
 

--- a/relayer/src/worker/connection.rs
+++ b/relayer/src/worker/connection.rs
@@ -6,26 +6,28 @@ use tracing::{debug, info, warn};
 use crate::connection::Connection as RelayConnection;
 use crate::telemetry::Telemetry;
 use crate::{
-    chain::handle::ChainHandlePair, object::Connection, util::retry::retry_with_index,
+    chain::handle::{ChainHandle, ChainHandlePair},
+    object::Connection,
+    util::retry::retry_with_index,
     worker::retry_strategy,
 };
 
 use super::error::RunError;
 use super::WorkerCmd;
 
-pub struct ConnectionWorker {
+pub struct ConnectionWorker<Chain: ChainHandle> {
     connection: Connection,
-    chains: ChainHandlePair,
+    chains: ChainHandlePair<Chain>,
     cmd_rx: Receiver<WorkerCmd>,
 
     #[allow(dead_code)]
     telemetry: Telemetry,
 }
 
-impl ConnectionWorker {
+impl<Chain: ChainHandle> ConnectionWorker<Chain> {
     pub fn new(
         connection: Connection,
-        chains: ChainHandlePair,
+        chains: ChainHandlePair<Chain>,
         cmd_rx: Receiver<WorkerCmd>,
         telemetry: Telemetry,
     ) -> Self {
@@ -133,7 +135,7 @@ impl ConnectionWorker {
     }
 
     /// Get a reference to the uni chan path worker's chains.
-    pub fn chains(&self) -> &ChainHandlePair {
+    pub fn chains(&self) -> &ChainHandlePair<Chain> {
         &self.chains
     }
 

--- a/relayer/src/worker/map.rs
+++ b/relayer/src/worker/map.rs
@@ -106,11 +106,11 @@ impl WorkerMap {
     /// with the given [`Object`].
     ///
     /// This function will spawn a new [`Worker`] if one does not exists already.
-    pub fn get_or_spawn(
+    pub fn get_or_spawn<Chain: ChainHandle + 'static>(
         &mut self,
         object: Object,
-        src: Box<dyn ChainHandle>,
-        dst: Box<dyn ChainHandle>,
+        src: Chain,
+        dst: Chain,
         config: &Config,
     ) -> &WorkerHandle {
         if self.workers.contains_key(&object) {
@@ -124,10 +124,10 @@ impl WorkerMap {
     /// Spawn a new [`Worker`], only if one does not exists already.
     ///
     /// Returns whether or not the worker was actually spawned.
-    pub fn spawn(
+    pub fn spawn<Chain: ChainHandle + 'static>(
         &mut self,
-        src: Box<dyn ChainHandle>,
-        dst: Box<dyn ChainHandle>,
+        src: Chain,
+        dst: Chain,
         object: &Object,
         config: &Config,
     ) -> bool {
@@ -141,10 +141,10 @@ impl WorkerMap {
     }
 
     /// Force spawn a worker for the given [`Object`].
-    fn spawn_worker(
+    fn spawn_worker<Chain: ChainHandle + 'static>(
         &mut self,
-        src: Box<dyn ChainHandle>,
-        dst: Box<dyn ChainHandle>,
+        src: Chain,
+        dst: Chain,
         object: &Object,
         config: &Config,
     ) -> WorkerHandle {

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::Receiver;
 use tracing::{error, info, warn};
 
 use crate::{
-    chain::handle::ChainHandlePair,
+    chain::handle::{ChainHandle, ChainHandlePair},
     link::{Link, LinkParameters, RelaySummary},
     object::Packet,
     telemetry,
@@ -22,18 +22,18 @@ enum Step {
 }
 
 #[derive(Debug)]
-pub struct PacketWorker {
+pub struct PacketWorker<Chain: ChainHandle> {
     path: Packet,
-    chains: ChainHandlePair,
+    chains: ChainHandlePair<Chain>,
     cmd_rx: Receiver<WorkerCmd>,
     telemetry: Telemetry,
     clear_packets_interval: u64,
 }
 
-impl PacketWorker {
+impl<Chain: ChainHandle> PacketWorker<Chain> {
     pub fn new(
         path: Packet,
-        chains: ChainHandlePair,
+        chains: ChainHandlePair<Chain>,
         cmd_rx: Receiver<WorkerCmd>,
         telemetry: Telemetry,
         clear_packets_interval: u64,
@@ -98,7 +98,12 @@ impl PacketWorker {
         }
     }
 
-    fn step(&self, cmd: Option<WorkerCmd>, link: &mut Link, index: u64) -> RetryResult<Step, u64> {
+    fn step(
+        &self,
+        cmd: Option<WorkerCmd>,
+        link: &mut Link<Chain>,
+        index: u64,
+    ) -> RetryResult<Step, u64> {
         if let Some(cmd) = cmd {
             let result = match cmd {
                 WorkerCmd::IbcEvents { batch } => link.a_to_b.update_schedule(batch),
@@ -156,7 +161,7 @@ impl PacketWorker {
     }
 
     /// Get a reference to the uni chan path worker's chains.
-    pub fn chains(&self) -> &ChainHandlePair {
+    pub fn chains(&self) -> &ChainHandlePair<Chain> {
         &self.chains
     }
 


### PR DESCRIPTION
Part of #1103

## Description

This PR removes the use of `Box<dyn ChainHandle>` and refactor functions that use it into generic functions. This is the first step in making use of generic types to help differentiate values that are being passed between two chains.

I find it difficult to keep track of values of types like `ClientId` and `ConnectionId`. There is not enough information to determine whether the ID belongs to the source or destination chain, and it is too easy to mix the two up. In the subsequent PRs, we should be able to add the IDs as associated types on the ChainHandle or other extended traits to help keep track of such information.

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
