### PR TITLE
Bump Rust toolchain to 1.57, fix lints

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -29,17 +29,9 @@ use crate::Height;
 
 use crate::downcast;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TendermintClient {
     verifier: ProdVerifier,
-}
-
-impl Default for TendermintClient {
-    fn default() -> Self {
-        Self {
-            verifier: ProdVerifier::default(),
-        }
-    }
 }
 
 impl ClientDef for TendermintClient {

--- a/modules/src/core/ics03_connection/connection.rs
+++ b/modules/src/core/ics03_connection/connection.rs
@@ -235,21 +235,11 @@ impl ConnectionEnd {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Counterparty {
     client_id: ClientId,
     pub connection_id: Option<ConnectionId>,
     prefix: CommitmentPrefix,
-}
-
-impl Default for Counterparty {
-    fn default() -> Self {
-        Counterparty {
-            client_id: Default::default(),
-            connection_id: None,
-            prefix: Default::default(),
-        }
-    }
 }
 
 impl Protobuf<RawCounterparty> for Counterparty {}

--- a/modules/src/core/ics03_connection/events.rs
+++ b/modules/src/core/ics03_connection/events.rs
@@ -71,25 +71,13 @@ fn extract_attributes_from_tx(event: &tendermint::abci::Event) -> Result<Attribu
     Ok(attr)
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Attributes {
     pub height: Height,
     pub connection_id: Option<ConnectionId>,
     pub client_id: ClientId,
     pub counterparty_connection_id: Option<ConnectionId>,
     pub counterparty_client_id: ClientId,
-}
-
-impl Default for Attributes {
-    fn default() -> Self {
-        Attributes {
-            height: Default::default(),
-            connection_id: Default::default(),
-            client_id: Default::default(),
-            counterparty_connection_id: Default::default(),
-            counterparty_client_id: Default::default(),
-        }
-    }
 }
 
 /// Convert attributes to Tendermint ABCI tags

--- a/modules/src/core/ics04_channel/channel.rs
+++ b/modules/src/core/ics04_channel/channel.rs
@@ -244,19 +244,10 @@ impl ChannelEnd {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Counterparty {
     pub port_id: PortId,
     pub channel_id: Option<ChannelId>,
-}
-
-impl Default for Counterparty {
-    fn default() -> Self {
-        Counterparty {
-            port_id: Default::default(),
-            channel_id: None,
-        }
-    }
 }
 
 impl Counterparty {

--- a/modules/src/core/ics04_channel/events.rs
+++ b/modules/src/core/ics04_channel/events.rs
@@ -180,7 +180,7 @@ fn extract_packet_and_write_ack_from_tx(
     Ok((packet, write_ack))
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Attributes {
     pub height: Height,
     pub port_id: PortId,
@@ -196,19 +196,6 @@ impl Attributes {
     }
     pub fn channel_id(&self) -> Option<&ChannelId> {
         self.channel_id.as_ref()
-    }
-}
-
-impl Default for Attributes {
-    fn default() -> Self {
-        Attributes {
-            height: Default::default(),
-            port_id: Default::default(),
-            channel_id: Default::default(),
-            connection_id: Default::default(),
-            counterparty_port_id: Default::default(),
-            counterparty_channel_id: Default::default(),
-        }
     }
 }
 

--- a/modules/src/core/ics04_channel/packet.rs
+++ b/modules/src/core/ics04_channel/packet.rs
@@ -54,14 +54,10 @@ impl core::fmt::Display for PacketMsgType {
 }
 
 /// The sequence number of a packet enforces ordering among packets from the same source.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize,
+)]
 pub struct Sequence(u64);
-
-impl Default for Sequence {
-    fn default() -> Self {
-        Sequence(0)
-    }
-}
 
 impl FromStr for Sequence {
     type Err = Error;

--- a/modules/src/timestamp.rs
+++ b/modules/src/timestamp.rs
@@ -20,7 +20,7 @@ pub const ZERO_DURATION: Duration = Duration::from_secs(0);
 /// a `u64` value and a raw timestamp. In protocol buffer, the timestamp is
 /// represented as a `u64` Unix timestamp in nanoseconds, with 0 representing the absence
 /// of timestamp.
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Deserialize, Serialize, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Default, Deserialize, Serialize, Hash)]
 pub struct Timestamp {
     time: Option<DateTime<Utc>>,
 }
@@ -238,12 +238,6 @@ impl From<Time> for Timestamp {
         Timestamp {
             time: Some(tendermint_time.into()),
         }
-    }
-}
-
-impl Default for Timestamp {
-    fn default() -> Self {
-        Timestamp { time: None }
     }
 }
 

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -1,14 +1,9 @@
-use std::io;
-
 use abscissa_core::{Component, FrameworkError, FrameworkErrorKind};
 use tracing_subscriber::{filter::EnvFilter, util::SubscriberInitExt, FmtSubscriber};
 
 use ibc_relayer::config::GlobalConfig;
 
 use crate::config::Error;
-
-/// Custom types to simplify the `Tracing` definition below
-type StdWriter = fn() -> io::Stderr;
 
 /// A custom component for parametrizing `tracing` in the relayer.
 /// Primarily used for:
@@ -21,7 +16,6 @@ pub struct JsonTracing;
 
 impl JsonTracing {
     /// Creates a new [`JsonTracing`] component
-    #[allow(trivial_casts)]
     pub fn new(cfg: GlobalConfig) -> Result<Self, FrameworkError> {
         let filter = build_tracing_filter(cfg.log_level.to_string())?;
         // Note: JSON formatter is un-affected by ANSI 'color' option. Set to 'false'.
@@ -31,7 +25,7 @@ impl JsonTracing {
         let builder = FmtSubscriber::builder()
             .with_target(false)
             .with_env_filter(filter)
-            .with_writer(std::io::stderr as StdWriter)
+            .with_writer(std::io::stderr)
             .with_ansi(use_color)
             .with_thread_ids(true)
             .json();
@@ -48,7 +42,6 @@ pub struct PrettyTracing;
 
 impl PrettyTracing {
     /// Creates a new [`PrettyTracing`] component
-    #[allow(trivial_casts)]
     pub fn new(cfg: GlobalConfig) -> Result<Self, FrameworkError> {
         let filter = build_tracing_filter(cfg.log_level.to_string())?;
 
@@ -56,7 +49,7 @@ impl PrettyTracing {
         let builder = FmtSubscriber::builder()
             .with_target(false)
             .with_env_filter(filter)
-            .with_writer(std::io::stderr as StdWriter)
+            .with_writer(std::io::stderr)
             .with_ansi(enable_ansi())
             .with_thread_ids(true);
 

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -1,25 +1,13 @@
 use std::io;
 
 use abscissa_core::{Component, FrameworkError, FrameworkErrorKind};
-use tracing_subscriber::{
-    filter::EnvFilter,
-    fmt::{
-        format::{DefaultFields, Format, Full, Json, JsonFields},
-        time::SystemTime,
-        Formatter as TracingFormatter,
-    },
-    reload::Handle,
-    util::SubscriberInitExt,
-    FmtSubscriber,
-};
+use tracing_subscriber::{filter::EnvFilter, util::SubscriberInitExt, FmtSubscriber};
 
 use ibc_relayer::config::GlobalConfig;
 
 use crate::config::Error;
 
 /// Custom types to simplify the `Tracing` definition below
-type JsonFormatter = TracingFormatter<JsonFields, Format<Json, SystemTime>, StdWriter>;
-type PrettyFormatter = TracingFormatter<DefaultFields, Format<Full, SystemTime>, StdWriter>;
 type StdWriter = fn() -> io::Stderr;
 
 /// A custom component for parametrizing `tracing` in the relayer.
@@ -29,9 +17,7 @@ type StdWriter = fn() -> io::Stderr;
 ///   (`debug!`, `info!`, etc.) or abscissa macros (`status_err`, `status_info`, etc.).
 /// - Enabling JSON-formatted output without coloring
 #[derive(Component, Debug)]
-pub struct JsonTracing {
-    filter_handle: Handle<EnvFilter, JsonFormatter>,
-}
+pub struct JsonTracing;
 
 impl JsonTracing {
     /// Creates a new [`JsonTracing`] component
@@ -48,22 +34,17 @@ impl JsonTracing {
             .with_writer(std::io::stderr as StdWriter)
             .with_ansi(use_color)
             .with_thread_ids(true)
-            .json()
-            .with_filter_reloading();
-
-        let filter_handle = builder.reload_handle();
+            .json();
 
         let subscriber = builder.finish();
         subscriber.init();
 
-        Ok(Self { filter_handle })
+        Ok(Self)
     }
 }
 
 #[derive(Component, Debug)]
-pub struct PrettyTracing {
-    filter_handle: Handle<EnvFilter, PrettyFormatter>,
-}
+pub struct PrettyTracing;
 
 impl PrettyTracing {
     /// Creates a new [`PrettyTracing`] component
@@ -77,15 +58,12 @@ impl PrettyTracing {
             .with_env_filter(filter)
             .with_writer(std::io::stderr as StdWriter)
             .with_ansi(enable_ansi())
-            .with_thread_ids(true)
-            .with_filter_reloading();
-
-        let filter_handle = builder.reload_handle();
+            .with_thread_ids(true);
 
         let subscriber = builder.finish();
         subscriber.init();
 
-        Ok(Self { filter_handle })
+        Ok(Self)
     }
 }
 

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -286,18 +286,10 @@ impl fmt::Display for LogLevel {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GlobalConfig {
     pub log_level: LogLevel,
-}
-
-impl Default for GlobalConfig {
-    fn default() -> Self {
-        Self {
-            log_level: LogLevel::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -1,5 +1,6 @@
 //! Relayer configuration
 
+mod error;
 mod proof_specs;
 pub mod reload;
 pub mod types;
@@ -18,8 +19,9 @@ use ibc::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
 use ibc::timestamp::ZERO_DURATION;
 
 use crate::config::types::{MaxMsgNum, MaxTxSize, Memo};
-use crate::error::Error;
 use crate::keyring::Store;
+
+pub use error::Error;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GasPrice {
@@ -403,9 +405,9 @@ pub struct ChainConfig {
 
 /// Attempt to load and parse the TOML config file as a `Config`.
 pub fn load(path: impl AsRef<Path>) -> Result<Config, Error> {
-    let config_toml = std::fs::read_to_string(&path).map_err(Error::config_io)?;
+    let config_toml = std::fs::read_to_string(&path).map_err(Error::io)?;
 
-    let config = toml::from_str::<Config>(&config_toml[..]).map_err(Error::config_decode)?;
+    let config = toml::from_str::<Config>(&config_toml[..]).map_err(Error::decode)?;
 
     Ok(config)
 }
@@ -417,16 +419,16 @@ pub fn store(config: &Config, path: impl AsRef<Path>) -> Result<(), Error> {
     } else {
         File::create(path)
     }
-    .map_err(Error::config_io)?;
+    .map_err(Error::io)?;
 
     store_writer(config, &mut file)
 }
 
 /// Serialize the given `Config` as TOML to the given writer.
 pub(crate) fn store_writer(config: &Config, mut writer: impl Write) -> Result<(), Error> {
-    let toml_config = toml::to_string_pretty(&config).map_err(Error::config_encode)?;
+    let toml_config = toml::to_string_pretty(&config).map_err(Error::encode)?;
 
-    writeln!(writer, "{}", toml_config).map_err(Error::config_io)?;
+    writeln!(writer, "{}", toml_config).map_err(Error::io)?;
 
     Ok(())
 }

--- a/relayer/src/config/error.rs
+++ b/relayer/src/config/error.rs
@@ -1,0 +1,18 @@
+use flex_error::{define_error, TraceError};
+
+define_error! {
+    Error {
+        Io
+            [ TraceError<std::io::Error> ]
+            |_| { "config I/O error" },
+
+        Decode
+            [ TraceError<toml::de::Error> ]
+            |_| { "invalid configuration" },
+
+        Encode
+            [ TraceError<toml::ser::Error> ]
+            |_| { "invalid configuration" },
+
+    }
+}

--- a/relayer/src/config/reload.rs
+++ b/relayer/src/config/reload.rs
@@ -20,7 +20,7 @@ use super::{ChainConfig, Config};
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("failed to load configuration from disk")]
-    LoadFailed(#[source] crate::error::Error),
+    LoadFailed(#[source] super::error::Error),
 
     #[error("configuration is inconsistent, did not find config for added/updated chain {0}")]
     InconsistentConfig(ChainId),

--- a/relayer/src/config/reload.rs
+++ b/relayer/src/config/reload.rs
@@ -80,7 +80,7 @@ impl ConfigReload {
         for update in updates {
             if self
                 .tx_cmd
-                .send(SupervisorCmd::UpdateConfig(update))
+                .send(SupervisorCmd::UpdateConfig(Box::new(update)))
                 .is_err()
             {
                 debug!("failed to send config update to supervisor, channel is closed");

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -39,21 +39,9 @@ use crate::sdk_error::SdkError;
 
 define_error! {
     Error {
-        ConfigIo
-            [ TraceError<std::io::Error> ]
-            |_| { "config I/O error" },
-
         Io
             [ TraceError<std::io::Error> ]
             |_| { "I/O error" },
-
-        ConfigDecode
-            [ TraceError<toml::de::Error> ]
-            |_| { "invalid configuration" },
-
-        ConfigEncode
-            [ TraceError<toml::ser::Error> ]
-            |_| { "invalid configuration" },
 
         Rpc
             { url: tendermint_rpc::Url }

--- a/relayer/src/supervisor.rs
+++ b/relayer/src/supervisor.rs
@@ -377,7 +377,7 @@ impl<Chain: ChainHandle + 'static> Supervisor<Chain> {
         if let Ok(cmd) = self.cmd_rx.try_recv() {
             match cmd {
                 SupervisorCmd::UpdateConfig(update) => {
-                    let effect = self.update_config(update);
+                    let effect = self.update_config(*update);
 
                     if let CmdEffect::ConfigChanged = effect {
                         match self.init_subscriptions() {

--- a/relayer/src/supervisor/cmd.rs
+++ b/relayer/src/supervisor/cmd.rs
@@ -14,7 +14,7 @@ pub enum ConfigUpdate {
 
 #[derive(Clone, Debug)]
 pub enum SupervisorCmd {
-    UpdateConfig(ConfigUpdate),
+    UpdateConfig(Box<ConfigUpdate>),
     DumpState(Sender<SupervisorState>),
     Stop(Sender<()>),
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "1.56"
+channel    = "1.57"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Description

New rust release, new lints to fix.
Some of them have uncovered little problems in the code, which are fixed at the root cause.

______

### PR author checklist:
- ~Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).~
- ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [ ] Linked to GitHub issue.
- ~Updated code comments and documentation (e.g., `docs/`).~

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).