### PR TITLE
Add a `default_gas` setting to be used for submitting a tx when tx simulation fails

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,9 +116,14 @@ address_type = { derivation = 'cosmos' }
 # Recommended value for Cosmos SDK: 'ibc'
 store_prefix = 'ibc'
 
+# Specify the default amount of gas to be used in case the tx simulation fails,
+# and Hermes cannot estimate the amount of gas needed.
+# Default: 100 000
+default_gas = 100000
+
 # Specify the maximum amount of gas to be used as the gas limit for a transaction.
-# Default: 300000
-max_gas = 3000000
+# Default: 300 000
+max_gas = 300000
 
 # Specify the price per gas used of the fee to submit a transaction and
 # the denomination of the fee. Required

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -87,10 +87,14 @@ use super::{ChainEndpoint, HealthCheck};
 
 mod compatibility;
 
+/// Default gas amount to be when submitting a transaction when we fail to estimate
+/// the amount of gas needed.
+const DEFAULT_GAS: u64 = 100_000;
+
 /// Default gas limit when submitting a transaction.
 const DEFAULT_MAX_GAS: u64 = 300_000;
 
-/// Fraction of the estimated gas to add to the gas limit when submitting a transaction.
+/// Fraction of the estimated gas to add to the estimated gas amount when submitting a transaction.
 const DEFAULT_GAS_PRICE_ADJUSTMENT: f64 = 0.1;
 
 /// Upper limit on the size of transactions submitted by Hermes, expressed as a
@@ -253,14 +257,14 @@ impl CosmosSdkChain {
         let estimated_gas = estimated_gas.map_or_else(
             |e| {
                 error!(
-                    "[{}] failed to estimate gas, falling back on max gas, error: {}",
+                    "[{}] failed to estimate gas, falling back on default gas, error: {}",
                     self.id(),
                     e
                 );
 
-                self.max_gas()
+                self.default_gas()
             },
-            |gas_info| gas_info.map_or(self.max_gas(), |g| g.gas_used),
+            |gas_info| gas_info.map_or(self.default_gas(), |g| g.gas_used),
         );
 
         if estimated_gas > self.max_gas() {
@@ -317,6 +321,12 @@ impl CosmosSdkChain {
         }
 
         Ok(response)
+    }
+
+    /// The default amount of gas the relayer is willing to pay for a transaction,
+    /// when it cannot simulate the tx and therefore estimate the gas amount needed.
+    fn default_gas(&self) -> u64 {
+        self.config.default_gas.unwrap_or(DEFAULT_GAS)
     }
 
     /// The maximum amount of gas the relayer is willing to pay for a transaction

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -310,6 +310,7 @@ pub struct ChainConfig {
     pub account_prefix: String,
     pub key_name: String,
     pub store_prefix: String,
+    pub default_gas: Option<u64>,
     pub max_gas: Option<u64>,
     pub gas_adjustment: Option<f64>,
     #[serde(default)]


### PR DESCRIPTION
Closes: #XXX

## Description

Add a `default_gas` setting to be used for submitting a tx when we cannot estimate the gas amount needed because the tx simulation failed.

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
