### PR TITLE
fix(chore): make metrics fn aligned with metrics name

### DIFF
--- a/relayer/src/worker/client.rs
+++ b/relayer/src/worker/client.rs
@@ -70,7 +70,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> ClientWorker<ChainA, ChainB> {
                 match client.refresh() {
                     Ok(Some(_)) => {
                         telemetry!(
-                            ibc_client_update,
+                            ibc_client_updates,
                             &self.client.dst_chain_id,
                             &self.client.dst_client_id,
                             1

--- a/telemetry/src/state.rs
+++ b/telemetry/src/state.rs
@@ -65,7 +65,7 @@ impl TelemetryState {
     }
 
     /// Update the number of client updates per client
-    pub fn ibc_client_update(&self, chain: &ChainId, client: &ClientId, count: u64) {
+    pub fn ibc_client_updates(&self, chain: &ChainId, client: &ClientId, count: u64) {
         let labels = &[
             KeyValue::new("chain", chain.to_string()),
             KeyValue::new("client", client.to_string()),


### PR DESCRIPTION
## Description

- fn `ibc_client_update` is the only fn which has a slightly different name with the metrics it emits.
- Renaming it to its metrics name improves the readability (and search-ability) of the code.
______

For contributor use:

- [NA] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [NA] If applicable: Unit tests written, added test to CI.
- [NA] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [NA] Updated relevant documentation (`docs/`) and code comments.
- [X] Re-reviewed `Files changed` in the Github PR explorer.
