### PR TITLE
guide: Document OpenSSL pre-requisite

### DIFF
--- a/guide/src/pre_requisites.md
+++ b/guide/src/pre_requisites.md
@@ -38,6 +38,11 @@ You will also need the __Go__ programming language installed and configured on y
 
 To install and configure Golang on your machine please follow the [Golang official documentation](https://golang.org/doc/install).
 
+## 3. Libraries
+
+The OpenSSL library with its headers is required. Refer to the
+[openssl crate documentation](https://docs.rs/openssl) for the ways to install OpenSSL on different platforms and make it available to the build script if necessary.
+
 ## Next Steps
 
 Next, go to the [Installation](./installation.md) section to learn how to build Hermes.


### PR DESCRIPTION
Closes: #1569

## Description

Document an OpenSSL Installation as a prerequisite in the Hermes guide.

______

For contributor use:

- [ ] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`) and code comments.
- [x] Re-reviewed `Files changed` in the Github PR explorer.
