### PR TITLE
Convert frozen height to None when raw frozen height is zero

### DIFF
--- a/e2e/e2e/client.py
+++ b/e2e/e2e/client.py
@@ -60,7 +60,7 @@ class AllowUpdate:
 @dataclass
 class ClientState:
     chain_id: ChainId
-    frozen_height: Height
+    frozen_height: Optional[Height]
     latest_height: Height
     max_clock_drift: Duration
     trust_level: TrustLevel

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -200,6 +200,15 @@ impl TryFrom<RawClientState> for ClientState {
             .clone()
             .ok_or_else(Error::missing_trusting_period)?;
 
+        let frozen_height = raw.frozen_height.and_then(|raw_height| {
+            let height = raw_height.into();
+            if height == Height::zero() {
+                None
+            } else {
+                Some(height)
+            }
+        });
+
         Ok(Self {
             chain_id: ChainId::from_string(raw.chain_id.as_str()),
             trust_level: trust_level
@@ -224,7 +233,7 @@ impl TryFrom<RawClientState> for ClientState {
                 .latest_height
                 .ok_or_else(Error::missing_latest_height)?
                 .into(),
-            frozen_height: raw.frozen_height.map(|h| h.into()),
+            frozen_height,
             upgrade_path: raw.upgrade_path,
             allow_update: AllowUpdate {
                 after_expiry: raw.allow_update_after_expiry,


### PR DESCRIPTION
Fixes #1619

## Description

This fixes a conversion error in #1619 which converts a raw zero frozen height to `Some(height)`. This causes the client refresh code to always fail and produce errors in the log that looks like:

```
2021-12-03T15:15:23.859171Z  WARN ibc_relayer::worker::client: failed to refresh client 'ibc-beta-db1b0834 -> ibc-alpha-d6aefd25:07-tendermint-3':
   0: client 07-tendermint-3 on chain id ibc-alpha-d6aefd25 is expired or frozen

Location:
   /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.4/src/tracer_impl/eyre.rs:10

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 5 frames hidden ⋮
   6: flex_error::tracer_impl::eyre::<impl flex_error::tracer::ErrorMessageTracer for eyre::Report>::new_message::h840ab510e0dd20df
      at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.4/src/tracer_impl/eyre.rs:10
   7: ibc_relayer::foreign_client::ForeignClientError::expired_or_frozen::h7431f07b814e8973
      at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/flex-error-0.4.4/src/macros.rs:823
   8: ibc_relayer::foreign_client::ForeignClient<DstChain,SrcChain>::refresh::h0c2eb9dc8d22c66b
      at /development/relayer/src/foreign_client.rs:575
   9: ibc_relayer::worker::client::ClientWorker<ChainA,ChainB>::run::h7a6eaa440ab40f79
      at /development/relayer/src/worker/client.rs:70
  10: ibc_relayer::worker::Worker<ChainA,ChainB>::run::hf27efb7db6ebec06
      at /development/relayer/src/worker.rs:122
  11: ibc_relayer::worker::Worker<ChainA,ChainB>::spawn::{{closure}}::hc3e19b432a406c12
      at /development/relayer/src/worker.rs:111
                                ⋮ 14 frames hidden ⋮
```

The error was not picked up by the CI because it is an error on the client worker, and therefore does not cause tests to crash.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).