### PR TITLE
Update config.toml trusting period comment

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -144,7 +144,7 @@ clock_drift = '5s'
 # Specify the amount of time to be used as the light client trusting period.
 # It should be significantly less than the unbonding period
 # (e.g. unbonding period = 3 weeks, trusting period = 2 weeks).
-# Default: 14days (336 hours)
+# Default: 2/3 of the `unbonding period` for Cosmos SDK chains
 trusting_period = '14days'
 
 # Specify the trust threshold for the light client, ie. the maximum fraction of validators


### PR DESCRIPTION
Extends: #1392 

## Description
Update config.toml trusting period comment for the default value.

______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
