### PR TITLE
Avoid submitting txs when simulation fails, except for one special case

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/1479-abort-failed-simulated-txs.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/1479-abort-failed-simulated-txs.md
@@ -1,0 +1,3 @@
+- The relayer will now avoid submitting a tx after the simulation failed
+  (in all but one special case) to avoid wasting fees unnecessarily
+  ([#1479](https://github.com/informalsystems/ibc-rs/issues/1479))

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -286,13 +286,13 @@ impl CosmosSdkChain {
             signatures: vec![signed_doc],
         };
 
-        let estimated_gas = self.estimate_gas(simulate_tx)?;
-        let adjusted_fee = self.fee_with_gas(estimated_gas);
+        let simulated_gas = self.simulate_gas(simulate_tx)?;
+        let adjusted_fee = self.fee_with_gas(simulated_gas);
 
         debug!(
             "[{}] send_tx: using {} gas, fee {}",
             self.id(),
-            estimated_gas,
+            simulated_gas,
             PrettyFee(&adjusted_fee)
         );
 
@@ -340,10 +340,10 @@ impl CosmosSdkChain {
     /// [`MsgUpdateClient`, `MsgRecvPacket`, ..., `MsgRecvPacket`]
     /// if the batch is split in two TX-es, the second one will fail the simulation in `deliverTx` check
     /// In this case we use the `default_gas` param.
-    fn estimate_gas(&self, tx: Tx) -> Result<u64, Error> {
-        let estimated_gas = self.send_tx_simulate(tx).map(|sr| sr.gas_info);
+    fn simulate_gas(&self, tx: Tx) -> Result<u64, Error> {
+        let simulated_gas = self.send_tx_simulate(tx).map(|sr| sr.gas_info);
 
-        if let Ok(ref gas) = estimated_gas {
+        if let Ok(ref gas) = simulated_gas {
             debug!(
                 "[{}] send_tx: tx simulation successful, simulated gas: {:?}",
                 self.id(),
@@ -351,7 +351,7 @@ impl CosmosSdkChain {
             );
         }
 
-        let estimated_gas = estimated_gas.map_or_else(
+        let simulated_gas = simulated_gas.map_or_else(
             |e| {
                 error!(
                     "[{}] send_tx: failed to estimate gas, falling back on default gas, error: {}",
@@ -364,17 +364,17 @@ impl CosmosSdkChain {
             |gas_info| gas_info.map_or(self.default_gas(), |g| g.gas_used),
         );
 
-        if estimated_gas > self.max_gas() {
-            debug!(estimated = ?estimated_gas, max = ?self.max_gas(), "[{}] send_tx: estimated gas is higher than max gas", self.id());
+        if simulated_gas > self.max_gas() {
+            debug!(simulated = ?simulated_gas, max = ?self.max_gas(), "[{}] send_tx: simulated gas is higher than max gas", self.id());
 
             return Err(Error::tx_simulate_gas_estimate_exceeded(
                 self.id().clone(),
-                estimated_gas,
+                simulated_gas,
                 self.max_gas(),
             ));
         }
 
-        Ok(estimated_gas)
+        Ok(simulated_gas)
     }
 
     /// The default amount of gas the relayer is willing to pay for a transaction,

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -337,8 +337,7 @@ impl CosmosSdkChain {
     ///
     /// It is possible that a batch of messages are fragmented by the caller (`send_msgs`) such that
     /// they do not individually verify. For example for the following batch:
-    ///
-    ///     [`MsgUpdateClient`, `MsgRecvPacket`, ..., `MsgRecvPacket`]
+    /// [`MsgUpdateClient`, `MsgRecvPacket`, ..., `MsgRecvPacket`]
     ///
     /// If the batch is split in two TX-es, the second one will fail the simulation in `deliverTx` check.
     /// In this case we use the `default_gas` param.

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -197,6 +197,24 @@ impl CosmosSdkChain {
             ));
         }
 
+        // Check that the configured max gas is lower or equal to the consensus params max gas.
+        let consensus_max_gas = result.consensus_params.block.max_gas;
+
+        // If the consensus max gas is < 0, this check does not make sense.
+        if consensus_max_gas >= 0 {
+            let consensus_max_gas: u64 = consensus_max_gas
+                .try_into()
+                .expect("cannot over or underflow because it is positive");
+
+            if self.max_gas() > consensus_max_gas {
+                return Err(Error::config_validation_max_gas_too_high(
+                    self.id().clone(),
+                    self.max_gas(),
+                    result.consensus_params.block.max_gas,
+                ));
+            }
+        }
+
         Ok(())
     }
 

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -2281,14 +2281,11 @@ async fn do_health_check(chain: &CosmosSdkChain) -> Result<(), Error> {
 
 /// Determine whether the given error yielded by `tx_simulate`
 /// can be recovered from by submitting the tx anyway.
-///
-/// At the moment, we have only seen this happen for
-/// account sequence mismatch errors, for reasons yet to be determined.
 fn can_recover_from_simulation_failure(e: &Error) -> bool {
     use crate::error::ErrorDetail::*;
 
     match e.detail() {
-        GrpcStatus(detail) => detail.is_account_sequence_mismatch(),
+        GrpcStatus(detail) => detail.is_client_state_height_too_low(),
         _ => false,
     }
 }

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -86,15 +86,15 @@ define_error! {
             |_| { "event monitor error" },
 
         Grpc
-            |_| { "GRPC error" },
+            |_| { "gRPC error" },
 
         GrpcStatus
             { status: GrpcStatus }
-            |e| { format!("GRPC call return error status {0}", e.status) },
+            |e| { format!("gRPC call failed with status: {0}", e.status) },
 
         GrpcTransport
             [ TraceError<TransportError> ]
-            |_| { "error in underlying transport when making GRPC call" },
+            |_| { "error in underlying transport when making gRPC call" },
 
         GrpcResponseParam
             { param: String }

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -410,8 +410,19 @@ define_error! {
                 genesis_bound: u64,
             }
             |e| {
-                format!("semantic config validation failed for option `max_tx_size` chain '{}', reason: `max_tx_size` = {} is greater than {}% of the genesis block param `max_size` = {}",
+                format!("semantic config validation failed for option `max_tx_size` for chain '{}', reason: `max_tx_size` = {} is greater than {}% of the consensus parameter `max_size` = {}",
                     e.chain_id, e.configured_bound, GENESIS_MAX_BYTES_MAX_FRACTION * 100.0, e.genesis_bound)
+            },
+
+        ConfigValidationMaxGasTooHigh
+            {
+                chain_id: ChainId,
+                configured_max_gas: u64,
+                consensus_max_gas: i64,
+            }
+            |e| {
+                format!("semantic config validation failed for option `max_gas` for chain '{}', reason: `max_gas` = {} is greater than the consensus parameter `max_gas` = {}",
+                    e.chain_id, e.configured_max_gas, e.consensus_max_gas)
             },
 
         ConfigValidationTrustingPeriodSmallerThanZero

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -477,3 +477,16 @@ impl Error {
         Error::channel_send()
     }
 }
+
+impl GrpcStatusSubdetail {
+    pub fn is_account_sequence_mismatch(&self) -> bool {
+        if self.status.code() != tonic::Code::InvalidArgument {
+            return false;
+        }
+
+        self.status
+            .message()
+            .trim_start()
+            .starts_with("account sequence mismatch")
+    }
+}

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -479,6 +479,21 @@ impl Error {
 }
 
 impl GrpcStatusSubdetail {
+    /// Check whether this gRPC error matches
+    /// - status: InvalidArgument
+    /// - message: verification failed: ... failed packet acknowledgement verification for client: client state height < proof height ...
+    pub fn is_client_state_height_too_low(&self) -> bool {
+        if self.status.code() != tonic::Code::InvalidArgument {
+            return false;
+        }
+
+        let msg = self.status.message();
+        msg.contains("verification failed") && msg.contains("client state height < proof height")
+    }
+
+    /// Check whether this gRPC error matches
+    /// - status: InvalidArgument
+    /// - message: account sequence mismatch ...
     pub fn is_account_sequence_mismatch(&self) -> bool {
         if self.status.code() != tonic::Code::InvalidArgument {
             return false;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1479
Related: #712

## Description

This PR changes the way the relayer reacts to tx simulation failures in the following way:
- if the tx simulation failed because the client state height is too low, the relayer will fallback on the default gas setting and attempt to submit the tx anyway.

   > @ancazamfir: https://github.com/informalsystems/ibc-rs/pull/1542#issuecomment-961766790
   > Regarding the first case, it's been a lot on my mind as we see this very often in the packet worker. It happens when we have to split N msgs in a number of Tx-es with n (aka max_msg_num) msgs each, with n < N and when the first message is UpdateClient.
    > We may have the worker determine n from the config and prepend the UpdateClient before every batch of n-1 packets. But by the time it gets serialized and into the runtime, it might have to split again due to max_tx_size. The other possibility that we discussed before is to not serialize messages at all and let the runtime ensure that each batch in the Tx starts with UpdateClient.
    > I think that if we could fix this then we can drop the Tx on all simulation errors.

- if the tx simulation failed for any other reason, we abort the submission of the tx and bubble the error up, and let the worker deal with the error. At the moment, workers do not handle these errors in any specific manner, and will just attempt to send the tx again for a fixed number of times. In that case, the overall behavior of the relayer does not change, except that we do not waste fees unnecessarily anymore because we won't attempt to actually submit the tx using the default gas.


## How to test

1. Create a channel

   ```
   ❯ hermes create channel ibc-0 ibc-1 --port-a transfer --port-b transfer
   ```

2. In the Hermes config, set `max_msg_num = 5` for chain `ibc-0`

3. Start Hermes

   ```
   ❯ hermes start
   ```

4. Send N > 5 packets to `ibc-0`

   ```
   ❯ hermes tx raw ft-transfer ibc-0 ibc-1 transfer channel-0 9999 -o 1000 -n 10 -k user2
   ```

5. Check the `hermes start` logs, you should find something like:

   ```
   2021-11-05T14:12:09.633184Z  WARN ThreadId(30) [ibc-1] estimate_gas: failed to simulate tx, falling back on default gas because the error is potentially recoverable: gRPC call failed with status: status: InvalidArgument, message: "failed to execute message; message index: 0: acknowledge packet verification failed: packet acknowledgement verification failed: failed packet acknowledgement verification for client (07-tendermint-0): client state height < proof height ({0 243} < {0 554}): invalid height: invalid request", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc"} }
   2021-11-05T14:12:09.633290Z DEBUG ThreadId(30) [ibc-1] send_tx: using 900000000 gas, fee Fee { amount: "900000stake", gas_limit: 900000000 }
   2021-11-05T14:12:09.639044Z DEBUG ThreadId(30) [ibc-1] send_tx: broadcast_tx_sync: Response { code: Ok, data: Data([]), log: Log("[]"), hash: transaction::Hash(BA94AE4CA198F56E27B4A44DA5E508A2E2207E306F475E5285D873296D892170) }
   ```


______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
