### PR TITLE
Clean up some unwraps in `relayer`

### DIFF
--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -308,7 +308,7 @@ impl CosmosSdkChain {
         };
 
         let mut tx_bytes = Vec::new();
-        prost::Message::encode(&tx_raw, &mut tx_bytes).unwrap();
+        prost::Message::encode(&tx_raw, &mut tx_bytes).map_err(|e| Error::protobuf_encode(String::from("Transaction"), e))?;
 
         let response = self.block_on(broadcast_tx_sync(self, tx_bytes))?;
 
@@ -485,7 +485,7 @@ impl CosmosSdkChain {
 
         // The `tx` field of `SimulateRequest` was deprecated in Cosmos SDK 0.43 in favor of `tx_bytes`.
         let mut tx_bytes = vec![];
-        prost::Message::encode(&tx, &mut tx_bytes).unwrap(); // FIXME: Handle error here
+        prost::Message::encode(&tx, &mut tx_bytes).map_err(|e| Error::protobuf_encode(String::from("Transaction"), e))?;
 
         #[allow(deprecated)]
         let req = SimulateRequest {
@@ -514,7 +514,7 @@ impl CosmosSdkChain {
 
     fn key_bytes(&self, key: &KeyEntry) -> Result<Vec<u8>, Error> {
         let mut pk_buf = Vec::new();
-        prost::Message::encode(&key.public_key.public_key.to_bytes(), &mut pk_buf).unwrap();
+        prost::Message::encode(&key.public_key.public_key.to_bytes(), &mut pk_buf).map_err(|e| Error::protobuf_encode(String::from("Key bytes"), e))?;
         Ok(pk_buf)
     }
 
@@ -613,7 +613,7 @@ impl CosmosSdkChain {
 
         // A protobuf serialization of a SignDoc
         let mut signdoc_buf = Vec::new();
-        prost::Message::encode(&sign_doc, &mut signdoc_buf).unwrap();
+        prost::Message::encode(&sign_doc, &mut signdoc_buf).map_err(|e| Error::protobuf_encode(String::from("SignDoc"), e))?;
 
         // Sign doc
         let signed = self
@@ -894,7 +894,7 @@ impl ChainEndpoint for CosmosSdkChain {
         for msg in proto_msgs.iter() {
             msg_batch.push(msg.clone());
             let mut buf = Vec::new();
-            prost::Message::encode(msg, &mut buf).unwrap();
+            prost::Message::encode(msg, &mut buf).map_err(|e| Error::protobuf_encode(String::from("Message"), e))?;
             n += 1;
             size += buf.len();
             if n >= self.max_msg_num() || size >= self.max_tx_size() {
@@ -950,7 +950,7 @@ impl ChainEndpoint for CosmosSdkChain {
         for msg in proto_msgs.iter() {
             msg_batch.push(msg.clone());
             let mut buf = Vec::new();
-            prost::Message::encode(msg, &mut buf).unwrap();
+            prost::Message::encode(msg, &mut buf).map_err(|e| Error::protobuf_encode(String::from("Messages"), e))?;
             n += 1;
             size += buf.len();
             if n >= self.max_msg_num() || size >= self.max_tx_size() {
@@ -2170,7 +2170,7 @@ fn auth_info_and_bytes(signer_info: SignerInfo, fee: Fee) -> Result<(AuthInfo, V
 
     // A protobuf serialization of a AuthInfo
     let mut auth_buf = Vec::new();
-    prost::Message::encode(&auth_info, &mut auth_buf).unwrap();
+    prost::Message::encode(&auth_info, &mut auth_buf).map_err(|e| Error::protobuf_encode(String::from("AuthInfo"), e))?;
     Ok((auth_info, auth_buf))
 }
 
@@ -2186,7 +2186,7 @@ fn tx_body_and_bytes(proto_msgs: Vec<Any>, memo: &Memo) -> Result<(TxBody, Vec<u
 
     // A protobuf serialization of a TxBody
     let mut body_buf = Vec::new();
-    prost::Message::encode(&body, &mut body_buf).unwrap();
+    prost::Message::encode(&body, &mut body_buf).map_err(|e| Error::protobuf_encode(String::from("TxBody"), e))?;
     Ok((body, body_buf))
 }
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -308,7 +308,8 @@ impl CosmosSdkChain {
         };
 
         let mut tx_bytes = Vec::new();
-        prost::Message::encode(&tx_raw, &mut tx_bytes).map_err(|e| Error::protobuf_encode(String::from("Transaction"), e))?;
+        prost::Message::encode(&tx_raw, &mut tx_bytes)
+            .map_err(|e| Error::protobuf_encode(String::from("Transaction"), e))?;
 
         let response = self.block_on(broadcast_tx_sync(self, tx_bytes))?;
 
@@ -432,9 +433,10 @@ impl CosmosSdkChain {
 
     fn query(&self, data: Path, height: ICSHeight, prove: bool) -> Result<QueryResponse, Error> {
         crate::time!("query");
-    
+
         // SAFETY: Creating a Path from a constant; this should never fail
-        let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).expect("Turning IBC query path constant into a Tendermint ABCI path");
+        let path = TendermintABCIPath::from_str(IBC_QUERY_PATH)
+            .expect("Turning IBC query path constant into a Tendermint ABCI path");
 
         let height = Height::try_from(height.revision_height).map_err(Error::invalid_height)?;
 
@@ -462,9 +464,10 @@ impl CosmosSdkChain {
         height: Height,
     ) -> Result<(Vec<u8>, MerkleProof), Error> {
         let prev_height = Height::try_from(height.value() - 1).map_err(Error::invalid_height)?;
-    
+
         // SAFETY: Creating a Path from a constant; this should never fail
-        let path = TendermintABCIPath::from_str(SDK_UPGRADE_QUERY_PATH).expect("Turning SDK upgrade query path constant into a Tendermint ABCI path");
+        let path = TendermintABCIPath::from_str(SDK_UPGRADE_QUERY_PATH)
+            .expect("Turning SDK upgrade query path constant into a Tendermint ABCI path");
         let response: QueryResponse = self.block_on(abci_query(
             self,
             path,
@@ -485,7 +488,8 @@ impl CosmosSdkChain {
 
         // The `tx` field of `SimulateRequest` was deprecated in Cosmos SDK 0.43 in favor of `tx_bytes`.
         let mut tx_bytes = vec![];
-        prost::Message::encode(&tx, &mut tx_bytes).map_err(|e| Error::protobuf_encode(String::from("Transaction"), e))?;
+        prost::Message::encode(&tx, &mut tx_bytes)
+            .map_err(|e| Error::protobuf_encode(String::from("Transaction"), e))?;
 
         #[allow(deprecated)]
         let req = SimulateRequest {
@@ -514,7 +518,8 @@ impl CosmosSdkChain {
 
     fn key_bytes(&self, key: &KeyEntry) -> Result<Vec<u8>, Error> {
         let mut pk_buf = Vec::new();
-        prost::Message::encode(&key.public_key.public_key.to_bytes(), &mut pk_buf).map_err(|e| Error::protobuf_encode(String::from("Key bytes"), e))?;
+        prost::Message::encode(&key.public_key.public_key.to_bytes(), &mut pk_buf)
+            .map_err(|e| Error::protobuf_encode(String::from("Key bytes"), e))?;
         Ok(pk_buf)
     }
 
@@ -613,7 +618,8 @@ impl CosmosSdkChain {
 
         // A protobuf serialization of a SignDoc
         let mut signdoc_buf = Vec::new();
-        prost::Message::encode(&sign_doc, &mut signdoc_buf).map_err(|e| Error::protobuf_encode(String::from("SignDoc"), e))?;
+        prost::Message::encode(&sign_doc, &mut signdoc_buf)
+            .map_err(|e| Error::protobuf_encode(String::from("SignDoc"), e))?;
 
         // Sign doc
         let signed = self
@@ -894,7 +900,8 @@ impl ChainEndpoint for CosmosSdkChain {
         for msg in proto_msgs.iter() {
             msg_batch.push(msg.clone());
             let mut buf = Vec::new();
-            prost::Message::encode(msg, &mut buf).map_err(|e| Error::protobuf_encode(String::from("Message"), e))?;
+            prost::Message::encode(msg, &mut buf)
+                .map_err(|e| Error::protobuf_encode(String::from("Message"), e))?;
             n += 1;
             size += buf.len();
             if n >= self.max_msg_num() || size >= self.max_tx_size() {
@@ -950,7 +957,8 @@ impl ChainEndpoint for CosmosSdkChain {
         for msg in proto_msgs.iter() {
             msg_batch.push(msg.clone());
             let mut buf = Vec::new();
-            prost::Message::encode(msg, &mut buf).map_err(|e| Error::protobuf_encode(String::from("Messages"), e))?;
+            prost::Message::encode(msg, &mut buf)
+                .map_err(|e| Error::protobuf_encode(String::from("Messages"), e))?;
             n += 1;
             size += buf.len();
             if n >= self.max_msg_num() || size >= self.max_tx_size() {
@@ -2112,16 +2120,14 @@ async fn query_account(chain: &CosmosSdkChain, address: String) -> Result<BaseAc
     .await
     .map_err(Error::grpc_transport)?;
 
-    let request = tonic::Request::new(QueryAccountRequest { address: address.clone() });
+    let request = tonic::Request::new(QueryAccountRequest {
+        address: address.clone(),
+    });
 
     let response = client.account(request).await;
 
     // Querying for an account might fail, i.e. if the account doesn't actually exist
-    let resp_account = match response
-        .map_err(Error::grpc_status)?
-        .into_inner()
-        .account 
-    {
+    let resp_account = match response.map_err(Error::grpc_status)?.into_inner().account {
         Some(account) => account,
         None => return Err(Error::empty_query_account(address)),
     };
@@ -2176,7 +2182,8 @@ fn auth_info_and_bytes(signer_info: SignerInfo, fee: Fee) -> Result<(AuthInfo, V
 
     // A protobuf serialization of a AuthInfo
     let mut auth_buf = Vec::new();
-    prost::Message::encode(&auth_info, &mut auth_buf).map_err(|e| Error::protobuf_encode(String::from("AuthInfo"), e))?;
+    prost::Message::encode(&auth_info, &mut auth_buf)
+        .map_err(|e| Error::protobuf_encode(String::from("AuthInfo"), e))?;
     Ok((auth_info, auth_buf))
 }
 
@@ -2192,7 +2199,8 @@ fn tx_body_and_bytes(proto_msgs: Vec<Any>, memo: &Memo) -> Result<(TxBody, Vec<u
 
     // A protobuf serialization of a TxBody
     let mut body_buf = Vec::new();
-    prost::Message::encode(&body, &mut body_buf).map_err(|e| Error::protobuf_encode(String::from("TxBody"), e))?;
+    prost::Message::encode(&body, &mut body_buf)
+        .map_err(|e| Error::protobuf_encode(String::from("TxBody"), e))?;
     Ok((body, body_buf))
 }
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -433,7 +433,7 @@ impl CosmosSdkChain {
     fn query(&self, data: Path, height: ICSHeight, prove: bool) -> Result<QueryResponse, Error> {
         crate::time!("query");
     
-        // Creating a Path from a constant; this should never fail
+        // SAFETY: Creating a Path from a constant; this should never fail
         let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).expect("Turning IBC query path constant into a Tendermint ABCI path");
 
         let height = Height::try_from(height.revision_height).map_err(Error::invalid_height)?;
@@ -463,7 +463,7 @@ impl CosmosSdkChain {
     ) -> Result<(Vec<u8>, MerkleProof), Error> {
         let prev_height = Height::try_from(height.value() - 1).map_err(Error::invalid_height)?;
     
-        // Creating a Path from a constant; this should never fail
+        // SAFETY: Creating a Path from a constant; this should never fail
         let path = TendermintABCIPath::from_str(SDK_UPGRADE_QUERY_PATH).expect("Turning SDK upgrade query path constant into a Tendermint ABCI path");
         let response: QueryResponse = self.block_on(abci_query(
             self,

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -432,8 +432,9 @@ impl CosmosSdkChain {
 
     fn query(&self, data: Path, height: ICSHeight, prove: bool) -> Result<QueryResponse, Error> {
         crate::time!("query");
-
-        let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).unwrap();
+    
+        // Creating a Path from a constant; this should never fail
+        let path = TendermintABCIPath::from_str(IBC_QUERY_PATH).expect("Turning IBC query path constant into a Tendermint ABCI path");
 
         let height = Height::try_from(height.revision_height).map_err(Error::invalid_height)?;
 
@@ -461,8 +462,9 @@ impl CosmosSdkChain {
         height: Height,
     ) -> Result<(Vec<u8>, MerkleProof), Error> {
         let prev_height = Height::try_from(height.value() - 1).map_err(Error::invalid_height)?;
-
-        let path = TendermintABCIPath::from_str(SDK_UPGRADE_QUERY_PATH).unwrap();
+    
+        // Creating a Path from a constant; this should never fail
+        let path = TendermintABCIPath::from_str(SDK_UPGRADE_QUERY_PATH).expect("Turning SDK upgrade query path constant into a Tendermint ABCI path");
         let response: QueryResponse = self.block_on(abci_query(
             self,
             path,

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 use flex_error::{define_error, DisplayOnly, TraceClone, TraceError};
 use http::uri::InvalidUri;
 use humantime::format_duration;
-use prost::DecodeError;
+use prost::{DecodeError, EncodeError};
 use tendermint::Error as TendermintError;
 use tendermint_light_client::{
     components::io::IoError as LightClientIoError, errors::Error as LightClientError,
@@ -328,6 +328,11 @@ define_error! {
             { payload_type: String }
             [ TraceError<DecodeError> ]
             |e| { format!("Error decoding protocol buffer for {}", e.payload_type) },
+
+        ProtobufEncode
+            { payload_type: String }
+            [ TraceError<EncodeError> ]
+            |e| { format!("Error encoding protocol buffer for {}", e.payload_type) },
 
         Cbor
             [ TraceError<serde_cbor::Error> ]

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -474,6 +474,9 @@ define_error! {
         EmptyBaseAccount
             |_| { "Empty BaseAccount within EthAccount" },
 
+        EmptyQueryAccount
+            { address: String }
+            |e| { format!("Query/Account RPC returned an empty account for address: {}", e.address) }
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Addresses: #987 

## Description

Remove usages of `unwrap` from non-test code in the `ibc` crate. The focus is on cleaning up unwraps in `relayer/src/chain/cosmos.rs` and `relayer/src/chain/runtime.rs`, as these are the cause of crashes in chain runtimes. A crashed chain runtime has ripple effects in all of the of workers that are holding a handle to the runtime. 
______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
