### PR TITLE
gm bugfix 1261 - fails silently on missing requirements

### DIFF
--- a/.changelog/unreleased/bug-fixes/1261-gm-req-detect.md
+++ b/.changelog/unreleased/bug-fixes/1261-gm-req-detect.md
@@ -1,0 +1,5 @@
+- [gm] Fix silent exit when requirements are missing
+
+[#1261]: https://github.com/informalsystems/ibc-rs/issues/1261
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## __Unreleased__
+
+### BUG FIXES
+- [gm] Fix silent exit when requirements are missing
+
+[#1261]: https://github.com/informalsystems/ibc-rs/issues/1261
+
 ## v0.6.2
 
 This minor release of Hermes re-enables the `upgrade client`, `upgrade clients`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # CHANGELOG
 
-## __Unreleased__
-
-### BUG FIXES
-- [gm] Fix silent exit when requirements are missing
-
-[#1261]: https://github.com/informalsystems/ibc-rs/issues/1261
-
 ## v0.6.2
 
 This minor release of Hermes re-enables the `upgrade client`, `upgrade clients`,

--- a/scripts/gm/CHANGELOG.md
+++ b/scripts/gm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Gaiad Manager Change Log
 
+## v0.0.7
+
+### BUGFIXES
+- Fixed gm not reporting missing dependencies ([#1261])
+
+[#1261]: https://github.com/informalsystems/ibc-rs/issues/1261
+
 ## v0.0.6
 
 ### FEATURES

--- a/scripts/gm/bin/lib-gm
+++ b/scripts/gm/bin/lib-gm
@@ -5,7 +5,7 @@ if [ "${DEBUG:-}" = "2" ]; then
 fi
 
 version() {
-  echo "v0.0.6"
+  echo "v0.0.7"
 }
 
 # Configuration Management
@@ -203,20 +203,20 @@ install() {
 }
 
 enforce_requirements() {
-  if [ -z "$(which sconfig)" ]; then
+  if [ -z "$(which sconfig || echo)" ]; then
     exit_with_error "missing sconfig, install it from https://github.com/freshautomations/sconfig/releases"
   fi
-  SED="$(which sed)"
+  SED="$(which sed || echo)"
   if [ -z "$SED" ]; then
     exit_with_error "missing sed, please install it"
   fi
-  if [ -z "$(which tr)" ]; then
+  if [ -z "$(which tr || echo)" ]; then
     exit_with_error "missing tr, please install it"
   fi
-  if [ -z "$(which dirname)" ]; then
+  if [ -z "$(which dirname || echo)" ]; then
     exit_with_error "missing dirname, please install it"
   fi
-  STOML="$(which stoml)"
+  STOML="$(which stoml || echo)"
   if [ -z "$STOML" ]; then
     exit_with_error "missing stoml, install it from https://github.com/freshautomations/stoml/releases"
   fi


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1261 

## Description
gm failed silently on missing requirements because the `which` command returned with a non-zero error code. Since an error and an empty string is considered the same, the error is replaced with an emtpy string using `|| echo`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Tested locally.
______

For contributor use:

- [X] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [X] Re-reviewed `Files changed` in the Github PR explorer.
