### PR TITLE
Add absolute path for lib gm

### DIFF
--- a/scripts/gm/CHANGELOG.md
+++ b/scripts/gm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gaiad Manager Change Log
 
+## v0.0.9
+
+### FEATURES
+- Add the option to set gm-lib path via the $GM_LIB environment variable ([#1365])
+
 ## v0.0.8
 
 ### BUGFIXES

--- a/scripts/gm/bin/gm
+++ b/scripts/gm/bin/gm
@@ -2,8 +2,7 @@
 
 set -eu
 
-# Load lib-gm either from the local folder or from the global $HOME/.gm/bin/lib-gm or finally from an absolute path set
-# as an environment variable
+# Load lib-gm either from the local folder or from the global $HOME/.gm/bin/lib-gm
 SCRIPT_0="${0:-$HOME/.gm/bin/gm}"
 export SCRIPT_DIR="${SCRIPT_0%%gm}"
 export LOCAL_LIB_GM="${SCRIPT_DIR}lib-gm"
@@ -11,8 +10,8 @@ if [ -f "$LOCAL_LIB_GM" ]; then
   . "$LOCAL_LIB_GM"
 elif [ -f "$HOME/.gm/bin/lib-gm" ]; then
   . "$HOME/.gm/bin/lib-gm"
-elif [ -f "$LIB_GM_PATH/lib-gm" ]; then
-  . "$LIB_GM_PATH/lib-gm"
+elif [ -f "${LIB_GM-:}" ]; then
+  . "$LIB_GM"
 else
   echo "ERROR: could not find lib-gm, exiting..."
   exit 1

--- a/scripts/gm/bin/gm
+++ b/scripts/gm/bin/gm
@@ -7,6 +7,7 @@ set -eu
 SCRIPT_0="${0:-$HOME/.gm/bin/gm}"
 export SCRIPT_DIR="${SCRIPT_0%%gm}"
 export LOCAL_LIB_GM="${SCRIPT_DIR}lib-gm"
+echo $LIB_GM_PATH
 if [ -f "$LOCAL_LIB_GM" ]; then
   . "$LOCAL_LIB_GM"
 elif [ -f "$HOME/.gm/bin/lib-gm" ]; then

--- a/scripts/gm/bin/gm
+++ b/scripts/gm/bin/gm
@@ -12,8 +12,8 @@ if [ -f "$LOCAL_LIB_GM" ]; then
   . "$LOCAL_LIB_GM"
 elif [ -f "$HOME/.gm/bin/lib-gm" ]; then
   . "$HOME/.gm/bin/lib-gm"
-elif [ -f "$LIB_GM_PATH" ]; then
-  . "$HOME"
+elif [ -f "$LIB_GM_PATH/lib-gm" ]; then
+  . "$LIB_GM_PATH/lib-gm"
 else
   echo "ERROR: could not find lib-gm, exiting..."
   exit 1

--- a/scripts/gm/bin/gm
+++ b/scripts/gm/bin/gm
@@ -2,7 +2,8 @@
 
 set -eu
 
-# Load lib-gm either from the local folder or from the global $HOME/.gm/bin/lib-gm
+# Load lib-gm either from the local folder or from the global $HOME/.gm/bin/lib-gm or finally from an absolute path set
+# as an environment variable
 SCRIPT_0="${0:-$HOME/.gm/bin/gm}"
 export SCRIPT_DIR="${SCRIPT_0%%gm}"
 export LOCAL_LIB_GM="${SCRIPT_DIR}lib-gm"
@@ -10,6 +11,8 @@ if [ -f "$LOCAL_LIB_GM" ]; then
   . "$LOCAL_LIB_GM"
 elif [ -f "$HOME/.gm/bin/lib-gm" ]; then
   . "$HOME/.gm/bin/lib-gm"
+elif [ -f "$LIB_GM_PATH" ]; then
+  . "$HOME"
 else
   echo "ERROR: could not find lib-gm, exiting..."
   exit 1

--- a/scripts/gm/bin/gm
+++ b/scripts/gm/bin/gm
@@ -10,7 +10,7 @@ if [ -f "$LOCAL_LIB_GM" ]; then
   . "$LOCAL_LIB_GM"
 elif [ -f "$HOME/.gm/bin/lib-gm" ]; then
   . "$HOME/.gm/bin/lib-gm"
-elif [ -f "${LIB_GM-:}" ]; then
+elif [ -f "${LIB_GM:-}" ]; then
   . "$LIB_GM"
 else
   echo "ERROR: could not find lib-gm, exiting..."

--- a/scripts/gm/bin/gm
+++ b/scripts/gm/bin/gm
@@ -7,7 +7,6 @@ set -eu
 SCRIPT_0="${0:-$HOME/.gm/bin/gm}"
 export SCRIPT_DIR="${SCRIPT_0%%gm}"
 export LOCAL_LIB_GM="${SCRIPT_DIR}lib-gm"
-echo $LIB_GM_PATH
 if [ -f "$LOCAL_LIB_GM" ]; then
   . "$LOCAL_LIB_GM"
 elif [ -f "$HOME/.gm/bin/lib-gm" ]; then


### PR DESCRIPTION
## Description

This is a tiny pr that adds the possibility to provide lib gm via the environment variable `$LIB_GM_PATH`. This helps me close https://github.com/informalsystems/cosmos.nix/issues/34 by allowing me to wrap the `gm` executable and provide all the runtime dependencies (namely `stoml` and `sconfig`). This wrapping, means that the `gm` executable is no longer located next to `lib-gm`, and I don't want to force the user to move lib-gm into their `$HOME` directory. Therefore I need a third option, to provide an absolute path to `lib-gm`. I hope that this change isn't too intrusive!


closes #1365
______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
