### PR TITLE
Fix tx simulation for chains based on Cosmos SDK 0.42.x

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/1345-fix-tx-simulation-0.42.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/1345-fix-tx-simulation-0.42.md
@@ -1,0 +1,4 @@
+- Fix a bug introduced in Hermes v0.7.0 where tx simulations would fail on
+  chains based on Cosmos SDK 0.42. This would cause Hermes to use the max
+  gas specified in the config when submitted the tx, leading to high fees.
+  ([#1345](https://github.com/informalsystems/ibc-rs/issues/1345))

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,7 +9,7 @@ The [End to end (e2e) testing workflow](https://github.com/informalsystems/ibc-r
 ### Testing Ethermint-based networks
 At this moment, the automated E2E workflow does not spin up a network with the (post-Stargate) Ethermint module. In the meantime, you can test it manually by following one of the resources below:
 
-- [the official documentation on ethermint.dev](https://ethermint.dev/quickstart/run_node.html)
+- [the official documentation on ethermint.dev](https://docs.ethermint.zone/quickstart/run_node.html)
 - [using the tweaked E2E scripts from the Injective's fork](https://github.com/InjectiveLabs/ibc-rs/commit/669535617a6e45be9916387e292d45a77e7d23d2)
 - [using the nix-based integration test scripts in the Cronos project](https://github.com/crypto-org-chain/cronos#quitck-start)
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -6,7 +6,7 @@ use core::{
     str::FromStr,
     time::Duration,
 };
-use std::{thread, time::Instant};
+use std::{fmt, thread, time::Instant};
 
 use bech32::{ToBase32, Variant};
 use bitcoin::hashes::hex::ToHex;
@@ -24,7 +24,7 @@ use tendermint_rpc::query::{EventType, Query};
 use tendermint_rpc::{endpoint::broadcast::tx_sync::Response, Client, HttpClient, Order};
 use tokio::runtime::Runtime as TokioRuntime;
 use tonic::codegen::http::Uri;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use ibc::downcast;
 use ibc::events::{from_tx_response_event, IbcEvent};
@@ -211,20 +211,24 @@ impl CosmosSdkChain {
 
     fn send_tx(&mut self, proto_msgs: Vec<Any>) -> Result<Response, Error> {
         crate::time!("send_tx");
+
         let account_seq = self.account_sequence()?;
 
         debug!(
-            "[{}] send_tx: sending {} messages using nonce {}",
+            "[{}] send_tx: sending {} messages using account sequence {}",
             self.id(),
             proto_msgs.len(),
             account_seq,
         );
 
         let signer_info = self.signer(account_seq)?;
-        let fee = self.default_fee();
+        let default_fee = self.default_fee();
+
+        debug!("[{}] default fee: {}", self.id(), PrettyFee(&default_fee));
+
         let (body, body_buf) = tx_body_and_bytes(proto_msgs)?;
 
-        let (auth_info, auth_buf) = auth_info_and_bytes(signer_info.clone(), fee.clone())?;
+        let (auth_info, auth_buf) = auth_info_and_bytes(signer_info.clone(), default_fee.clone())?;
         let signed_doc = self.signed_doc(body_buf.clone(), auth_buf, account_seq)?;
 
         // Try to simulate the Tx.
@@ -239,11 +243,26 @@ impl CosmosSdkChain {
                 auth_info: Some(auth_info),
                 signatures: vec![signed_doc],
             })
-            .map_or(self.max_gas(), |sr| {
-                sr.gas_info.map_or(self.max_gas(), |g| g.gas_used)
-            });
+            .map(|sr| sr.gas_info);
+
+        debug!("[{}] simulated gas: {:?}", self.id(), estimated_gas);
+
+        let estimated_gas = estimated_gas.map_or_else(
+            |e| {
+                error!(
+                    "[{}] failed to estimate gas, falling back on max gas, error: {}",
+                    self.id(),
+                    e
+                );
+
+                self.max_gas()
+            },
+            |gas_info| gas_info.map_or(self.max_gas(), |g| g.gas_used),
+        );
 
         if estimated_gas > self.max_gas() {
+            debug!(estimated = ?estimated_gas, max = ?self.max_gas(), "[{}] estimated gas is higher than max gas", self.id());
+
             return Err(Error::tx_simulate_gas_estimate_exceeded(
                 self.id().clone(),
                 estimated_gas,
@@ -254,10 +273,10 @@ impl CosmosSdkChain {
         let adjusted_fee = self.fee_with_gas(estimated_gas);
 
         trace!(
-            "[{}] send_tx: based on the estimated gas, adjusting fee from {:?} to {:?}",
+            "[{}] send_tx: based on the estimated gas, adjusting fee from {} to {}",
             self.id(),
-            fee,
-            adjusted_fee
+            PrettyFee(&default_fee),
+            PrettyFee(&adjusted_fee)
         );
 
         let (_auth_adjusted, auth_buf_adjusted) = auth_info_and_bytes(signer_info, adjusted_fee)?;
@@ -379,12 +398,15 @@ impl CosmosSdkChain {
     fn send_tx_simulate(&self, tx: Tx) -> Result<SimulateResponse, Error> {
         crate::time!("tx simulate");
 
-        // The `tx` field of `SimulateRequest` was deprecated
-        // in favor of `tx_bytes`
+        // The `tx` field of `SimulateRequest` was deprecated in Cosmos SDK 0.43 in favor of `tx_bytes`.
         let mut tx_bytes = vec![];
         prost::Message::encode(&tx, &mut tx_bytes).unwrap();
+
         #[allow(deprecated)]
-        let req = SimulateRequest { tx: None, tx_bytes };
+        let req = SimulateRequest {
+            tx: Some(tx), // needed for simulation to go through with Cosmos SDK <  0.43
+            tx_bytes,     // needed for simulation to go through with Cosmos SDk >= 0.43
+        };
 
         let mut client = self
             .block_on(
@@ -2043,6 +2065,21 @@ async fn do_health_check(chain: &CosmosSdkChain) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+struct PrettyFee<'a>(&'a Fee);
+impl fmt::Display for PrettyFee<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let amount = match self.0.amount.get(0) {
+            Some(coin) => format!("{}{}", coin.amount, coin.denom),
+            None => "<no amount specified>".to_string(),
+        };
+
+        f.debug_struct("Fee")
+            .field("amount", &amount)
+            .field("gas_limit", &self.0.gas_limit)
+            .finish()
+    }
 }
 
 fn calculate_fee(adjusted_gas_amount: u64, gas_price: &GasPrice) -> Coin {

--- a/relayer/src/registry.rs
+++ b/relayer/src/registry.rs
@@ -96,7 +96,7 @@ impl<Chain: ChainHandle> Registry<Chain> {
         if !self.handles.contains_key(chain_id) {
             let handle = spawn_chain_runtime(&self.config, chain_id, self.rt.clone())?;
             self.handles.insert(chain_id.clone(), handle);
-            trace!("spawned chain runtime for chain {}", chain_id);
+            trace!("[{}] spawned chain runtime", chain_id);
             Ok(true)
         } else {
             Ok(false)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1354

## Description

In Cosmos SDK 0.43+, the Protocol Buffers message for `SimulateRequest` was updated, now included a `tx_bytes` field and deprecating the `tx` field:

```diff
pub struct SimulateRequest {
     /// tx is the transaction to simulate.
+    /// Deprecated. Send raw tx bytes instead.
+    #[deprecated]
     #[prost(message, optional, tag = "1")]
     pub tx: ::core::option::Option<Tx>,
+    /// tx_bytes is the raw transaction.
+    #[prost(bytes = "vec", tag = "2")]
+    pub tx_bytes: ::prost::alloc::vec::Vec<u8>,
 }
```

https://github.com/informalsystems/ibc-rs/commit/c4b6e3035c3b717f9f8ca09ec97c15beaf3d7cd9#diff-9ea64978cd0695e7d1321fc30fabcaa46a5857c514b638a22f6bad5f9ca25870R240-R248

As part of #948, we have changed the logic for building the `SimulateRequest` message accordingly, but did not realize that chains based on Cosmos SDK <0.43 would now reject the message with `invalid empty tx: invalid request`.

This would cause the gRPC call to fail and Hermes to then use the `max_gas` specified in the config to compute the fee for sending the actual transaction.

This PR fixes this by including both the `tx` and the `tx_bytes` fields so that chains requiring either field can process the request:

```rust
        let req = SimulateRequest {
             tx: Some(tx), // needed for simulation to go through with Cosmos SDK <  0.43
             tx_bytes,     // needed for simulation to go through with Cosmos SDk >= 0.43
         };
```

https://github.com/informalsystems/ibc-rs/pull/1405/files#diff-c12c5f52a7e35d9e3d8220ad3701dbe0f33dc1c21c7bf44518c44a5864f46907R406-R409

We may have to revisit this if the deprecated `tx` field is eventually removed, but this is outside the scope of this PR.

______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
