### PR TITLE
Set capability index

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1257-set-capability-index.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1257-set-capability-index.md
@@ -1,0 +1,3 @@
+- Set the index of `ibc::ics05_port::capabilities::Capability` ([#1257])
+
+[#1257]: https://github.com/informalsystems/ibc-rs/issues/1257

--- a/modules/src/ics05_port/capabilities.rs
+++ b/modules/src/ics05_port/capabilities.rs
@@ -9,10 +9,20 @@ impl Capability {
     pub fn new() -> Capability {
         Self { index: 0x0 }
     }
+
+    pub fn index(&self) -> u64 {
+        self.index
+    }
 }
 
 impl Default for Capability {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl From<u64> for Capability {
+    fn from(index: u64) -> Self {
+        Self { index }
     }
 }


### PR DESCRIPTION
Closes: #1257 

## Description
- Set and get the index for `ibc::ics05_port::capabilities::Capability`


______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
