### PR TITLE
Fix bug in chanOpenAck handler verification

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1649-fix-chan-open-ack-verify.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1649-fix-chan-open-ack-verify.md
@@ -1,0 +1,2 @@
+- Set the `counterparty_channel_id` correctly to fix ICS04 [`chanOpenAck` handler verification](https://github.com/informalsystems/ibc-rs/blob/master/modules/src/core/ics04_channel/handler/chan_open_ack.rs)
+   ([#1649](https://github.com/informalsystems/ibc-rs/issues/1649))

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -68,6 +68,10 @@ pub(crate) fn process(
         expected_connection_hops,
         msg.counterparty_version().clone(),
     );
+
+    // set the counterparty channel id to verify against it
+    channel_end.set_counterparty_channel_id(msg.counterparty_channel_id.clone());
+
     //2. Verify proofs
     verify_channel_proofs(
         ctx,
@@ -82,7 +86,6 @@ pub(crate) fn process(
     // Transition the channel end to the new state & pick a version.
     channel_end.set_state(State::Open);
     channel_end.set_version(msg.counterparty_version().clone());
-    channel_end.set_counterparty_channel_id(msg.counterparty_channel_id.clone());
 
     let result = ChannelResult {
         port_id: msg.port_id().clone(),


### PR DESCRIPTION
Closes: #1649 

## Description
Note that in the [spec](https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#opening-handshake), `chanOpenAck` calls the `verifyChannelState` with the `counterpartyChannelIdentifier` that it receives from the `ChanOpenAck` datagram.
```
function chanOpenAck(
  portIdentifier: Identifier,
  channelIdentifier: Identifier,
  counterpartyVersion: string,
  counterpartyChannelIdentifier: string,
  proofTry: CommitmentProof,
  proofHeight: Height) {
    // ...
    abortTransactionUnless(connection.verifyChannelState(
      proofHeight,
      proofTry,
      channel.counterpartyPortIdentifier,
      counterpartyChannelIdentifier,            // <------------------------- here
      expected
    ))
    channel.state = OPEN
    channel.version = counterpartyVersion
    channel.counterpartyChannelIdentifier = counterpartyChannelIdentifier
    provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
}
```
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~~Added tests: integration (for Hermes) or unit/mock tests (for modules).~~
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).