### PR TITLE
Increase default for max_gas pre defined

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer-cli/1636.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/1636.md
@@ -1,0 +1,2 @@
+- Increase the default for `max_gas` from `300_000` to `400_000` ([#1636](https://github.com/informalsystems/ibc-rs/pull/1636))
+

--- a/config.toml
+++ b/config.toml
@@ -155,8 +155,8 @@ store_prefix = 'ibc'
 default_gas = 100000
 
 # Specify the maximum amount of gas to be used as the gas limit for a transaction.
-# Default: 300 000
-max_gas = 300000
+# Default: 400 000
+max_gas = 400000
 
 # Specify the price per gas used of the fee to submit a transaction and
 # the denomination of the fee. Required
@@ -239,7 +239,7 @@ account_prefix = 'cosmos'
 key_name = 'testkey'
 store_prefix = 'ibc'
 default_gas = 100000
-max_gas = 3000000
+max_gas = 400000
 gas_price = { price = 0.001, denom = 'stake' }
 gas_adjustment = 0.1
 max_msg_num = 30

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -98,7 +98,7 @@ mod compatibility;
 pub mod version;
 
 /// Default gas limit when submitting a transaction.
-const DEFAULT_MAX_GAS: u64 = 300_000;
+const DEFAULT_MAX_GAS: u64 = 400_000;
 
 /// Fraction of the estimated gas to add to the estimated gas amount when submitting a transaction.
 const DEFAULT_GAS_PRICE_ADJUSTMENT: f64 = 0.1;


### PR DESCRIPTION
## Description
Increase default for max_gas constant

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Manually tested (in case integration/unit/mock tests are absent).
- [x] Reviewed `Files changed` in the GitHub PR explorer.
