### PR TITLE
Enable global use of telemetrics

### DIFF
--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -22,7 +22,6 @@ use crate::{
     object::Object,
     registry::Registry,
     rest,
-    telemetry::Telemetry,
     util::try_recv_multiple,
     worker::{WorkerMap, WorkerMsg},
 };
@@ -61,9 +60,6 @@ pub struct Supervisor<Chain: ChainHandle> {
     worker_msg_rx: Receiver<WorkerMsg>,
     rest_rx: Option<rest::Receiver>,
     client_state_filter: FilterPolicy,
-
-    #[allow(dead_code)]
-    telemetry: Telemetry,
 }
 
 impl<Chain: ChainHandle + 'static> Supervisor<Chain> {
@@ -71,11 +67,10 @@ impl<Chain: ChainHandle + 'static> Supervisor<Chain> {
     pub fn new(
         config: RwArc<Config>,
         rest_rx: Option<rest::Receiver>,
-        telemetry: Telemetry,
     ) -> (Self, Sender<SupervisorCmd>) {
         let registry = Registry::new(config.clone());
         let (worker_msg_tx, worker_msg_rx) = crossbeam_channel::unbounded();
-        let workers = WorkerMap::new(worker_msg_tx, telemetry.clone());
+        let workers = WorkerMap::new(worker_msg_tx);
         let client_state_filter = FilterPolicy::default();
 
         let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded();
@@ -88,7 +83,6 @@ impl<Chain: ChainHandle + 'static> Supervisor<Chain> {
             worker_msg_rx,
             rest_rx,
             client_state_filter,
-            telemetry,
         };
 
         (supervisor, cmd_tx)

--- a/relayer/src/telemetry.rs
+++ b/relayer/src/telemetry.rs
@@ -21,7 +21,7 @@ pub type Telemetry = TelemetryDisabled;
 /// ## Example
 ///
 /// ```rust,ignore
-/// telemetry!(self.telemetry.tx_count(1));
+/// telemetry!(ibc_telemetry::global().tx_count(1));
 /// ```
 #[macro_export]
 macro_rules! telemetry {

--- a/relayer/src/telemetry.rs
+++ b/relayer/src/telemetry.rs
@@ -14,17 +14,30 @@ pub type Telemetry = TelemetryDisabled;
 /// only if the `telemetry` feature is enabled.
 /// Otherwise, it compiles to a no-op.
 ///
-/// ## Note
-/// Equivalent to `#[cfg(feature = "telemetry")]`, but
-/// should be preferred over the latter.
+/// The macro can be used in two ways:
 ///
-/// ## Example
+/// a) By passing it an arbitrary expression as its single argument.
 ///
 /// ```rust,ignore
-/// telemetry!(ibc_telemetry::global().tx_count(1));
+/// telemetry!(ibc_telemetry::global().tx_count(chain.id(), 1));
 /// ```
+///
+/// b) In the common case where one wants to update a metric,
+///    the macro accepts the metric's name, followed by its arguments.
+///
+/// ```rust,ignore
+/// telemetry!(tx_count, chain.id(), 1);
+/// ```
+///
 #[macro_export]
 macro_rules! telemetry {
+    ($id:ident, $($args:expr),* $(,)*) => {
+        #[cfg(feature = "telemetry")]
+        {
+            ::ibc_telemetry::global().$id($($args),*);
+        }
+    };
+
     ($e:expr) => {
         #[cfg(feature = "telemetry")]
         {

--- a/relayer/src/worker.rs
+++ b/relayer/src/worker.rs
@@ -8,7 +8,6 @@ use crate::{
     chain::handle::{ChainHandle, ChainHandlePair},
     config::Config,
     object::Object,
-    telemetry::Telemetry,
 };
 
 pub mod retry_strategy;
@@ -85,7 +84,6 @@ impl<ChainA: ChainHandle + 'static, ChainB: ChainHandle + 'static> Worker<ChainA
         id: WorkerId,
         object: Object,
         msg_tx: Sender<WorkerMsg>,
-        telemetry: Telemetry,
         config: &Config,
     ) -> WorkerHandle {
         let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded();
@@ -93,25 +91,22 @@ impl<ChainA: ChainHandle + 'static, ChainB: ChainHandle + 'static> Worker<ChainA
         debug!("spawning worker for object {}", object.short_name(),);
 
         let worker = match &object {
-            Object::Client(client) => Self::Client(
-                id,
-                ClientWorker::new(client.clone(), chains, cmd_rx, telemetry),
-            ),
+            Object::Client(client) => {
+                Self::Client(id, ClientWorker::new(client.clone(), chains, cmd_rx))
+            }
             Object::Connection(connection) => Self::Connection(
                 id,
-                ConnectionWorker::new(connection.clone(), chains, cmd_rx, telemetry),
+                ConnectionWorker::new(connection.clone(), chains, cmd_rx),
             ),
-            Object::Channel(channel) => Self::Channel(
-                id,
-                ChannelWorker::new(channel.clone(), chains, cmd_rx, telemetry),
-            ),
+            Object::Channel(channel) => {
+                Self::Channel(id, ChannelWorker::new(channel.clone(), chains, cmd_rx))
+            }
             Object::Packet(path) => Self::Packet(
                 id,
                 PacketWorker::new(
                     path.clone(),
                     chains,
                     cmd_rx,
-                    telemetry,
                     config.global.clear_packets_interval,
                 ),
             ),

--- a/relayer/src/worker/channel.rs
+++ b/relayer/src/worker/channel.rs
@@ -5,7 +5,6 @@ use crossbeam_channel::Receiver;
 use tracing::{debug, info, warn};
 
 use crate::channel::Channel as RelayChannel;
-use crate::telemetry::Telemetry;
 use crate::{
     chain::handle::{ChainHandle, ChainHandlePair},
     object::Channel,
@@ -20,9 +19,6 @@ pub struct ChannelWorker<ChainA: ChainHandle, ChainB: ChainHandle> {
     channel: Channel,
     chains: ChainHandlePair<ChainA, ChainB>,
     cmd_rx: Receiver<WorkerCmd>,
-
-    #[allow(dead_code)]
-    telemetry: Telemetry,
 }
 
 impl<ChainA: ChainHandle, ChainB: ChainHandle> ChannelWorker<ChainA, ChainB> {
@@ -30,13 +26,11 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ChannelWorker<ChainA, ChainB> {
         channel: Channel,
         chains: ChainHandlePair<ChainA, ChainB>,
         cmd_rx: Receiver<WorkerCmd>,
-        telemetry: Telemetry,
     ) -> Self {
         Self {
             channel,
             chains,
             cmd_rx,
-            telemetry,
         }
     }
 

--- a/relayer/src/worker/client.rs
+++ b/relayer/src/worker/client.rs
@@ -11,7 +11,6 @@ use crate::{
     foreign_client::{ForeignClient, ForeignClientErrorDetail, MisbehaviourResults},
     object::Client,
     telemetry,
-    telemetry::Telemetry,
 };
 
 use super::error::RunError;
@@ -21,9 +20,6 @@ pub struct ClientWorker<ChainA: ChainHandle, ChainB: ChainHandle> {
     client: Client,
     chains: ChainHandlePair<ChainA, ChainB>,
     cmd_rx: Receiver<WorkerCmd>,
-
-    #[allow(dead_code)]
-    telemetry: Telemetry,
 }
 
 impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
@@ -31,13 +27,11 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
         client: Client,
         chains: ChainHandlePair<ChainA, ChainB>,
         cmd_rx: Receiver<WorkerCmd>,
-        telemetry: Telemetry,
     ) -> Self {
         Self {
             client,
             chains,
             cmd_rx,
-            telemetry,
         }
     }
 
@@ -64,7 +58,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
             match client.refresh() {
                 Ok(Some(_)) => {
                     telemetry! {
-                        self.telemetry.ibc_client_update(
+                        ibc_telemetry::global().ibc_client_update(
                             &self.client.dst_chain_id,
                             &self.client.dst_client_id,
                             1
@@ -111,7 +105,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
                         // iteration with frozen client
                         if self.detect_misbehaviour(client, Some(update)) {
                             telemetry! {
-                                self.telemetry.ibc_client_misbehaviour(
+                                ibc_telemetry::global().ibc_client_misbehaviour(
                                     &self.client.dst_chain_id,
                                     &self.client.dst_client_id,
                                     1

--- a/relayer/src/worker/client.rs
+++ b/relayer/src/worker/client.rs
@@ -57,13 +57,12 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
             // Run client refresh, exit only if expired or frozen
             match client.refresh() {
                 Ok(Some(_)) => {
-                    telemetry! {
-                        ibc_telemetry::global().ibc_client_update(
-                            &self.client.dst_chain_id,
-                            &self.client.dst_client_id,
-                            1
-                        )
-                    };
+                    telemetry!(
+                        ibc_client_update,
+                        &self.client.dst_chain_id,
+                        &self.client.dst_client_id,
+                        1
+                    );
                 }
                 Err(e) => {
                     if let ForeignClientErrorDetail::ExpiredOrFrozen(_) = e.detail() {
@@ -104,13 +103,12 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
                         // Run misbehaviour. If evidence submitted the loop will exit in next
                         // iteration with frozen client
                         if self.detect_misbehaviour(client, Some(update)) {
-                            telemetry! {
-                                ibc_telemetry::global().ibc_client_misbehaviour(
-                                    &self.client.dst_chain_id,
-                                    &self.client.dst_client_id,
-                                    1
-                                )
-                            };
+                            telemetry!(
+                                ibc_client_misbehaviour,
+                                &self.client.dst_chain_id,
+                                &self.client.dst_client_id,
+                                1
+                            );
                         }
                     }
                 }

--- a/relayer/src/worker/connection.rs
+++ b/relayer/src/worker/connection.rs
@@ -5,7 +5,6 @@ use crossbeam_channel::Receiver;
 use tracing::{debug, info, warn};
 
 use crate::connection::Connection as RelayConnection;
-use crate::telemetry::Telemetry;
 use crate::{
     chain::handle::{ChainHandle, ChainHandlePair},
     object::Connection,
@@ -20,9 +19,6 @@ pub struct ConnectionWorker<ChainA: ChainHandle, ChainB: ChainHandle> {
     connection: Connection,
     chains: ChainHandlePair<ChainA, ChainB>,
     cmd_rx: Receiver<WorkerCmd>,
-
-    #[allow(dead_code)]
-    telemetry: Telemetry,
 }
 
 impl<ChainA: ChainHandle, ChainB: ChainHandle> ConnectionWorker<ChainA, ChainB> {
@@ -30,13 +26,11 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ConnectionWorker<ChainA, ChainB> 
         connection: Connection,
         chains: ChainHandlePair<ChainA, ChainB>,
         cmd_rx: Receiver<WorkerCmd>,
-        telemetry: Telemetry,
     ) -> Self {
         Self {
             connection,
             chains,
             cmd_rx,
-            telemetry,
         }
     }
 

--- a/relayer/src/worker/map.rs
+++ b/relayer/src/worker/map.rs
@@ -10,7 +10,6 @@ use crate::{
     config::Config,
     object::Object,
     telemetry,
-    telemetry::Telemetry,
 };
 
 use super::{Worker, WorkerHandle, WorkerId, WorkerMsg};
@@ -21,18 +20,16 @@ pub struct WorkerMap {
     workers: HashMap<Object, WorkerHandle>,
     latest_worker_id: WorkerId,
     msg_tx: Sender<WorkerMsg>,
-    telemetry: Telemetry,
 }
 
 impl WorkerMap {
     /// Create a new worker map, which will spawn workers with
     /// the given channel for sending messages back to the [`Supervisor`].
-    pub fn new(msg_tx: Sender<WorkerMsg>, telemetry: Telemetry) -> Self {
+    pub fn new(msg_tx: Sender<WorkerMsg>) -> Self {
         Self {
             workers: HashMap::new(),
             latest_worker_id: WorkerId::new(0),
             msg_tx,
-            telemetry,
         }
     }
 
@@ -46,7 +43,7 @@ impl WorkerMap {
     pub fn remove_stopped(&mut self, id: WorkerId, object: Object) -> bool {
         match self.workers.remove(&object) {
             Some(handle) if handle.id() == id => {
-                telemetry!(self.telemetry.worker(metric_type(&object), -1));
+                telemetry!(ibc_telemetry::global().worker(metric_type(&object), -1));
 
                 let id = handle.id();
 
@@ -148,14 +145,13 @@ impl WorkerMap {
         object: &Object,
         config: &Config,
     ) -> WorkerHandle {
-        telemetry!(self.telemetry.worker(metric_type(object), 1));
+        telemetry!(ibc_telemetry::global().worker(metric_type(object), 1));
 
         Worker::spawn(
             ChainHandlePair { a: src, b: dst },
             self.next_worker_id(),
             object.clone(),
             self.msg_tx.clone(),
-            self.telemetry.clone(),
             config,
         )
     }
@@ -187,7 +183,7 @@ impl WorkerMap {
     /// Shutdown the worker associated with the given [`Object`].
     pub fn shutdown_worker(&mut self, object: &Object) {
         if let Some(handle) = self.workers.remove(object) {
-            telemetry!(self.telemetry.worker(metric_type(object), -1));
+            telemetry!(ibc_telemetry::global().worker(metric_type(object), -1));
 
             match handle.shutdown() {
                 Ok(()) => {

--- a/relayer/src/worker/map.rs
+++ b/relayer/src/worker/map.rs
@@ -43,7 +43,7 @@ impl WorkerMap {
     pub fn remove_stopped(&mut self, id: WorkerId, object: Object) -> bool {
         match self.workers.remove(&object) {
             Some(handle) if handle.id() == id => {
-                telemetry!(ibc_telemetry::global().worker(metric_type(&object), -1));
+                telemetry!(worker, metric_type(&object), -1);
 
                 let id = handle.id();
 
@@ -145,7 +145,7 @@ impl WorkerMap {
         object: &Object,
         config: &Config,
     ) -> WorkerHandle {
-        telemetry!(ibc_telemetry::global().worker(metric_type(object), 1));
+        telemetry!(worker, metric_type(object), 1);
 
         Worker::spawn(
             ChainHandlePair { a: src, b: dst },
@@ -183,7 +183,7 @@ impl WorkerMap {
     /// Shutdown the worker associated with the given [`Object`].
     pub fn shutdown_worker(&mut self, object: &Object) {
         if let Some(handle) = self.workers.remove(object) {
-            telemetry!(ibc_telemetry::global().worker(metric_type(object), -1));
+            telemetry!(worker, metric_type(object), -1);
 
             match handle.shutdown() {
                 Ok(()) => {

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -192,12 +192,13 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
             .filter(|e| matches!(e, WriteAcknowledgement(_)))
             .count();
 
-        ibc_telemetry::global().ibc_receive_packets(
+        telemetry!(
+            ibc_receive_packets,
             &self.path.src_chain_id,
             &self.path.src_channel_id,
             &self.path.src_port_id,
             count as u64,
-        )
+        );
     }
 
     #[cfg(feature = "telemetry")]
@@ -210,12 +211,13 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
             .filter(|e| matches!(e, AcknowledgePacket(_)))
             .count();
 
-        ibc_telemetry::global().ibc_acknowledgment_packets(
+        telemetry!(
+            ibc_acknowledgment_packets,
             &self.path.src_chain_id,
             &self.path.src_channel_id,
             &self.path.src_port_id,
             count as u64,
-        )
+        );
     }
 
     #[cfg(feature = "telemetry")]
@@ -227,11 +229,12 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
             .filter(|e| matches!(e, TimeoutPacket(_)))
             .count();
 
-        ibc_telemetry::global().ibc_timeout_packets(
+        telemetry!(
+            ibc_timeout_packets,
             &self.path.src_chain_id,
             &self.path.src_channel_id,
             &self.path.src_port_id,
             count as u64,
-        )
+        );
     }
 }

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -8,7 +8,6 @@ use crate::{
     link::{Link, LinkParameters, RelaySummary},
     object::Packet,
     telemetry,
-    telemetry::Telemetry,
     util::retry::{retry_with_index, RetryResult},
     worker::retry_strategy,
 };
@@ -26,7 +25,6 @@ pub struct PacketWorker<ChainA: ChainHandle, ChainB: ChainHandle> {
     path: Packet,
     chains: ChainHandlePair<ChainA, ChainB>,
     cmd_rx: Receiver<WorkerCmd>,
-    telemetry: Telemetry,
     clear_packets_interval: u64,
 }
 
@@ -35,14 +33,12 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
         path: Packet,
         chains: ChainHandlePair<ChainA, ChainB>,
         cmd_rx: Receiver<WorkerCmd>,
-        telemetry: Telemetry,
         clear_packets_interval: u64,
     ) -> Self {
         Self {
             path,
             chains,
             cmd_rx,
-            telemetry,
             clear_packets_interval,
         }
     }
@@ -196,7 +192,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
             .filter(|e| matches!(e, WriteAcknowledgement(_)))
             .count();
 
-        self.telemetry.ibc_receive_packets(
+        ibc_telemetry::global().ibc_receive_packets(
             &self.path.src_chain_id,
             &self.path.src_channel_id,
             &self.path.src_port_id,
@@ -214,7 +210,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
             .filter(|e| matches!(e, AcknowledgePacket(_)))
             .count();
 
-        self.telemetry.ibc_acknowledgment_packets(
+        ibc_telemetry::global().ibc_acknowledgment_packets(
             &self.path.src_chain_id,
             &self.path.src_channel_id,
             &self.path.src_port_id,
@@ -231,7 +227,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> PacketWorker<ChainA, ChainB> {
             .filter(|e| matches!(e, TimeoutPacket(_)))
             .count();
 
-        self.telemetry.ibc_timeout_packets(
+        ibc_telemetry::global().ibc_timeout_packets(
             &self.path.src_chain_id,
             &self.path.src_channel_id,
             &self.path.src_port_id,

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -17,7 +17,7 @@ pub fn new_state() -> Arc<TelemetryState> {
     Arc::new(TelemetryState::default())
 }
 
-static GLOBAL_STATE: once_cell::sync::Lazy<Arc<TelemetryState>> = Lazy::new(new_state);
+static GLOBAL_STATE: Lazy<Arc<TelemetryState>> = Lazy::new(new_state);
 
 pub fn global() -> &'static Arc<TelemetryState> {
     &GLOBAL_STATE

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -4,6 +4,7 @@ pub mod server;
 pub mod state;
 
 use alloc::sync::Arc;
+use once_cell::sync::Lazy;
 use std::{
     error::Error,
     net::{SocketAddr, ToSocketAddrs},
@@ -14,6 +15,12 @@ pub use crate::state::TelemetryState;
 
 pub fn new_state() -> Arc<TelemetryState> {
     Arc::new(TelemetryState::default())
+}
+
+static GLOBAL_STATE: once_cell::sync::Lazy<Arc<TelemetryState>> = Lazy::new(new_state);
+
+pub fn global() -> Arc<TelemetryState> {
+    GLOBAL_STATE.clone()
 }
 
 pub fn spawn<A>(

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -19,8 +19,8 @@ pub fn new_state() -> Arc<TelemetryState> {
 
 static GLOBAL_STATE: once_cell::sync::Lazy<Arc<TelemetryState>> = Lazy::new(new_state);
 
-pub fn global() -> Arc<TelemetryState> {
-    GLOBAL_STATE.clone()
+pub fn global() -> &'static Arc<TelemetryState> {
+    &GLOBAL_STATE
 }
 
 pub fn spawn<A>(


### PR DESCRIPTION
## Description

Enable the use of telemetrics globally across the whole `ibc-relayer` codebase without having to thread a `Arc<TelemetryState>` everywhere.

To this end, this PR introduces a global (`static`) `Arc<TelemetryState>` which can be accessed with `ibc_telemetry::global()` from anywhere in the `ibc-relayer` crate.

Updating a metric now looks like this:

```rust
telemetry!(ibc_telemetry::global().update_some_metric(foo, bar, 42));
```

---

Note: Internal change: no need for issue + changelog