### PR TITLE
Support uint256 transfer amount

### DIFF
--- a/.changelog/unreleased/improvements/1319-u256-amount-transfer.md
+++ b/.changelog/unreleased/improvements/1319-u256-amount-transfer.md
@@ -1,0 +1,4 @@
+- Add support for uint256 transfer amounts ([#1319])
+
+[#1319]: https://github.com/informalsystems/ibc-rs/issues/1319
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1423,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber 0.2.20",
+ "uint",
 ]
 
 [[package]]
@@ -1425,7 +1432,6 @@ version = "0.7.0"
 dependencies = [
  "abscissa_core",
  "atty",
- "bitcoin",
  "color-eyre",
  "crossbeam-channel 0.5.1",
  "dirs-next",
@@ -3489,6 +3495,18 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "uint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ version = "0.7.0"
 dependencies = [
  "abscissa_core",
  "atty",
+ "bitcoin",
  "color-eyre",
  "crossbeam-channel 0.5.1",
  "dirs-next",

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -53,7 +53,6 @@ itertools = "0.10.1"
 atty = "0.2.14"
 flex-error = { version = "0.4.2", default-features = false }
 signal-hook = "0.3.10"
-bitcoin = { version = "=0.27", features = ["use-serde"] }
 
 [dependencies.tendermint-proto]
 version = "=0.21.0"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -53,6 +53,7 @@ itertools = "0.10.1"
 atty = "0.2.14"
 flex-error = { version = "0.4.2", default-features = false }
 signal-hook = "0.3.10"
+bitcoin = { version = "=0.27", features = ["use-serde"] }
 
 [dependencies.tendermint-proto]
 version = "=0.21.0"

--- a/relayer-cli/src/commands/tx/transfer.rs
+++ b/relayer-cli/src/commands/tx/transfer.rs
@@ -1,5 +1,9 @@
-use abscissa_core::{config::Override, Command, FrameworkErrorKind, Options, Runnable};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
+use abscissa_core::{config::Override, Command, FrameworkErrorKind, Options, Runnable};
+use bitcoin::util::uint::{ParseLengthError, Uint256};
+use hex::FromHexError;
 use ibc::{
     events::IbcEvent,
     ics02_client::client_state::ClientState,
@@ -36,7 +40,7 @@ pub struct TxIcs20MsgTransferCmd {
         required,
         help = "amount of coins (samoleans, by default) to send (e.g. `100000`)"
     )]
-    amount: u64,
+    amount: Amount,
 
     #[options(help = "timeout in number of blocks since current", short = "o")]
     timeout_height_offset: u64,
@@ -112,7 +116,7 @@ impl TxIcs20MsgTransferCmd {
             packet_dst_chain_config: dest_chain_config.clone(),
             packet_src_port_id: self.src_port_id.clone(),
             packet_src_channel_id: self.src_channel_id.clone(),
-            amount: self.amount,
+            amount: self.amount.0,
             denom,
             receiver: self.receiver.clone(),
             timeout_height_offset: self.timeout_height_offset,
@@ -158,7 +162,7 @@ impl Runnable for TxIcs20MsgTransferCmd {
                 self.src_chain_id,
                 channel_end_src.state
             ))
-            .exit();
+                .exit();
         }
 
         let conn_id = match channel_end_src.connection_hops.first() {
@@ -167,7 +171,7 @@ impl Runnable for TxIcs20MsgTransferCmd {
                     "could not retrieve the connection hop underlying port/channel '{}'/'{}' on chain '{}'",
                     opts.packet_src_port_id, opts.packet_src_channel_id, self.src_chain_id
                 ))
-                .exit()
+                    .exit();
             }
             Some(cid) => cid,
         };
@@ -206,5 +210,46 @@ impl Runnable for TxIcs20MsgTransferCmd {
             Ok(ev) => Output::success(ev).exit(),
             Err(e) => Output::error(format!("{}", e)).exit(),
         }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Amount(Uint256);
+
+enum AmountParseError {
+    HexDecode(FromHexError),
+    U256Parse(ParseLengthError),
+}
+
+impl From<FromHexError> for AmountParseError {
+    fn from(e: FromHexError) -> Self {
+        Self::HexDecode(e)
+    }
+}
+
+impl From<ParseLengthError> for AmountParseError {
+    fn from(e: ParseLengthError) -> Self {
+        Self::U256Parse(e)
+    }
+}
+
+impl Display for AmountParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AmountParseError::HexDecode(e) => write!(f, "Failed to decode hex str: {}", e),
+            AmountParseError::U256Parse(e) => write!(f, "Parse length error: {}", e),
+        }
+    }
+}
+
+impl FromStr for Amount {
+    type Err = AmountParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        const SIZEOF_U256: usize = 32;
+        let value = s.strip_prefix("0x").unwrap_or(s);
+        let mut bytes = [0u8; SIZEOF_U256];
+        hex::decode_to_slice(value, &mut bytes[SIZEOF_U256 - value.len() / 2..])?;
+        Ok(Self(Uint256::from_be_slice(&bytes)?))
     }
 }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -62,6 +62,7 @@ signature = "1.3.0"
 anyhow = "1.0.43"
 fraction = {version = "0.9.0", default-features = false }
 semver = "1.0"
+uint = "0.9"
 
 [dependencies.tendermint]
 version = "=0.21.0"

--- a/relayer/src/transfer.rs
+++ b/relayer/src/transfer.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use bitcoin::util::uint::Uint256;
 use flex_error::{define_error, DetailOnly};
 use ibc::application::ics20_fungible_token_transfer::msgs::transfer::MsgTransfer;
 use ibc::events::IbcEvent;
@@ -56,7 +57,7 @@ pub struct TransferOptions {
     pub packet_dst_chain_config: ChainConfig,
     pub packet_src_port_id: PortId,
     pub packet_src_channel_id: ChannelId,
-    pub amount: u64,
+    pub amount: Uint256,
     pub denom: String,
     pub receiver: Option<String>,
     pub timeout_height_offset: u64,

--- a/relayer/src/util.rs
+++ b/relayer/src/util.rs
@@ -4,6 +4,7 @@ pub use block_on::block_on;
 mod recv_multiple;
 pub use recv_multiple::try_recv_multiple;
 
+pub mod bigint;
 pub mod diff;
 pub mod iter;
 pub mod queue;

--- a/relayer/src/util/bigint.rs
+++ b/relayer/src/util/bigint.rs
@@ -1,0 +1,8 @@
+#![allow(clippy::assign_op_pattern)]
+#![allow(clippy::ptr_offset_with_cast)]
+
+use uint::construct_uint;
+
+construct_uint! {
+    pub struct U256(4);
+}


### PR DESCRIPTION
Closes: #1319 

## Description
This PR adds support for `uint256` transfer amounts for the `hermes tx raw ft-transfer` CLI command. 
I tried to reuse `bitcoin::util::uint::Uint256` because we're already using the `bitcoin` crate, but that type doesn't implement a `from_radix_str()` and instead implements a `FromStr` which can only parse a hex string. 
______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
