### PR TITLE
Handle start/end block send packet events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,8 +2891,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5354dfcc3bbd8bf3b000b9cfb19afcb4e1bbaed9d6b2d6bc2fa05e027bd7e1"
+source = "git+https://github.com/informalsystems/tendermint-rs?branch=master#72398480e08356c5a4dc1c276628a7a60229bc87"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2925,8 +2924,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67bd8950fa29cd53f482ae3030700c74235260d9143bf634563136b5da5224c"
+source = "git+https://github.com/informalsystems/tendermint-rs?branch=master#72398480e08356c5a4dc1c276628a7a60229bc87"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -2945,8 +2943,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c36f58bd68be7a6e3221c49cc1a14cbc619c189bb26a43425f544831922d2be"
+source = "git+https://github.com/informalsystems/tendermint-rs?branch=master#72398480e08356c5a4dc1c276628a7a60229bc87"
 dependencies = [
  "bytes",
  "chrono",
@@ -2963,8 +2960,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca84e07a1ca78193a81854685a9cb99c17080674442c4fe10ee53f4d2195169"
+source = "git+https://github.com/informalsystems/tendermint-rs?branch=master#72398480e08356c5a4dc1c276628a7a60229bc87"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -2996,8 +2992,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fe76085d594f6c836f60b84a7acc69ddd12556d3d3a4f8c3d83626da2e658e"
+source = "git+https://github.com/informalsystems/tendermint-rs?branch=master#72398480e08356c5a4dc1c276628a7a60229bc87"
 dependencies = [
  "ed25519-dalek",
  "gumdrop 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ exclude = [
     "proto-compiler"
 ]
 
-# [patch.crates-io]
-# tendermint              = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
-# tendermint-rpc          = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
-# tendermint-proto        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
-# tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
-# tendermint-testgen      = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
+[patch.crates-io]
+tendermint              = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
+tendermint-rpc          = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
+tendermint-proto        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
+tendermint-light-client = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }
+tendermint-testgen      = { git = "https://github.com/informalsystems/tendermint-rs", branch = "master" }

--- a/modules/src/query.rs
+++ b/modules/src/query.rs
@@ -12,4 +12,9 @@ pub enum QueryTxRequest {
 }
 
 #[derive(Clone, Debug)]
+pub enum QueryBlockRequest {
+    Packet(QueryPacketEventDataRequest),
+}
+
+#[derive(Clone, Debug)]
 pub struct QueryTxHash(pub Hash);

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -18,7 +18,7 @@ use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
 use ibc::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofBytes};
 use ibc::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
 use ibc::proofs::{ConsensusProof, Proofs};
-use ibc::query::QueryTxRequest;
+use ibc::query::{QueryBlockRequest, QueryTxRequest};
 use ibc::signer::Signer;
 use ibc::Height as ICSHeight;
 use ibc_proto::ibc::core::channel::v1::{
@@ -263,6 +263,8 @@ pub trait ChainEndpoint: Sized {
     ) -> Result<Sequence, Error>;
 
     fn query_txs(&self, request: QueryTxRequest) -> Result<Vec<IbcEvent>, Error>;
+
+    fn query_block(&self, request: QueryBlockRequest) -> Result<Vec<IbcEvent>, Error>;
 
     // Provable queries
     fn proven_client_state(

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -1874,8 +1874,8 @@ fn all_ibc_events_from_tx_search_response(chain_id: &ChainId, response: ResultTx
 fn send_packet_from_event(event: Event, request: &QueryPacketEventDataRequest) -> Option<IbcEvent> {
     if event.type_str == IbcEventType::SendPacket.as_str() {
         if let Some(ibc_event) = ChannelEvents::try_from_tx(&event) {
-            if let IbcEvent::SendPacket(send_packet) = ibc_event.clone() {
-                let packet = send_packet.packet;
+            if let IbcEvent::SendPacket(ref send_packet) = ibc_event {
+                let packet = &send_packet.packet;
                 if packet.source_port == request.source_port_id
                     && packet.source_channel == request.source_channel_id
                     && packet.destination_port == request.destination_port_id

--- a/relayer/src/chain/handle.rs
+++ b/relayer/src/chain/handle.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::fmt::{self, Debug};
 
 use crossbeam_channel as channel;
-use ibc::ics03_connection::connection::IdentifiedConnectionEnd;
+use ibc::{ics03_connection::connection::IdentifiedConnectionEnd, query::QueryBlockRequest};
 use ibc_proto::ibc::core::connection::v1::QueryConnectionsRequest;
 use serde::Serialize;
 
@@ -303,8 +303,13 @@ pub enum ChainRequest {
         reply_to: ReplyTo<Vec<u64>>,
     },
 
-    QueryPacketEventData {
+    QueryPacketEventDataFromTx {
         request: QueryTxRequest,
+        reply_to: ReplyTo<Vec<IbcEvent>>,
+    },
+
+    QueryPacketEventDataFromBlock {
+        request: QueryBlockRequest,
         reply_to: ReplyTo<Vec<IbcEvent>>,
     },
 }
@@ -516,4 +521,6 @@ pub trait ChainHandle: Clone + Send + Sync + Serialize + Debug {
     ) -> Result<Vec<u64>, Error>;
 
     fn query_txs(&self, request: QueryTxRequest) -> Result<Vec<IbcEvent>, Error>;
+
+    fn query_block(&self, request: QueryBlockRequest) -> Result<Vec<IbcEvent>, Error>;
 }

--- a/relayer/src/chain/handle/prod.rs
+++ b/relayer/src/chain/handle/prod.rs
@@ -10,7 +10,7 @@ use ibc::ics02_client::misbehaviour::MisbehaviourEvidence;
 use ibc::ics03_connection::connection::IdentifiedConnectionEnd;
 use ibc::ics04_channel::channel::IdentifiedChannelEnd;
 use ibc::ics04_channel::packet::{PacketMsgType, Sequence};
-use ibc::query::QueryTxRequest;
+use ibc::query::{QueryBlockRequest, QueryTxRequest};
 use ibc::{
     events::IbcEvent,
     ics02_client::header::AnyHeader,
@@ -422,7 +422,11 @@ impl ChainHandle for ProdChainHandle {
     }
 
     fn query_txs(&self, request: QueryTxRequest) -> Result<Vec<IbcEvent>, Error> {
-        self.send(|reply_to| ChainRequest::QueryPacketEventData { request, reply_to })
+        self.send(|reply_to| ChainRequest::QueryPacketEventDataFromTx { request, reply_to })
+    }
+
+    fn query_block(&self, request: QueryBlockRequest) -> Result<Vec<IbcEvent>, Error> {
+        self.send(|reply_to| ChainRequest::QueryPacketEventDataFromBlock { request, reply_to })
     }
 }
 

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -25,7 +25,7 @@ use ibc::{
     ics23_commitment::commitment::CommitmentPrefix,
     ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
     proofs::Proofs,
-    query::QueryTxRequest,
+    query::{QueryBlockRequest, QueryTxRequest},
     signer::Signer,
     Height,
 };
@@ -348,8 +348,12 @@ where
                             self.query_next_sequence_receive(request, reply_to)?
                         },
 
-                        Ok(ChainRequest::QueryPacketEventData { request, reply_to }) => {
+                        Ok(ChainRequest::QueryPacketEventDataFromTx { request, reply_to }) => {
                             self.query_txs(request, reply_to)?
+                        },
+
+                        Ok(ChainRequest::QueryPacketEventDataFromBlock { request, reply_to }) => {
+                            self.query_block(request, reply_to)?
                         },
 
                         Err(e) => error!("received error via chain request channel: {}", e),
@@ -769,5 +773,17 @@ where
     ) -> Result<(), Error> {
         let result = self.chain.query_txs(request);
         reply_to.send(result).map_err(Error::send)
+    }
+
+    fn query_block(
+        &self,
+        request: QueryBlockRequest,
+        reply_to: ReplyTo<Vec<IbcEvent>>,
+    ) -> Result<(), Error> {
+        let result = self.chain.query_block(request);
+
+        reply_to.send(result).map_err(Error::send)?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes: #1231 

## Description
Handles Send packet events that are emitted from the BeginBlock and EndBlock ABCI methods. 

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
