### PR TITLE
Add configuration file for `unclog` 0.4

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,0 +1,77 @@
+# The GitHub URL for your project.
+#
+# This is mainly necessary if you need to automatically generate changelog
+# entries directly from the CLI. Right now we only support GitHub, but if
+# anyone wants GitLab support please let us know and we'll try implement it
+# too.
+project_url = "https://github.com/informalsystems/ibc-rs"
+
+# The file to use as a Handlebars template for changes added directly through
+# the CLI.
+#
+# Assumes that relative paths are relative to the `.changelog` folder. If this
+# file does not exist, a default template will be used.
+change_template = "change-template.md"
+
+# The number of characters at which to wrap entries automatically added from
+# the CLI.
+wrap = 80
+
+# The heading right at the beginning of the changelog.
+heading = "# CHANGELOG"
+
+# What style of bullet to use for the instances where unclog has to generate
+# bullets for you. Can be "-" or "*".
+bullet_style = "-"
+
+# The message to output when your changelog has no entries yet.
+empty_msg = "Nothing to see here! Add some entries to get started."
+
+# The name of the file (relative to the `.changelog` directory) to use as an
+# epilogue for your changelog (will be appended as-is to the end of your
+# generated changelog).
+epilogue_filename = "epilogue.md"
+
+
+# Settings relating to unreleased changelog entries.
+[unreleased]
+
+# The name of the folder containing unreleased entries, relative to the
+# `.changelog` folder.
+folder = "unreleased"
+
+# The heading to use for the unreleased entries section.
+heading = "## Unreleased"
+
+
+# Settings relating to sets (groups) of changes in the changelog. For example,
+# the "BREAKING CHANGES" section would be considered a change set.
+[change_sets]
+
+# The filename containing a summary of the intended changes. Relative to the
+# change set folder (e.g. `.changelog/unreleased/breaking-changes/summary.md`).
+summary_filename = "summary.md"
+
+# The extension of files in a change set.
+entry_ext = "md"
+
+
+# Settings related to components/sub-modules. Only relevant if you make use of
+# components/sub-modules.
+[components]
+
+# The title to use for the section of entries not relating to a specific
+# component.
+general_entries_title = "General"
+
+# The number of spaces to inject before each component-related entry.
+entry_indent = 2
+
+    # The components themselves. Each component has a name (used when rendered
+    # to Markdown) and a path relative to the project folder (i.e. relative to
+    # the parent of the `.changelog` folder).
+    [components.all]
+    ibc             = { name = "IBC Modules",     path = "modules" }
+    ibc-relayer     = { name = "Relayer Library", path = "relayer" }
+    ibc-relayer-cli = { name = "Relayer CLI",     path = "relayer-cli" }
+    guide           = { name = "Guide",           path = "guide" }


### PR DESCRIPTION
With unclog 0.4 and the configuration file bundled in this PR, we can now add changelog entries in one go using `unclog add`.

For example, to add an entry concerning the `ibc-relayer` library under the improvements section with issue number 1234:

```bash
$ unclog add \
  -s improvements \                                       # section
  -c ibc-relayer \                                        # component
  -i 1234-my-new-entry \                                  # file name
  -n 1234 \                                               # issue number
  -m 'My fancy new addition to the relayer library'       # message
```

The command above will create a .changelog entry at `.changelog/unreleased/improvements/ibc-relayer/1234-my-new-entry.md` with the following content:

```md
- My fancy new addition to the relayer library
  ([#1234](https://github.com/informalsystems/ibc-rs/issues/1234))
```

Now, when building the changelog the entries will be grouped by components (in this case `ibc-relayer`):

```bash
$ unclog build -u
```

```md
## Unreleased

### IMPROVEMENTS

- [Relayer Library](./relayer)
  - My fancy new addition to the relayer library
    ([#1234](https://github.com/informalsystems/ibc-rs/issues/1234))
  - Set default trusting period to be 2/3 of unbonding period for Cosmos chains
    ([#1392](https://github.com/informalsystems/ibc-rs/issues/1392))
```

The available components, as listed in the configuration file, are:

- `ibc` for the *IBC Modules*
- `ibc-relayer` for the *Relayer Library*
- `ibc-relayer-cli` for the *Relayer CLI*
- `guide` for the *Guide*

I will update the CONTRIBUTING instructions accordingly in a separate PR.