### PR TITLE
Quick fix to default OUTPUT in lib-gm

### DIFF
--- a/scripts/gm/CHANGELOG.md
+++ b/scripts/gm/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Increased default Hermes config constants `rpc_timeout` and `max_gas`
+- Fixed undefaulted `$OUPUT` in `lib-gm`
 
 ## v0.0.9
 

--- a/scripts/gm/bin/lib-gm
+++ b/scripts/gm/bin/lib-gm
@@ -6,7 +6,7 @@ fi
 
 version() {
   VERSION="v0.0.9"
-  if [ "$OUTPUT" == "json" ]; then
+  if [ "${OUTPUT:-}" == "json" ]; then
     printf '{"status": "success", "message": "%s"}' "$VERSION"
   else
     echo "$VERSION"


### PR DESCRIPTION
## Description

Getting this error when running `gm`
```
/nix/store/rszjpkmfarq7dlmqrsybsjlvg2r8dc0q-gm-0.0.8/bin/lib-gm: line 9: OUTPUT: unbound variable
```

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- ~~If applicable: Unit tests written, added test to CI.~~
- ~~Linked to Github issue with discussion and accepted design OR link to spec that describes this work.~~
- ~~Updated relevant documentation (`docs/`) and code comments.~~
- [x] Re-reviewed `Files changed` in the Github PR explorer.