### PR TITLE
Fix example config.toml, add regression test

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -223,61 +223,6 @@ memo_prefix = ''
 #   ['transfer', 'channel-0'],
 # ]
 
-# Specify custom ICS23 proof-specs for the chain (serialized as JSON).
-# Default: [`ProofSpecs::cosmos()`](modules/src/core/ics23_commitment/specs.rs)
-proof_specs = '''
-[
-  {
-    "leaf_spec": {
-      "hash": 1,
-      "prehash_key": 0,
-      "prehash_value": 1,
-      "length": 1,
-      "prefix": [
-        0
-      ]
-    },
-    "inner_spec": {
-      "child_order": [
-        0,
-        1
-      ],
-      "child_size": 33,
-      "min_prefix_length": 4,
-      "max_prefix_length": 12,
-      "empty_child": [],
-      "hash": 1
-    },
-    "max_depth": 0,
-    "min_depth": 0
-  },
-  {
-    "leaf_spec": {
-      "hash": 1,
-      "prehash_key": 0,
-      "prehash_value": 1,
-      "length": 1,
-      "prefix": [
-        0
-      ]
-    },
-    "inner_spec": {
-      "child_order": [
-        0,
-        1
-      ],
-      "child_size": 32,
-      "min_prefix_length": 1,
-      "max_prefix_length": 1,
-      "empty_child": [],
-      "hash": 1
-    },
-    "max_depth": 0,
-    "min_depth": 0
-  }
-]
-'''
-
 [[chains]]
 id = 'ibc-1'
 rpc_addr = 'http://127.0.0.1:26557'

--- a/config.toml
+++ b/config.toml
@@ -225,7 +225,7 @@ memo_prefix = ''
 
 # Specify custom ICS23 proof-specs for the chain (serialized as JSON).
 # Default: [`ProofSpecs::cosmos()`](modules/src/core/ics23_commitment/specs.rs)
-proof-specs = '''
+proof_specs = '''
 [
   {
     "leaf_spec": {

--- a/relayer-cli/tests/acceptance.rs
+++ b/relayer-cli/tests/acceptance.rs
@@ -45,3 +45,15 @@ fn start_no_args() {
     ); // Todo: find out how to disable colored output and then remove the `[^ ]*` part from the regexp.
     cmd.wait().unwrap().expect_success();
 }
+
+#[cfg(not(tarpaulin))]
+#[test]
+fn example_configuration_is_valid() {
+    let mut runner = RUNNER.clone();
+    let mut cmd = runner
+        .capture_stdout()
+        .args(["--config", "../config.toml", "config", "validate"])
+        .run();
+    cmd.stdout().expect_regex("configuration is valid");
+    cmd.wait().unwrap().expect_success();
+}


### PR DESCRIPTION

## Description

The example `config.toml` is broken in master: the `proof_specs` field
was mistakenly named `proof-specs`.

Fix this and add a CLI test against future regressions in validity of the
example `config.toml`.

______

### PR author checklist:
- ~Added changelog entry~
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- ~Updated code comments and documentation (e.g., `docs/`).~

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).