### PR TITLE
Revert "Revert to Cargo resolver v1, to fix build of `ibc` crate"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 
-resolver = "1"
+resolver = "2"
 
 members = [
     "modules",


### PR DESCRIPTION
Reverts informalsystems/ibc-rs#1522

This was in the end not the culprit for blocking the release of the `ibc` crate, but rather a [source incompatibility](https://github.com/confio/ics23/pull/54) in `ics23` when building `ibc` in no-std mode during the `cargo publish` step.