### PR TITLE
Set default trusting period to be 2/3 of unbonding period for Cosmos chains

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/1392-trusting-period-default.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/1392-trusting-period-default.md
@@ -1,0 +1,2 @@
+- Set default trusting period to be 2/3 of unbonding period for Cosmos chains
+  ([#1392](https://github.com/informalsystems/ibc-rs/issues/1392))

--- a/relayer/src/chain/mock.rs
+++ b/relayer/src/chain/mock.rs
@@ -61,6 +61,14 @@ pub struct MockChain {
     event_receiver: EventReceiver,
 }
 
+impl MockChain {
+    fn trusting_period(&self) -> Duration {
+        self.config
+            .trusting_period
+            .unwrap_or(Duration::from_secs(14 * 24 * 60 * 60)) // 14 days
+    }
+}
+
 impl ChainEndpoint for MockChain {
     type LightBlock = TmLightBlock;
     type Header = TendermintHeader;
@@ -317,8 +325,8 @@ impl ChainEndpoint for MockChain {
         let client_state = TendermintClientState::new(
             self.id().clone(),
             self.config.trust_threshold.into(),
-            self.config.trusting_period,
-            self.config.trusting_period.add(Duration::from_secs(1000)),
+            self.trusting_period(),
+            self.trusting_period().add(Duration::from_secs(1000)),
             Duration::from_millis(3000),
             height,
             Height::zero(),
@@ -426,7 +434,7 @@ pub mod test_utils {
             max_msg_num: Default::default(),
             max_tx_size: Default::default(),
             clock_drift: Duration::from_secs(5),
-            trusting_period: Duration::from_secs(14 * 24 * 60 * 60), // 14 days
+            trusting_period: Some(Duration::from_secs(14 * 24 * 60 * 60)), // 14 days
             trust_threshold: Default::default(),
             packet_filter: PacketFilter::default(),
             address_type: AddressType::default(),

--- a/relayer/src/chain/mock.rs
+++ b/relayer/src/chain/mock.rs
@@ -65,7 +65,7 @@ impl MockChain {
     fn trusting_period(&self) -> Duration {
         self.config
             .trusting_period
-            .unwrap_or(Duration::from_secs(14 * 24 * 60 * 60)) // 14 days
+            .unwrap_or_else(|| Duration::from_secs(14 * 24 * 60 * 60)) // 14 days
     }
 }
 

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -318,6 +318,7 @@ pub struct ChainConfig {
     pub max_tx_size: MaxTxSize,
     #[serde(default = "default::clock_drift", with = "humantime_serde")]
     pub clock_drift: Duration,
+    #[serde(with = "humantime_serde")]
     pub trusting_period: Option<Duration>,
 
     // these two need to be last otherwise we run into `ValueAfterTable` error when serializing to TOML

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -97,10 +97,6 @@ pub mod default {
         Duration::from_secs(10)
     }
 
-    pub fn trusting_period() -> Duration {
-        Duration::from_secs(336 * 60 * 60) // 336 hours ~ 14 days
-    }
-
     pub fn clock_drift() -> Duration {
         Duration::from_secs(5)
     }
@@ -322,8 +318,7 @@ pub struct ChainConfig {
     pub max_tx_size: MaxTxSize,
     #[serde(default = "default::clock_drift", with = "humantime_serde")]
     pub clock_drift: Duration,
-    #[serde(default = "default::trusting_period", with = "humantime_serde")]
-    pub trusting_period: Duration,
+    pub trusting_period: Option<Duration>,
 
     // these two need to be last otherwise we run into `ValueAfterTable` error when serializing to TOML
     #[serde(default)]


### PR DESCRIPTION
Closes: #1133 

## Description
Set config trusting period to be 2/3 of unbonding period if not specified for Cosmos chains. 
This is done where the `ChainEndpoint` impl for chains exists because we aren't sure if a chain is a Cosmos SDK chain while parsing the config. 

______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
