### PR TITLE
Increase max length for port identifier to 128

### DIFF
--- a/modules/src/core/ics24_host/validate.rs
+++ b/modules/src/core/ics24_host/validate.rs
@@ -61,10 +61,10 @@ pub fn validate_connection_identifier(id: &str) -> Result<(), Error> {
 
 /// Default validator function for Port identifiers.
 ///
-/// A valid Identifier must be between 2-64 characters and only contain lowercase
+/// A valid Identifier must be between 2-128 characters and only contain lowercase
 /// alphabetic characters,
 pub fn validate_port_identifier(id: &str) -> Result<(), Error> {
-    validate_identifier(id, 2, 64)
+    validate_identifier(id, 2, 128)
 }
 
 /// Default validator function for Channel identifiers.
@@ -92,9 +92,9 @@ mod tests {
 
     #[test]
     fn parse_invalid_port_id_max() {
-        // invalid max port id (test string length is 65 chars)
+        // invalid max port id (test string length is 130 chars)
         let id = validate_port_identifier(
-            "9anxkcme6je544d5lnj46zqiiiygfqzf8w4bjecbnyj4lj6s7zlpst67yln64tixp",
+            "9anxkcme6je544d5lnj46zqiiiygfqzf8w4bjecbnyj4lj6s7zlpst67yln64tixp9anxkcme6je544d5lnj46zqiiiygfqzf8w4bjecbnyj4lj6s7zlpst67yln64tixp",
         );
         assert!(id.is_err())
     }


### PR DESCRIPTION
Following ibc-go spec the default length for port identifier is 2-128 

[ibc-go/PortIdentifierValidator](https://github.com/cosmos/ibc-go/blob/main/modules/core/24-host/validate.go#L86)

Tested using hermes(0.7.3) during cw20-ics20 transfer where port_id was wasm.bostrom14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sww4mxt

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
