### PR TITLE
Fix gaiad keys add outputs to stderr instead of stdout in SDK 0.43

### DIFF
--- a/.changelog/unreleased/bug-fixes/1312-fix-gm-stderr.md
+++ b/.changelog/unreleased/bug-fixes/1312-fix-gm-stderr.md
@@ -1,0 +1,6 @@
+- [gm](scripts/gm)
+  - Fix gaiad keys add prints to stderr instead of stdout in SDK 0.43 ([#1312])
+  - Bumped default rpc_timeout in Hermes config to 5s ([#1312])
+
+[#1312]: https://github.com/informalsystems/ibc-rs/issues/1312
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+
+### BUG FIXES
+
+- [gm](scripts/gm)
+  - Fix gaiad keys add prints to stderr instead of stdout in SDK 0.43 ([#1312])
+  - Bumped default rpc_timeout in Hermes config to 5s ([#1312])
+
+[#1312]: https://github.com/informalsystems/ibc-rs/issues/1312
+
 ## v0.7.0
 
 This release of Hermes is the first to be compatible with the development version of Cosmos SDK 0.43.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # CHANGELOG
 
-## Unreleased
-
-### BUG FIXES
-
-- [gm](scripts/gm)
-  - Fix gaiad keys add prints to stderr instead of stdout in SDK 0.43 ([#1312])
-  - Bumped default rpc_timeout in Hermes config to 5s ([#1312])
-
-[#1312]: https://github.com/informalsystems/ibc-rs/issues/1312
-
 ## v0.7.0
 
 This release of Hermes is the first to be compatible with the development version of Cosmos SDK 0.43.

--- a/scripts/gm/CHANGELOG.md
+++ b/scripts/gm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Gaiad Manager Change Log
 
+## v0.0.8
+
+### BUGFIXES
+- Fixed gaiad 0.43 keys add printing key to stderr instead of stdout issue ([#1312])
+- Bumped default rpc_timeout in Hermes config to 5s ([#1312])
+
+[#1312]: https://github.com/informalsystems/ibc-rs/issues/1312
+
 ## v0.0.7
 
 ### BUGFIXES

--- a/scripts/gm/bin/lib-gm
+++ b/scripts/gm/bin/lib-gm
@@ -5,7 +5,7 @@ if [ "${DEBUG:-}" = "2" ]; then
 fi
 
 version() {
-  echo "v0.0.7"
+  echo "v0.0.8"
 }
 
 # Configuration Management

--- a/scripts/gm/bin/lib-gm
+++ b/scripts/gm/bin/lib-gm
@@ -462,27 +462,27 @@ create() {
     # Create validator key
     VALIDATOR_MNEMONIC="$(get_validator_mnemonic "$1")"
     if [ -z "$VALIDATOR_MNEMONIC" ] && [ -z "$HDPATH" ]; then
-      "$GAIAD_BINARY" keys add "validator" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/validator_seed.json"
+      "$GAIAD_BINARY" keys add "validator" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/validator_seed.json" 2>&1
     elif [ -z "$VALIDATOR_MNEMONIC" ] && [ -n "$HDPATH" ]; then
-      "$GAIAD_BINARY" keys add "validator" --hd-path "$HDPATH" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/validator_seed.json"
+      "$GAIAD_BINARY" keys add "validator" --hd-path "$HDPATH" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/validator_seed.json" 2>&1
     elif [ -n "$VALIDATOR_MNEMONIC" ] && [ -z "$HDPATH" ]; then
-      echo "$VALIDATOR_MNEMONIC" | "$GAIAD_BINARY" keys add "validator" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/validator_seed.json"
+      echo "$VALIDATOR_MNEMONIC" | "$GAIAD_BINARY" keys add "validator" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/validator_seed.json" 2>&1
       sconfig "${HOME_DIR}/validator_seed.json" -t string "mnemonic=${VALIDATOR_MNEMONIC}" 1> /dev/null
     elif [ -n "$VALIDATOR_MNEMONIC" ] && [ -n "$HDPATH" ]; then
-      echo "$VALIDATOR_MNEMONIC" | "$GAIAD_BINARY" keys add "validator" --hd-path "$HDPATH" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/validator_seed.json"
+      echo "$VALIDATOR_MNEMONIC" | "$GAIAD_BINARY" keys add "validator" --hd-path "$HDPATH" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/validator_seed.json" 2>&1
       sconfig "${HOME_DIR}/validator_seed.json" -t string "mnemonic=${VALIDATOR_MNEMONIC}" 1> /dev/null
     fi
     # Create wallet key
     WALLET_MNEMONIC="$(get_wallet_mnemonic "$1")"
     if [ -z "$WALLET_MNEMONIC" ] && [ -z "$HDPATH" ]; then
-      "$GAIAD_BINARY" keys add "wallet" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/wallet_seed.json"
+      "$GAIAD_BINARY" keys add "wallet" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/wallet_seed.json" 2>&1
     elif [ -z "$WALLET_MNEMONIC" ] && [ -n "$HDPATH" ]; then
-      "$GAIAD_BINARY" keys add "wallet" --hd-path "$HDPATH" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/wallet_seed.json"
+      "$GAIAD_BINARY" keys add "wallet" --hd-path "$HDPATH" --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/wallet_seed.json" 2>&1
     elif [ -n "$WALLET_MNEMONIC" ] && [ -z "$HDPATH" ]; then
-      echo "$WALLET_MNEMONIC" | "$GAIAD_BINARY" keys add "wallet" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/wallet_seed.json"
+      echo "$WALLET_MNEMONIC" | "$GAIAD_BINARY" keys add "wallet" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/wallet_seed.json" 2>&1
       sconfig "${HOME_DIR}/wallet_seed.json" -t string "mnemonic=${WALLET_MNEMONIC}" 1> /dev/null
     elif [ -n "$WALLET_MNEMONIC" ] && [ -n "$HDPATH" ]; then
-      echo "$WALLET_MNEMONIC" | "$GAIAD_BINARY" keys add "wallet" --hd-path "$HDPATH" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json > "${HOME_DIR}/wallet_seed.json"
+      echo "$WALLET_MNEMONIC" | "$GAIAD_BINARY" keys add "wallet" --hd-path "$HDPATH" --recover --keyring-backend test --keyring-dir "${HOME_DIR}" --output json 1> "${HOME_DIR}/wallet_seed.json" 2>&1
       sconfig "${HOME_DIR}/wallet_seed.json" -t string "mnemonic=${WALLET_MNEMONIC}" 1> /dev/null
     fi
     # Add accounts to genesis
@@ -769,7 +769,7 @@ id = '${ID}'
 rpc_addr = 'http://localhost:${RPC}'
 grpc_addr = 'http://localhost:${GRPC}'
 websocket_addr = 'ws://localhost:${RPC}/websocket'
-rpc_timeout = '1s'
+rpc_timeout = '5s'
 account_prefix = '${ACCOUNT_PREFIX}'
 key_name = 'wallet'
 store_prefix = 'ibc'


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1312

## Description
Fixes gm for SDK 0.43: in SDK 0.43, `gaiad keys add` will print its result onto stderr instead of stdout. Previous versions sent output to stdout.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Now it will work both with SDK 0.42 and 0.43.

Tested locally.

______

For contributor use:

- [X] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [X] Re-reviewed `Files changed` in the Github PR explorer.
