### PR TITLE
Pin the abscissa version to 0.6.0-beta.1

### DIFF
--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -71,10 +71,10 @@ version = "=0.23.1"
 features = ["unstable"]
 
 [dependencies.abscissa_core]
-version = "0.6.0-beta.1"
+version = "=0.6.0-beta.1"
 features = ["options"]
 
 [dev-dependencies]
-abscissa_core = { version = "0.6.0-beta.1", features = ["testing"] }
+abscissa_core = { version = "=0.6.0-beta.1", features = ["testing"] }
 once_cell = "1.8"
 regex = "1.5"


### PR DESCRIPTION
Unpinned, a `cargo update` "updates" it to 0.6.0-pre.2, which is later
by semver, but not by the pre-release sequence used by abscissa.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).