### PR TITLE
Derive `Debug`, `PartialEq` and `Eq` for module errors

### DIFF
--- a/.changelog/unreleased/improvements/1281-derive-traits-module-errors.md
+++ b/.changelog/unreleased/improvements/1281-derive-traits-module-errors.md
@@ -1,0 +1,4 @@
+- Derive `Debug`, `PartialEq` and `Eq` traits for module errors ([#1281])
+
+[#1281]: https://github.com/informalsystems/ibc-rs/issues/1281
+

--- a/modules/src/application/ics20_fungible_token_transfer/error.rs
+++ b/modules/src/application/ics20_fungible_token_transfer/error.rs
@@ -4,6 +4,7 @@ use crate::ics24_host::identifier::{ChannelId, PortId};
 use flex_error::define_error;
 
 define_error! {
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         UnknowMessageTypeUrl
             { url: String }

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -57,7 +57,6 @@ mod tests {
     use test_env_log::test;
 
     use super::ClientType;
-    use crate::ics02_client::error::{Error, ErrorDetail};
 
     #[test]
     fn parse_tendermint_client_type() {

--- a/modules/src/ics02_client/client_type.rs
+++ b/modules/src/ics02_client/client_type.rs
@@ -57,6 +57,7 @@ mod tests {
     use test_env_log::test;
 
     use super::ClientType;
+    use crate::ics02_client::error::{Error, ErrorDetail};
 
     #[test]
     fn parse_tendermint_client_type() {

--- a/modules/src/ics02_client/error.rs
+++ b/modules/src/ics02_client/error.rs
@@ -4,12 +4,14 @@ use crate::ics23_commitment::error::Error as Ics23Error;
 use crate::ics24_host::error::ValidationError;
 use crate::ics24_host::identifier::ClientId;
 use crate::Height;
+
 use std::num::TryFromIntError;
-use tendermint_proto::Error as TendermintError;
 
 use flex_error::{define_error, DisplayOnly, TraceError};
+use tendermint_proto::Error as TendermintError;
 
 define_error! {
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         UnknownClientType
             { client_type: String }

--- a/modules/src/ics03_connection/error.rs
+++ b/modules/src/ics03_connection/error.rs
@@ -6,6 +6,7 @@ use crate::Height;
 use flex_error::define_error;
 
 define_error! {
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         Ics02Client
             [ client_error::Error ]

--- a/modules/src/ics04_channel/error.rs
+++ b/modules/src/ics04_channel/error.rs
@@ -10,6 +10,7 @@ use flex_error::{define_error, TraceError};
 use tendermint_proto::Error as TendermintError;
 
 define_error! {
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         UnknownState
             { state: i32 }

--- a/modules/src/ics07_tendermint/error.rs
+++ b/modules/src/ics07_tendermint/error.rs
@@ -2,6 +2,7 @@ use crate::ics24_host::error::ValidationError;
 use flex_error::{define_error, DisplayOnly, TraceError};
 
 define_error! {
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         InvalidTrustingPeriod
             { reason: String }

--- a/modules/src/ics23_commitment/error.rs
+++ b/modules/src/ics23_commitment/error.rs
@@ -2,7 +2,7 @@ use flex_error::{define_error, TraceError};
 use prost::DecodeError;
 
 define_error! {
-    #[derive(Debug, Clone)]
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         InvalidRawMerkleProof
             [ TraceError<DecodeError> ]

--- a/modules/src/ics23_commitment/merkle.rs
+++ b/modules/src/ics23_commitment/merkle.rs
@@ -6,7 +6,7 @@ use ibc_proto::ibc::core::commitment::v1::MerkleProof as RawMerkleProof;
 use crate::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofBytes};
 use crate::ics23_commitment::error::Error;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EmptyPrefixError;
 
 pub fn apply_prefix(

--- a/modules/src/ics26_routing/error.rs
+++ b/modules/src/ics26_routing/error.rs
@@ -5,6 +5,7 @@ use crate::ics04_channel;
 use flex_error::{define_error, TraceError};
 
 define_error! {
+    #[derive(Debug, PartialEq, Eq)]
     Error {
         Ics02Client
             [ ics02_client::error::Error ]


### PR DESCRIPTION
Closes: #1281 

## Description
This PR (currently) only derives these traits for errors in the `ibc` crate, but we could do this for all public errors. 


______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
