### PR TITLE
Implement custom `Default` instance for `ModeConfig`

### DIFF
--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -162,7 +162,7 @@ impl Config {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ModeConfig {
     pub clients: Clients,
@@ -180,6 +180,26 @@ impl ModeConfig {
     }
 }
 
+impl Default for ModeConfig {
+    fn default() -> Self {
+        Self {
+            clients: Clients {
+                enabled: true,
+                refresh: true,
+                misbehaviour: true,
+            },
+            connections: Connections { enabled: false },
+            channels: Channels { enabled: false },
+            packets: Packets {
+                enabled: true,
+                clear_interval: default::clear_packets_interval(),
+                clear_on_start: true,
+                filter: false,
+                tx_confirmation: true,
+            },
+        }
+    }
+}
 #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Clients {


### PR DESCRIPTION
## Description

This is a follow up on  #1539 to implement a `Default` instance for `ModeConfig` that has default values as described in #1539:

```toml
[mode]

[mode.clients]
enabled = true
refresh = true
misbehaviour = true

[mode.connections]
enabled = false

[mode.channels]
enabled = false

[mode.packets]
enabled = true
clear_interval = 100
clear_on_start = true
filter = false
tx_confirmation = true
```

The use of the new default values are tested in  #1521.


______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
