### PR TITLE
Attempt to document the associated chains for each packet field

### DIFF
--- a/modules/src/ics04_channel/msgs.rs
+++ b/modules/src/ics04_channel/msgs.rs
@@ -39,10 +39,47 @@ pub enum ChannelMsg {
     ChannelCloseConfirm(MsgChannelCloseConfirm),
 }
 
+/*
+    `PacketMsg` represents packet messages sent between an ALPHA chain
+    and a BETA chain.
+
+    The roles of ALPHA and BETA are FIXED and never change during
+    the relaying session. DIFFERENT relaying sessions are executed
+    for the case where the ALPHA and BETA roles are FLIPPED
+
+    Depending on the variant, a packet can flow in *either* direction,
+    and the exact flow is documented below.
+
+    All variants are parameterized by the SAME ALPHA and BETA
+    chains, i.e. the chain roles DO NOT FLIP.
+
+    In the same relaying session, the packet's ALPHA chain is
+    ALWAYS the SOURCE chain, and the packet's BETA
+    chain is ALWAYS the DESTINATION chain.
+*/
 #[derive(Clone, Debug, PartialEq)]
 pub enum PacketMsg {
+    /*
+        A `RecvPacket` represents the ALPHA chain RECEIVING
+        an INCOMING packet from the BETA chain.
+     */
     RecvPacket(MsgRecvPacket),
+
+    /*
+        An `AckPacket` represents the ALPHA chain SENDING
+        an acknowlegement as OUTGOING packet to the BETA chain.
+    */
     AckPacket(MsgAcknowledgement),
+
+    /*
+        A `ToPacket` represents the ALPHA chain RECEIVING
+        a timeout INCOMING packet from the BETA chain.
+     */
     ToPacket(MsgTimeout),
+
+    /*
+        A `ToClosePacket` represents the ALPHA chain RECEIVING
+        a timeout-on-close INCOMING packet from the BETA chain.
+     */
     ToClosePacket(MsgTimeoutOnClose),
 }

--- a/modules/src/ics04_channel/msgs/acknowledgement.rs
+++ b/modules/src/ics04_channel/msgs/acknowledgement.rs
@@ -12,14 +12,31 @@ use crate::tx_msg::Msg;
 
 pub const TYPE_URL: &str = "/ibc.core.channel.v1.MsgAcknowledgement";
 
-///
-/// Message definition for packet acknowledgements.
-///
+/*
+    A `MsgRecvPacket` is part of a `PacketMsg` which represents
+    an OUTGOING acknowledgment packet SENT by the ALPHA chain to
+    the BETA chain.
+ */
 #[derive(Clone, Debug, PartialEq)]
 pub struct MsgAcknowledgement {
+    /*
+        An OUTGOING packet with the SAME ALPHA and BETA chains.
+     */
     pub packet: Packet,
+
+    /*
+        The acknowlegement PRODUCED BY the ALPHA chain.
+     */
     pub acknowledgement: Vec<u8>, // TODO(romac): Introduce a newtype for this
+
+    /*
+        The proof of acknowledgement PRODUCED BY the ALPHA chain.
+     */
     pub proofs: Proofs,
+
+    /*
+        The signer FOR the BETA chain.
+     */
     pub signer: Signer,
 }
 

--- a/modules/src/ics04_channel/msgs/recv_packet.rs
+++ b/modules/src/ics04_channel/msgs/recv_packet.rs
@@ -12,13 +12,28 @@ use crate::tx_msg::Msg;
 
 pub const TYPE_URL: &str = "/ibc.core.channel.v1.MsgRecvPacket";
 
-///
-/// Message definition for the "packet receiving" datagram.
-///
+/*
+    Message definition for the "packet receiving" datagram.
+
+    A `MsgRecvPacket` is part of a `PacketMsg` which represents
+    an INCOMING packet RECEIVED by the ALPHA chain
+    and SENT from the BETA chain.
+ */
 #[derive(Clone, Debug, PartialEq)]
 pub struct MsgRecvPacket {
+    /*
+        An INCOMING packet with the ALPHA and BETA chains remain the SAME.
+     */
     pub packet: Packet,
+
+    /*
+        A proof that is produced FROM the BETA chain.
+     */
     pub proofs: Proofs,
+
+    /*
+        A signer FOR the ALPHA chain.
+     */
     pub signer: Signer,
 }
 

--- a/modules/src/ics04_channel/msgs/timeout.rs
+++ b/modules/src/ics04_channel/msgs/timeout.rs
@@ -12,14 +12,33 @@ use crate::tx_msg::Msg;
 
 pub const TYPE_URL: &str = "/ibc.core.channel.v1.MsgTimeout";
 
-///
-/// Message definition for packet timeout domain type.
-///
+/*
+    Message definition for packet timeout domain type.
+
+    A `MsgTimeout` is part of `PacketMsg` representing an
+    INCOMING timeout packet RECEIVED BY the ALPHA chain
+    and SENT FROM the BETA chain.
+ */
 #[derive(Clone, Debug, PartialEq)]
 pub struct MsgTimeout {
+    /*
+        An INCOMING packet with the SAME ALPHA and BETA chains.
+     */
     pub packet: Packet,
+
+    /*
+        The sequence number ON the ALPHA chain.
+     */
     pub next_sequence_recv: Sequence,
+
+    /*
+        The proof FROM the BETA chain proving the timeout.
+     */
     pub proofs: Proofs,
+
+    /*
+        The signer FOR the ALPHA chain.
+     */
     pub signer: Signer,
 }
 

--- a/modules/src/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/ics04_channel/msgs/timeout_on_close.rs
@@ -12,14 +12,33 @@ use crate::tx_msg::Msg;
 
 pub const TYPE_URL: &str = "/ibc.core.channel.v1.MsgTimeoutOnClose";
 
-///
-/// Message definition for packet timeout domain type.
-///
+/*
+    Message definition for packet timeout domain type.
+
+    A `MsgTimeoutOnClose` is part of `PacketMsg` representing an
+    INCOMING timeout-on-close packet RECEIVED BY the ALPHA chain
+    and SENT FROM the BETA chain.
+ */
 #[derive(Clone, Debug, PartialEq)]
 pub struct MsgTimeoutOnClose {
+    /*
+        An INCOMING packet with the SAME ALPHA and BETA chains.
+     */
     pub packet: Packet,
+
+    /*
+        The sequence number ON the ALPHA chain.
+     */
     pub next_sequence_recv: Sequence,
+
+    /*
+        The proof FROM the BETA chain proving the timeout.
+     */
     pub proofs: Proofs,
+
+    /*
+        The signer FOR the ALPHA chain.
+     */
     pub signer: Signer,
 }
 

--- a/relayer/src/chain/handle.rs
+++ b/relayer/src/chain/handle.rs
@@ -300,6 +300,21 @@ pub enum ChainRequest {
     },
 }
 
+/*
+    A ChainHandle is used in the context of a HOST chain and
+    a COUNTERPARTY chain.
+
+    The HOST chain is the chain that the underlying ChainHandle
+    implementation is communicating to.
+
+    The COUNTERPARTY chain is the chain that exist as an
+    IBC CLIENT on the HOST chain.
+
+    While a HOST chain can have many COUNTERPARTY chains, in a
+    single relaying session, the COUNTERPARTY chain is ALWAYS FIXED.
+    i.e. other than the registry glue code, the relayer code itself
+    DO NOT use a ChainHandle with multiple COUNTERPARTY chains.
+ */
 pub trait ChainHandle: Clone + Send + Sync + Serialize + Debug {
     fn new(chain_id: ChainId, sender: channel::Sender<ChainRequest>) -> Self;
 
@@ -462,12 +477,33 @@ pub trait ChainHandle: Clone + Send + Sync + Serialize + Debug {
         height: Height,
     ) -> Result<Proofs, Error>;
 
+    /*
+        Build packet proofs, depending on the DIRECTION identified by `packet_type`
+     */
     fn build_packet_proofs(
         &self,
         packet_type: PacketMsgType,
+
+        /*
+            The port ID of the COUNTERPARTY chain on the HOST chain
+         */
         port_id: &PortId,
+
+        /*
+            The channel ID of the COUNTERPARTY chain on the HOST chain
+         */
         channel_id: &ChannelId,
+
+        /*
+            If the direction is INCOMING, this is the sequence from the COUNTERPARTY chain.
+
+            If the direction is OUTGOING, this is the sequence from the HOST chain.
+         */
         sequence: Sequence,
+
+        /*
+            The height on the HOST chain
+         */
         height: Height,
     ) -> Result<(Vec<u8>, Proofs), Error>;
 


### PR DESCRIPTION
## Description

This is my attempt to document the associated chains for each packet field to understand how the relayer code really works. I am pretty sure some of the documentation are completely wrong. So the hope is through the reviews I can get a clearer picture of which packet field really belongs to which chain.

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
