### PR TITLE
Delete packet commitment instead of acknowledgement in acknowledgePacket

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1573-delete-commitment-in-acknowledgePacket.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1573-delete-commitment-in-acknowledgePacket.md
@@ -1,0 +1,2 @@
+- Delete packet commitment instead of acknowledgement in acknowledgePacket
+  [#1573](https://github.com/informalsystems/ibc-rs/issues/1573)

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -160,7 +160,7 @@ pub trait ChannelKeeper {
                     }
                     None => {
                         //Unordered Channel
-                        self.delete_packet_acknowledgement((
+                        self.delete_packet_commitment((
                             res.port_id.clone(),
                             res.channel_id.clone(),
                             res.seq,


### PR DESCRIPTION
Closes: #1573

## Description
See [processing-acknowledgements](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#processing-acknowledgements) ->
```
function acknowledgePacket(
  packet: OpaquePacket,
  acknowledgement: bytes,
  proof: CommitmentProof,
  proofHeight: Height,
  relayer: string): Packet {

    // ...
    
    // delete our commitment so we can't "acknowledge" again
    provableStore.delete(packetCommitmentPath(packet.sourcePort, packet.sourceChannel, packet.sequence))  // <---- here

    // return transparent packet
    return packet
}
```

______

For contributor use:

- [x] Added a changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] If applicable: Unit tests written, added test to CI.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated relevant documentation (`docs/`) and code comments.
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
