### PR TITLE
Make hermes CLI display error traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "flex-error"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c21e3345cc1318971ddb5d04add3b4eaa970349e4f3e1d870535173cb745cf"
+checksum = "d8754b6f51ccfe4ff91bd54f34f3b46a3027007e29d7f42d56ef814f96010dd9"
 dependencies = [
  "eyre",
  "paste",
@@ -1438,8 +1465,10 @@ version = "0.6.2"
 dependencies = [
  "abscissa_core",
  "atty",
+ "color-eyre",
  "crossbeam-channel 0.5.1",
  "dirs-next",
+ "eyre",
  "flex-error",
  "futures",
  "gumdrop 0.7.0",
@@ -1981,6 +2010,12 @@ checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parking_lot"
@@ -3441,6 +3476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.2.19",
 ]
 
 [[package]]

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -40,7 +40,7 @@ dyn-clonable = "0.9.0"
 regex = "1"
 subtle-encoding = "0.5"
 sha2 = { version = "0.9.3", optional = true }
-flex-error = { version = "0.4.1", default-features = false }
+flex-error = { version = "0.4.2", default-features = false }
 
 [dependencies.tendermint]
 version = "=0.21.0"

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -57,6 +57,7 @@ mod tests {
     use test_env_log::test;
 
     use super::ClientType;
+    use crate::ics02_client::error::{Error, ErrorDetail};
 
     #[test]
     fn parse_tendermint_client_type() {
@@ -80,14 +81,16 @@ mod tests {
 
     #[test]
     fn parse_unknown_client_type() {
-        let client_type = ClientType::from_str("some-random-client-type");
+        let client_type_str = "some-random-client-type";
+        let result = ClientType::from_str(client_type_str);
 
-        match client_type {
-            Err(err) => assert_eq!(
-                format!("{}", err),
-                "unknown client type: some-random-client-type"
-            ),
-            _ => panic!("parse didn't fail"),
+        match result {
+            Err(Error(ErrorDetail::UnknownClientType(e), _)) => {
+                assert_eq!(&e.client_type, client_type_str)
+            }
+            _ => {
+                panic!("Expected ClientType::from_str to fail with UnknownClientType, instead got",)
+            }
         }
     }
 

--- a/no-std-check/Cargo.toml
+++ b/no-std-check/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 # ibc = { path = "../modules" }
 ibc-proto = { path = "../proto" }
-flex-error = { version = "0.3.0", default-features = false }
+flex-error = { version = "0.4.2", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -36,6 +36,8 @@ serde = { version = "1", features = ["serde_derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.26"
 tracing-subscriber = "0.2.19"
+eyre = "0.6.5"
+color-eyre = "0.5"
 futures = "0.3.16"
 toml = "0.5.8"
 serde_derive = "1.0.116"
@@ -49,7 +51,7 @@ subtle-encoding = "0.5"
 dirs-next = "2.0.0"
 itertools = "0.10.1"
 atty = "0.2.14"
-flex-error = { version = "0.4.1", default-features = false }
+flex-error = { version = "0.4.2", default-features = false }
 signal-hook = "0.3.9"
 
 [dependencies.tendermint-proto]

--- a/relayer-cli/src/bin/hermes/main.rs
+++ b/relayer-cli/src/bin/hermes/main.rs
@@ -6,6 +6,7 @@
 use ibc_relayer_cli::application::APPLICATION;
 
 /// Boot Cli
-fn main() {
+fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
     abscissa_core::boot(&APPLICATION);
 }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -59,7 +59,7 @@ dyn-clone = "1.0.3"
 retry = { version = "1.2.1", default-features = false }
 async-stream = "0.3.2"
 http = "0.2.4"
-flex-error = { version = "0.4.1", default-features = false }
+flex-error = { version = "0.4.2", default-features = false }
 signature = "1.3.0"
 anyhow = "1.0.41"
 fraction = {version = "0.8.0", default-features = false }


### PR DESCRIPTION
## Description

- Update to `flex-error` v0.4.2 to always use `Debug` instead of `Display` to format error traces, as `eyre` only display error trace information in `Debug` mode.

- Install `color-eyre` in the `main()` function of `hermes` CLI to allow prettified display of error traces when `RUST_BACKTRACE` is set.

## Example output

Default output:

```bash
$ hermes create client ibc-0 ibc-1
Error: 
   0: relayer error
   1: RPC error to endpoint http://127.0.0.1:26557/
   2: error trying to connect: tcp connect error: Connection refused (os error 111) (code: 0)

Location:
   /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.2/src/tracer_impl/eyre.rs:31

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Output with `RUST_BACKTRACE=1` set:

```bash
$ RUST_BACKTRACE=1 hermes create client ibc-0 ibc-1
Error: 
   0: relayer error
   1: RPC error to endpoint http://127.0.0.1:26557/
   2: error trying to connect: tcp connect error: Connection refused (os error 111) (code: 0)

Location:
   /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.2/src/tracer_impl/eyre.rs:31

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 5 frames hidden ⋮                               
   6: flex_error::tracer_impl::eyre::<impl flex_error::tracer::ErrorTracer<E> for eyre::Report>::new_trace::h07fd25f756dacb51
      at /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.2/src/tracer_impl/eyre.rs:31
   7: <flex_error::source::TraceClone<E> as flex_error::source::ErrorSource<Tracer>>::error_details::hff7a39d79c01ffd5
      at /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.2/src/source.rs:157
   8: ibc_relayer::error::Error::trace_from::h81130643c0d90e2d
      at /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.2/src/macros.rs:538
   9: ibc_relayer::error::Error::rpc::h69dd10854a773d37
      at /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.2/src/macros.rs:854
  10: <ibc_relayer::chain::cosmos::CosmosSdkChain as ibc_relayer::chain::Chain>::init_light_client::{{closure}}::h4d580f62249dad71
      at /mnt/gamma/development/informal/ibc-rs/relayer/src/chain/cosmos.rs:741
  11: core::result::Result<T,E>::map_err::hc3029bfdfe12b89b
      at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/result.rs:591
  12: <ibc_relayer::chain::cosmos::CosmosSdkChain as ibc_relayer::chain::Chain>::init_light_client::hfeedc087732be35e
      at /mnt/gamma/development/informal/ibc-rs/relayer/src/chain/cosmos.rs:737
  13: ibc_relayer::chain::runtime::ChainRuntime<C>::spawn::he5565e94ec214aef
      at /mnt/gamma/development/informal/ibc-rs/relayer/src/chain/runtime.rs:103
  14: ibc_relayer_cli::cli_utils::spawn_chain_runtime::h0d26d7b849b10b82
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/cli_utils.rs:48
  15: ibc_relayer_cli::cli_utils::ChainHandlePair::spawn::h6427b71e77c4c73e
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/cli_utils.rs:29
  16: <ibc_relayer_cli::commands::tx::client::TxCreateClientCmd as abscissa_core::runnable::Runnable>::run::ha151e29f4d9dcfbe
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/commands/tx/client.rs:36
  17: ibc_relayer_cli::commands::create::_DERIVE_Runnable_FOR_CreateCmds::<impl abscissa_core::runnable::Runnable for ibc_relayer_cli::commands::create::CreateCmds>::run::h0244829e32a2d7dc
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/commands/create.rs:12
  18: ibc_relayer_cli::commands::_DERIVE_Runnable_FOR_CliCmd::<impl abscissa_core::runnable::Runnable for ibc_relayer_cli::commands::CliCmd>::run::h9e27bf3b6414213f
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/commands.rs:42
  19: <ibc_relayer_cli::entry::EntryPoint<Cmd> as abscissa_core::runnable::Runnable>::run::hc38db8db448670d8
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/entry.rs:47
  20: abscissa_core::application::Application::run::h3315370613757974
      at /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/application.rs:64
  21: abscissa_core::application::boot::h30d357bd7a8c39c2
      at /home/soares/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.5.2/src/application.rs:196
  22: hermes::main::h1d191be398abfa8c
      at /mnt/gamma/development/informal/ibc-rs/relayer-cli/src/bin/hermes/main.rs:11
  23: core::ops::function::FnOnce::call_once::h802fce211bee6ad4
      at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/ops/function.rs:227
                                ⋮ 11 frames hidden ⋮                              

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
Run with RUST_BACKTRACE=full to include source snippets.
```

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
