### PR TITLE
Correct small TypeOk bug in IBC.tla

### DIFF
--- a/.changelog/unreleased/bug-fixes/1285-fix-typeok-bug.md
+++ b/.changelog/unreleased/bug-fixes/1285-fix-typeok-bug.md
@@ -1,0 +1,4 @@
+- Fix small typo in IBC.tla specification
+
+[#1285]: https://github.com/informalsystems/ibc-rs/pull/1285
+

--- a/modules/tests/support/model_based/IBC.tla
+++ b/modules/tests/support/model_based/IBC.tla
@@ -113,7 +113,7 @@ ActionOutcomes == {
     "None",
     "ModelError",
     \* ICS02_CreateClient outcomes:
-    "icS02CreateOk",
+    "Ics02CreateOk",
     \* ICS02_UpdateClient outcomes:
     "Ics02UpdateOk",
     "Ics02ClientNotFound",


### PR DESCRIPTION
Closes: #XXX (I'm not doing a separate issue because it's a one-line fix that I noticed and fixed)

## Description

This PR fixes one line in the IBC.tla testing spec. There was a typo in the typeOK invariant which stops this spec from running correctly. It did not affect the tests because they import a different spec, which imports this spec, but whose config file does not check the invariant with the typo.
______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
