### PR TITLE
Update ics23 dep version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef521023da88dba3168980a8184e22bb42041d8b7e166f38df2d3d54ff6cb5e9"
+checksum = "ce15e4758c46a0453bdf4b3b1dfcce70c43f79d1943c2ee0635b77eb2e7aa233"
 dependencies = [
  "anyhow",
  "bytes",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -26,7 +26,7 @@ mocks = ["tendermint-testgen", "sha2"]
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.12.0", path = "../proto" }
-ics23 = { version = "0.6.6", default-features = false }
+ics23 = { version = "0.6.7", default-features = false }
 chrono = { version = "0.4.19", default-features = false }
 thiserror = { version = "1.0.30", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false }


### PR DESCRIPTION
Unblocks release 0.8.0 by fixing build/publish in `no_std` mode. See https://github.com/confio/ics23/pull/54