### PR TITLE
Fixed account seq. nr logic in the error case

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/1402-fix-account-seq-error-case.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/1402-fix-account-seq-error-case.md
@@ -1,0 +1,3 @@
+- Only increase cached account sequence number when `broadcast_tx_sync` fails,
+  therefore ensuring that the cached sequence number stays in sync with the
+  node. ([#1402](https://github.com/informalsystems/ibc-rs/issues/1402))

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -284,8 +284,16 @@ impl CosmosSdkChain {
             }
             tendermint::abci::Code::Err(_) => {
                 // Avoid increasing the account s.n. if CheckTx failed
-                // Simply log the error
+                // Log the error
                 error!("[{}] send_tx: broadcast_tx_sync: {:?}", self.id(), response);
+                // The primary reason (we know of) causing broadcast_tx_sync to fail
+                // is due to "out of gas" errors. These are unrecoverable at the moment
+                // on the Hermes side. We'll inform the user to check for misconfig.
+                error!(
+                    "[{}] the price configuration for this chain may be too low!\\
+                    please check the `gas_price.price` Hermes config.toml",
+                    self.id()
+                );
             }
         }
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -71,7 +71,6 @@ use ibc_proto::ibc::core::connection::v1::{
     QueryClientConnectionsRequest, QueryConnectionsRequest,
 };
 
-use crate::config::{AddressType, ChainConfig, GasPrice};
 use crate::error::Error;
 use crate::event::monitor::{EventMonitor, EventReceiver};
 use crate::keyring::{KeyEntry, KeyRing, Store};
@@ -79,6 +78,10 @@ use crate::light_client::tendermint::LightClient as TmLightClient;
 use crate::light_client::LightClient;
 use crate::light_client::Verified;
 use crate::{chain::QueryResponse, event::monitor::TxMonitorCmd};
+use crate::{
+    config::{AddressType, ChainConfig, GasPrice},
+    sdk_error::sdk_error_from_tx_sync_error_code,
+};
 
 use super::{ChainEndpoint, HealthCheck};
 
@@ -282,16 +285,14 @@ impl CosmosSdkChain {
                 self.incr_account_sequence()?;
                 debug!("[{}] send_tx: broadcast_tx_sync: {:?}", self.id(), response);
             }
-            tendermint::abci::Code::Err(_) => {
+            tendermint::abci::Code::Err(code) => {
                 // Avoid increasing the account s.n. if CheckTx failed
                 // Log the error
-                error!("[{}] send_tx: broadcast_tx_sync: {:?}", self.id(), response);
-                // The primary reason (we know of) causing broadcast_tx_sync to fail
-                // is due to "out of gas" errors. These are unrecoverable at the moment
-                // on the Hermes side. We'll inform the user to check for misconfig.
                 error!(
-                    "[{}] the price configuration for this chain may be too low! please check the `gas_price.price` Hermes config.toml",
-                    self.id()
+                    "[{}] send_tx: broadcast_tx_sync: {:?}: diagnostic: {:?}",
+                    self.id(),
+                    response,
+                    sdk_error_from_tx_sync_error_code(code)
                 );
             }
         }

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -278,7 +278,10 @@ impl CosmosSdkChain {
 
         debug!("[{}] send_tx: broadcast_tx_sync: {:?}", self.id(), response);
 
-        self.incr_account_sequence()?;
+        // Avoid bumping up the account s.n. if CheckTx failed
+        if response.code.is_ok() {
+            self.incr_account_sequence()?;
+        }
 
         Ok(response)
     }

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -290,8 +290,7 @@ impl CosmosSdkChain {
                 // is due to "out of gas" errors. These are unrecoverable at the moment
                 // on the Hermes side. We'll inform the user to check for misconfig.
                 error!(
-                    "[{}] the price configuration for this chain may be too low!\\
-                    please check the `gas_price.price` Hermes config.toml",
+                    "[{}] the price configuration for this chain may be too low! please check the `gas_price.price` Hermes config.toml",
                     self.id()
                 );
             }

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -1122,6 +1122,7 @@ fn check_destination_connection_state(
             == expected_connection.counterparty().connection_id();
 
     // TODO check versions and store prefix
+    // https://github.com/informalsystems/ibc-rs/issues/1389
 
     if good_state && good_client_ids && good_connection_ids {
         Ok(())

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -875,7 +875,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
                 match event {
                     IbcEvent::SendPacket(send_event) => {
                         packet_sequences.push(send_event.packet.sequence);
-                        if packet_sequences.len() > 10 {
+                        if packet_sequences.len() >= 10 {
                             // Enough to print the first 10
                             break;
                         }
@@ -964,7 +964,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
                 match event {
                     IbcEvent::WriteAcknowledgement(write_ack_event) => {
                         packet_sequences.push(write_ack_event.packet.sequence);
-                        if packet_sequences.len() > 10 {
+                        if packet_sequences.len() >= 10 {
                             // Enough to print the first 10
                             break;
                         }

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -923,7 +923,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             return Ok((events_result, query_height));
         }
 
-        debug!(
+        trace!(
             "[{}] packets that have acknowledgments on {}: [{:?}..{:?}] (total={})",
             self,
             self.src_chain().id(),
@@ -932,7 +932,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             acked_sequences.len()
         );
 
-        debug!(
+        trace!(
             "[{}] ack packets to send out to {} of the ones with acknowledgments on {}: {} (first 10 shown here; total={})",
             self,
             self.dst_chain().id(),
@@ -953,22 +953,29 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             }))
             .map_err(|e| LinkError::query(self.src_chain().id(), e))?;
 
-        let mut packet_sequences = vec![];
-        for event in events_result.iter() {
-            match event {
-                IbcEvent::WriteAcknowledgement(write_ack_event) => {
-                    packet_sequences.push(write_ack_event.packet.sequence);
-                    if packet_sequences.len() > 10 {
-                        // Enough to print the first 10
-                        break;
+        if events_result.is_empty() {
+            info!(
+                "[{}] found zero unprocessed WriteAcknowledgement events on source chain, nothing to do",
+                self
+            );
+        } else {
+            let mut packet_sequences = vec![];
+            for event in events_result.iter() {
+                match event {
+                    IbcEvent::WriteAcknowledgement(write_ack_event) => {
+                        packet_sequences.push(write_ack_event.packet.sequence);
+                        if packet_sequences.len() > 10 {
+                            // Enough to print the first 10
+                            break;
+                        }
+                    }
+                    _ => {
+                        return Err(LinkError::unexpected_event(event.clone()));
                     }
                 }
-                _ => {
-                    return Err(LinkError::unexpected_event(event.clone()));
-                }
             }
+            info!("[{}] found unprocessed WriteAcknowledgement events for {:?} (first 10 shown here; total={})", self, packet_sequences, events_result.len());
         }
-        info!("[{}] found unprocessed WriteAcknowledgement events for {:?} (first 10 shown here; total={})", self, packet_sequences, events_result.len());
 
         Ok((events_result, query_height))
     }

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -833,7 +833,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             return Ok((events_result, query_height));
         }
 
-        trace!(
+        debug!(
             "[{}] packets that still have commitments on {}: {} (first 10 shown here; total={})",
             self,
             self.src_chain().id(),
@@ -841,7 +841,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             commit_sequences.len()
         );
 
-        trace!(
+        debug!(
             "[{}] recv packets to send out to {} of the ones with commitments on source {}: {} (first 10 shown here; total={})",
             self,
             self.dst_chain().id(),
@@ -923,7 +923,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             return Ok((events_result, query_height));
         }
 
-        trace!(
+        debug!(
             "[{}] packets that have acknowledgments on {}: [{:?}..{:?}] (total={})",
             self,
             self.src_chain().id(),
@@ -932,7 +932,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             acked_sequences.len()
         );
 
-        trace!(
+        debug!(
             "[{}] ack packets to send out to {} of the ones with acknowledgments on {}: {} (first 10 shown here; total={})",
             self,
             self.dst_chain().id(),

--- a/relayer/src/supervisor/spawn.rs
+++ b/relayer/src/supervisor/spawn.rs
@@ -297,8 +297,8 @@ impl<'a, Chain: ChainHandle + 'static> SpawnContext<'a, Chain> {
             ),
             Err(e) => error!(
                 "skipped workers for connection {} on chain {}, reason: {}",
-                chain.id(),
                 connection.connection_id,
+                chain.id(),
                 e
             ),
         }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1402

## Description


- [x] fixes the logic for account seq. nr, to only increment it if the call to `broadcast_tx_sync` is successful
- [x] fixes following the discussion from issue #1404 
    - lowers the log-level for a couple of log lines in the packet clearing methods, 
    - avoid printing "found unprocessed" log in the packet clearing methods if no event was found


______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
