### PR TITLE
Modified packet worker to use stubborn strategy

### DIFF
--- a/.changelog/unreleased/features/1290-stubborn-workers.md
+++ b/.changelog/unreleased/features/1290-stubborn-workers.md
@@ -1,0 +1,2 @@
+- Modified packet worker to use stubborn strategy ([#1290](https://github.com/informalsystems/ibc-rs/issues/1290))
+

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -77,7 +77,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
                 recv(crossbeam_channel::after(BACKOFF)) -> _ => None,
             };
 
-            let result = retry_with_index(retry_strategy::worker_default_strategy(), |index| {
+            let result = retry_with_index(retry_strategy::worker_stubborn_strategy(), |index| {
                 self.step(maybe_cmd.clone(), &mut link, index)
             });
 

--- a/relayer/src/worker/retry_strategy.rs
+++ b/relayer/src/worker/retry_strategy.rs
@@ -1,12 +1,93 @@
-use crate::util::retry::{clamp_total, ConstantGrowth};
+use crate::util::retry::{clamp_total, clamp, ConstantGrowth};
 use std::time::Duration;
 
-const MAX_DELAY: Duration = Duration::from_millis(500);
-const DELAY_INCR: Duration = Duration::from_millis(100);
-const INITIAL_DELAY: Duration = Duration::from_millis(200);
-const MAX_RETRY_DURATION: Duration = Duration::from_secs(2);
 
+/// A basic worker retry strategy.
+///
+/// The delay is initially 200ms and grows
+/// by 100ms at each step. The delay is
+/// capped at 500ms.
+/// The overall amount of time spent retrying
+/// is capped to 2 seconds.
+/// See the `default_strategy` test below.
 pub fn worker_default_strategy() -> impl Iterator<Item = Duration> {
-    let strategy = ConstantGrowth::new(INITIAL_DELAY, DELAY_INCR);
-    clamp_total(strategy, MAX_DELAY, MAX_RETRY_DURATION)
+    let strategy = ConstantGrowth::new(Duration::from_millis(200), Duration::from_millis(100));
+    clamp_total(strategy, Duration::from_millis(500), Duration::from_secs(2))
+}
+
+
+/// A stubborn worker retry strategy.
+///
+/// Initial retry delay is hardcoded to 500ms, and
+/// the delay grows by 500ms at every step. The
+/// strategy delay is capped at 20 sec. The
+/// total number of retries is capped to 200.
+/// Therefore the overall amount of time spent
+/// retrying will be approx. 1 hour.
+///
+/// See the `stubbord_strategy` test below.
+pub fn worker_stubborn_strategy() -> impl Iterator<Item = Duration> {
+    let strategy = ConstantGrowth::new(Duration::from_millis(500), Duration::from_millis(500));
+    clamp(strategy, Duration::from_secs(20), 200)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::worker::retry_strategy::{worker_stubborn_strategy, worker_default_strategy};
+
+    #[test]
+    fn default_strategy() {
+        let strategy = worker_default_strategy();
+        let delays = strategy.take(10).collect::<Vec<_>>();
+        assert_eq!(delays,
+            vec![
+                Duration::from_millis(200),
+                Duration::from_millis(300),
+                Duration::from_millis(400),
+                Duration::from_millis(500),
+                Duration::from_millis(500),
+                Duration::from_millis(100),
+            ]
+        );
+    }
+
+    #[test]
+    fn stubborn_strategy() {
+        let strategy = worker_stubborn_strategy();
+        let delays = strategy.collect::<Vec<_>>();
+        assert_eq!(delays.len(), 200);
+
+        // Assert the first 10 steps manually
+        assert_eq!(delays.iter().take(10).cloned().collect::<Vec<_>>(),
+            vec![
+                Duration::from_millis(500),
+                Duration::from_millis(1000),
+                Duration::from_millis(1500),
+                Duration::from_millis(2000),
+                Duration::from_millis(2500),
+                Duration::from_millis(3000),
+                Duration::from_millis(3500),
+                Duration::from_millis(4000),
+                Duration::from_millis(4500),
+                Duration::from_millis(5000),
+            ]
+        );
+
+        // Assert that delays increment by 500ms and are capped to 20s
+        let mut delaysp = delays.into_iter().peekable();
+        let cap = Duration::from_secs(20);
+        let step = Duration::from_millis(500);
+        for first in delaysp.next() {
+            if let Some(next) = delaysp.peek() {
+                if first == cap {
+                    assert_eq!(*next, cap);
+                } else {
+                    assert_eq!(first + step, *next);
+                }
+            }
+        }
+    }
 }

--- a/relayer/src/worker/retry_strategy.rs
+++ b/relayer/src/worker/retry_strategy.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 
 /// A basic worker retry strategy.
 ///
-/// The delay is initially 200ms and grows
-/// by 100ms at each step. The delay is
+/// The backoff delay is initially 200ms and grows
+/// by 100ms at each step. The backoff delay is
 /// capped at 500ms.
-/// The overall amount of time spent retrying
+/// The overall amount of time spent backing off
 /// is capped to 2 seconds.
 /// See the `default_strategy` test below.
 pub fn worker_default_strategy() -> impl Iterator<Item = Duration> {
@@ -16,8 +16,8 @@ pub fn worker_default_strategy() -> impl Iterator<Item = Duration> {
 
 /// A stubborn worker retry strategy.
 ///
-/// Initial retry delay is hardcoded to 1s, and
-/// the delay grows very slowly and steadily by
+/// Initial retry backoff is hardcoded to 1s, and
+/// this delay grows very slowly and steadily by
 /// 10ms at every step. The strategy delay is
 /// not capped, so it will retry indefinitely.
 ///
@@ -36,6 +36,7 @@ mod tests {
     fn default_strategy() {
         let strategy = worker_default_strategy();
         let delays = strategy.take(10).collect::<Vec<_>>();
+        // This strategy has exactly 6 retry steps
         assert_eq!(
             delays,
             vec![
@@ -52,6 +53,7 @@ mod tests {
     #[test]
     fn stubborn_strategy() {
         let strategy = worker_stubborn_strategy();
+        // This strategy has an infinite amount of retry steps
         // Assert that delays increment by 10ms
         // Stop after 50 iterations
         let mut delaysp = strategy.into_iter().take(50).peekable();

--- a/relayer/src/worker/retry_strategy.rs
+++ b/relayer/src/worker/retry_strategy.rs
@@ -1,6 +1,5 @@
-use crate::util::retry::{clamp_total, clamp, ConstantGrowth};
+use crate::util::retry::{clamp, clamp_total, ConstantGrowth};
 use std::time::Duration;
-
 
 /// A basic worker retry strategy.
 ///
@@ -14,7 +13,6 @@ pub fn worker_default_strategy() -> impl Iterator<Item = Duration> {
     let strategy = ConstantGrowth::new(Duration::from_millis(200), Duration::from_millis(100));
     clamp_total(strategy, Duration::from_millis(500), Duration::from_secs(2))
 }
-
 
 /// A stubborn worker retry strategy.
 ///
@@ -31,18 +29,18 @@ pub fn worker_stubborn_strategy() -> impl Iterator<Item = Duration> {
     clamp(strategy, Duration::from_secs(60), 400)
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
-    use crate::worker::retry_strategy::{worker_stubborn_strategy, worker_default_strategy};
+    use crate::worker::retry_strategy::{worker_default_strategy, worker_stubborn_strategy};
 
     #[test]
     fn default_strategy() {
         let strategy = worker_default_strategy();
         let delays = strategy.take(10).collect::<Vec<_>>();
-        assert_eq!(delays,
+        assert_eq!(
+            delays,
             vec![
                 Duration::from_millis(200),
                 Duration::from_millis(300),
@@ -61,7 +59,8 @@ mod tests {
         assert_eq!(delays.len(), 400);
 
         // Assert the first 10 steps manually
-        assert_eq!(delays.iter().take(10).cloned().collect::<Vec<_>>(),
+        assert_eq!(
+            delays.iter().take(10).cloned().collect::<Vec<_>>(),
             vec![
                 Duration::from_secs(1),
                 Duration::from_secs(2),
@@ -80,7 +79,7 @@ mod tests {
         let mut delaysp = delays.into_iter().peekable();
         let cap = Duration::from_secs(60);
         let step = Duration::from_secs(1);
-        for first in delaysp.next() {
+        while let Some(first) = delaysp.next() {
             if let Some(next) = delaysp.peek() {
                 if first == cap {
                     assert_eq!(*next, cap);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1290 

## Description

The following describes worker behavior after this PR:

- packet worker:
    - old behavior: used a default retry strategy that retried for 6 iterations and then gave up;
      - the individual retry backoff varied between 200ms and 500ms
      - **the cumulative backoff time was 2 seconds**
    - new behavior: using a stubborn strategy, which retries for infinite iterations and never gives up
      - the individual backoff time (between subsequent retries) is 1sec in the beginning, and increases steadily by 10ms at every step

~~The rationale for this choice is as follows. I expect past a certain duration (I choose in this PR 6 hours), Hermes might as well give up, as there is little chance that the connection can become healthy again without operator intervention, but not sure if my intuition is appropriate.~~


---

Unchanged behavior:

- client worker
    - this worker is in charge of regularly updating clients (unless there is already channel traffic, which will trigger client updates), at a frequency of 2/3 of trusting period
    - **this worker is already stubborn**: never quits unless the supervisor instructs it to do so, or if the client is expired or frozen

- channel and connection workers
    - these are in charge of finishing up initialized (but incomplete) connection handshakes or initialized channel handshakes
    - **these workers don't need to retry stubbornly**, because their activity is time-sensitive

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
