### PR TITLE
Verification with Prusti

### DIFF
--- a/ibc.rs
+++ b/ibc.rs
@@ -1,0 +1,324 @@
+#![allow(dead_code)]
+#![allow(unused_must_use)]
+#![allow(unused_variables)]
+extern crate prusti_contracts;
+use prusti_contracts::*;
+
+// The following types are essentially uninterpreted
+
+#[derive(Clone, Copy)]
+pub struct AnyConsensusState(u32);
+
+// Cannot be wrapped in Struct due to Prusti Internal Error (fold/unfold)
+type AnyClientState = u32;
+
+#[pure]
+#[trusted]
+fn get_latest_height(cs: AnyClientState) -> Height {
+   unreachable!()
+}
+
+// Cannot be wrapped in Struct due to Prusti Internal Error (fold/unfold)
+type ClientId = u32;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ClientRecord {
+    client_state: Option<AnyClientState>
+}
+
+impl ClientRecord {
+    #[pure]
+    fn client_state_equals(
+        self,
+        state: AnyClientState
+    ) -> bool {
+        match self.client_state {
+            Some(cs) => cs == state,
+            None     => false
+        }
+    }
+
+    #[pure]
+    #[trusted]
+    fn get_max_consensus_state_height(self) -> Option<Height> {
+        unreachable!()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ClientType(u32);
+
+// Collection of clients
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Clients(u32);
+
+impl Clients {
+    #[pure]
+    #[trusted]
+    fn contains_key(self, client_id: ClientId) -> bool {
+        unreachable!()
+    }
+}
+
+// TODO: Make this an associated function of Clients
+#[pure]
+#[trusted]
+#[requires(clients.contains_key(client_id))]
+fn get_client(clients: Clients, client_id: ClientId) -> ClientRecord {
+   unreachable!()
+}
+
+// Cannot be wrapped in Struct due to Prusti Internal Error (fold/unfold)
+type Height = u32;
+
+
+
+// IBC Relayer Messages
+
+#[derive(Clone, Copy)]
+pub struct CreateResult {
+    pub client_id: ClientId,
+    pub client_type: ClientType,
+    pub client_state: AnyClientState,
+    pub consensus_state: AnyConsensusState,
+}
+
+#[derive(Clone, Copy)]
+pub struct UpdateResult {
+    pub client_id: ClientId,
+    pub client_state: AnyClientState,
+    pub consensus_state: AnyConsensusState,
+}
+
+#[derive(Clone, Copy)]
+pub struct UpgradeResult {
+    pub client_id: ClientId,
+    pub client_state: AnyClientState,
+    pub consensus_state: AnyConsensusState,
+}
+
+#[derive(Clone, Copy)]
+pub enum ClientResult {
+    Create(CreateResult),
+    Update(UpdateResult),
+    Upgrade(UpgradeResult)
+}
+
+#[pure]
+fn get_cid(res: ClientResult) -> ClientId {
+   match res {
+        ClientResult::Create(res) => res.client_id,
+        ClientResult::Update(res) => res.client_id,
+        ClientResult::Upgrade(res) => res.client_id
+   }
+}
+
+
+// INVARIANTS
+
+predicate! {
+    fn mock_context_invariant(context: &Context) -> bool {
+        clients_invariant(context.clients)
+    }
+}
+predicate! {
+    fn clients_invariant(clients: Clients) -> bool {
+        forall(|client_id: ClientId|
+               clients.contains_key(client_id) ==>
+               client_invariant(get_client(clients, client_id)))
+    }
+}
+
+/* Corresponds to this invariant on mock context
+
+fn client_invariant(client: &MockClientRecord) {
+    match client.client_state {
+        Some(cs) =>
+            match client.consensus_states.keys().max() {
+                Some(max_height) => cs.latest_height() == max_height,
+                None => false
+            },
+        None => client.consensus_states.is_empty()
+    }
+}
+
+*/
+
+#[pure]
+pub fn client_invariant(client: ClientRecord) -> bool {
+    let hcs = client.get_max_consensus_state_height();
+    match client.client_state {
+        Some(cs) => hcs.is_some() && hcs.unwrap() == get_latest_height(cs),
+        None => hcs.is_none()
+    }
+}
+
+// Context Definition
+
+struct Context {
+    clients: Clients,
+}
+
+#[derive(Clone, Copy)]
+pub struct Ics02Error(u32);
+
+
+impl Context {
+
+    #[requires(clients_invariant(self.clients))]
+    #[ensures(
+        forall(|cid: ClientId|
+            self.clients.contains_key(cid) && get_cid(handler_res) != cid ==>
+                get_client(self.clients, cid) == get_client(old(self.clients), cid)))
+    ]
+    #[ensures(matches!(result, Ok(_)) ==> client_invariant(get_client(self.clients, get_cid(handler_res))))]
+    #[ensures(matches!(result, Ok(_)) ==> clients_invariant(self.clients))]
+    fn store_client_result(&mut self, handler_res: ClientResult) -> Result<(), Ics02Error> {
+        match handler_res {
+            ClientResult::Create(res) => {
+                let client_id = res.client_id;
+                handle_result!(self.store_client_type(client_id, res.client_type));
+                handle_result!(self.store_client_state(client_id, res.client_state));
+                handle_result!(self.store_consensus_state(
+                    client_id,
+                    get_latest_height(res.client_state),
+                    res.consensus_state,
+                ));
+                self.increase_client_counter();
+                Ok(())
+            }
+            ClientResult::Update(res) => {
+                handle_result!(self.store_client_state(res.client_id, res.client_state));
+                handle_result!(self.store_consensus_state(
+                    res.client_id,
+                    get_latest_height(res.client_state),
+                    res.consensus_state,
+                ));
+                Ok(())
+            }
+            ClientResult::Upgrade(res) => {
+                handle_result!(self.store_client_state(res.client_id, res.client_state));
+                handle_result!(self.store_consensus_state(
+                    res.client_id,
+                    get_latest_height(res.client_state),
+                    res.consensus_state,
+                ));
+                Ok(())
+            }
+        }
+    }
+
+    #[trusted]
+    #[ensures(self.clients == old(self.clients))]
+    fn increase_client_counter(&mut self) {
+    }
+
+    #[ensures(
+        forall(|cid: ClientId|
+            (old(self.clients).contains_key(cid) || cid == client_id) ==
+                self.clients.contains_key(cid)))
+    ]
+    #[ensures(
+        forall(|cid: ClientId|
+            self.clients.contains_key(cid) && client_id != cid ==>
+                get_client(self.clients, cid) == get_client(old(self.clients), cid)))
+    ]
+    #[ensures(
+        self.clients.contains_key(client_id) &&
+            get_client(self.clients, client_id).client_state_equals(client_state)
+    )]
+    #[ensures(
+        old(self.clients).contains_key(client_id) ==>
+            get_client(self.clients, client_id).get_max_consensus_state_height() ==
+                get_client(old(self.clients), client_id).get_max_consensus_state_height()
+    )]
+    #[ensures(
+        !old(self.clients).contains_key(client_id) ==>
+            get_client(self.clients, client_id).get_max_consensus_state_height().is_none()
+    )]
+    #[trusted]
+    fn store_client_state(
+        &mut self,
+        client_id: ClientId,
+        client_state: AnyClientState,
+    ) -> Result<(), Ics02Error> {
+        unreachable!()
+    }
+
+    #[ensures(
+        forall(|cid: ClientId|
+            (old(self.clients).contains_key(cid) || cid == client_id) ==
+                self.clients.contains_key(cid)))
+    ]
+    #[ensures(
+        forall(|cid: ClientId|
+            self.clients.contains_key(cid) && client_id != cid ==>
+                get_client(self.clients, cid) == get_client(old(self.clients), cid)))
+    ]
+    #[trusted]
+    fn store_client_type(
+        &mut self,
+        client_id: ClientId,
+        client_type: ClientType,
+    ) -> Result<(), Ics02Error> {
+        unreachable!()
+    }
+
+    #[ensures(
+        forall(|cid: ClientId|
+            (old(self.clients).contains_key(cid) || cid == client_id) ==
+                self.clients.contains_key(cid)))
+    ]
+    #[ensures(
+        forall(|cid: ClientId|
+            self.clients.contains_key(cid) && client_id != cid ==>
+                get_client(self.clients, cid) == get_client(old(self.clients), cid)))
+    ]
+    #[ensures(
+        self.clients.contains_key(client_id) &&
+            get_client(self.clients, client_id).get_max_consensus_state_height().is_some() &&
+            get_client(self.clients, client_id).get_max_consensus_state_height().unwrap() == height
+    )]
+    #[ensures(
+        old(self.clients).contains_key(client_id) ==>
+            get_client(self.clients, client_id).client_state ==
+                get_client(old(self.clients), client_id).client_state
+    )]
+    #[trusted]
+    fn store_consensus_state(
+        &mut self,
+        client_id: ClientId,
+        height: Height,
+        consensus_state: AnyConsensusState
+    ) -> Result<(), Ics02Error> {
+        unreachable!()
+    }
+}
+
+fn main(){}
+
+// Prusti doesn't support ?, so use this macro instead
+#[macro_export]
+macro_rules! handle_result {
+    ($e: expr) => {
+        match $e {
+            Ok(data) => data,
+            Err(err) => return Err(err)
+        }
+    };
+}
+
+#[extern_spec]
+impl std::option::Option<u32> {
+    #[pure]
+    #[ensures(matches!(*self, Some(_)) == result)]
+    pub fn is_some(&self) -> bool;
+
+    #[pure]
+    #[ensures(self.is_some() == !result)]
+    pub fn is_none(&self) -> bool;
+
+    #[pure]
+    #[requires(self.is_some())]
+    pub fn unwrap(self) -> u32;
+}

--- a/modules/src/applications/ics20_fungible_token_transfer/msgs/transfer.rs
+++ b/modules/src/applications/ics20_fungible_token_transfer/msgs/transfer.rs
@@ -1,4 +1,6 @@
 //! This is the definition of a transfer messages that an application submits to a chain.
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
 
 use crate::prelude::*;
 
@@ -17,6 +19,11 @@ pub const TYPE_URL: &str = "/ibc.applications.transfer.v1.MsgTransfer";
 
 /// Message definition for the "packet receiving" datagram.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature="prusti",
+    invariant(
+        self.timeout_timestamp.time.is_some() ==>
+            self.timeout_timestamp.time.unwrap().timestamp_nanos() >= 0))]
 pub struct MsgTransfer {
     /// the port on which the packet will be sent
     pub source_port: PortId,

--- a/modules/src/core/ics02_client/height.rs
+++ b/modules/src/core/ics02_client/height.rs
@@ -1,3 +1,5 @@
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
 use crate::prelude::*;
 use core::cmp::Ordering;
 
@@ -40,6 +42,7 @@ impl Height {
         self.revision_height == 0
     }
 
+    #[cfg_attr(feature="prusti", requires(u64::MAX - self.revision_height >= delta))]
     pub fn add(&self, delta: u64) -> Height {
         Height {
             revision_number: self.revision_number,
@@ -47,6 +50,7 @@ impl Height {
         }
     }
 
+    #[cfg_attr(feature="prusti", requires(self.revision_height < u64::MAX))]
     pub fn increment(&self) -> Height {
         self.add(1)
     }

--- a/modules/src/core/ics04_channel/packet.rs
+++ b/modules/src/core/ics04_channel/packet.rs
@@ -1,3 +1,5 @@
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
 use crate::prelude::*;
 
 use core::str::FromStr;
@@ -74,6 +76,7 @@ impl Sequence {
         self.0 == 0
     }
 
+    #[cfg_attr(feature="prusti", requires(self.0 < u64::MAX))]
     pub fn increment(&self) -> Sequence {
         Sequence(self.0 + 1)
     }

--- a/modules/src/core/ics24_host/validate.rs
+++ b/modules/src/core/ics24_host/validate.rs
@@ -1,3 +1,6 @@
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
+
 use crate::prelude::*;
 
 use super::error::ValidationError as Error;
@@ -10,6 +13,7 @@ const VALID_SPECIAL_CHARS: &str = "._+-#[]<>";
 ///
 /// A valid identifier only contain lowercase alphabetic characters, and be of a given min and max
 /// length.
+#[cfg_attr(feature="prusti", requires(max >= min))]
 pub fn validate_identifier(id: &str, min: usize, max: usize) -> Result<(), Error> {
     assert!(max >= min);
 

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -1,3 +1,6 @@
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
+
 use crate::prelude::*;
 use alloc::collections::btree_map::BTreeMap as HashMap;
 use core::convert::{TryFrom, TryInto};
@@ -344,6 +347,10 @@ impl IbcEvent {
         }
     }
 
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::ChainError(_))))]
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::UpgradeClient(_))))]
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::Empty(_))))]
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::TimeoutOnClosePacket(_))))]
     pub fn height(&self) -> Height {
         match self {
             IbcEvent::NewBlock(bl) => bl.height(),
@@ -369,6 +376,9 @@ impl IbcEvent {
         }
     }
 
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::ChainError(_))))]
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::Empty(_))))]
+    #[cfg_attr(feature="prusti", requires(!matches!(*self, IbcEvent::TimeoutOnClosePacket(_))))]
     pub fn set_height(&mut self, height: Height) {
         match self {
             IbcEvent::NewBlock(ev) => ev.set_height(height),

--- a/modules/src/mock/host.rs
+++ b/modules/src/mock/host.rs
@@ -1,4 +1,6 @@
 //! Host chain types and methods, used by context mock.
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
 
 use tendermint::time::Time;
 use tendermint_testgen::light_block::TmLightBlock;
@@ -58,6 +60,7 @@ impl HostBlock {
         }
     }
 
+    #[cfg_attr(feature="prusti", requires(TestgenLightBlock::new_default(height).generate().is_ok()))]
     pub fn generate_tm_block(chain_id: ChainId, height: u64) -> TmLightBlock {
         // Sleep is required otherwise the generator produces blocks with the
         // same timestamp as two block can be generated per second.

--- a/modules/src/serializers.rs
+++ b/modules/src/serializers.rs
@@ -1,6 +1,10 @@
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
+
 use serde::ser::{Serialize, Serializer};
 use subtle_encoding::{Encoding, Hex};
 
+#[cfg_attr(feature="prusti", requires(Hex::upper_case().encode_to_string(data).is_ok()))]
 pub fn ser_hex_upper<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/modules/src/timestamp.rs
+++ b/modules/src/timestamp.rs
@@ -122,6 +122,7 @@ impl Timestamp {
     }
 
     /// Convert a `Timestamp` to an optional [`chrono::DateTime<Utc>`]
+    #[cfg_attr(feature="prusti", requires(as_nanos_spec(&self.time)))]
     pub fn as_datetime(&self) -> Option<DateTime<Utc>> {
         self.time
     }
@@ -149,6 +150,15 @@ impl Timestamp {
             (Some(time1), Some(time2)) => time1 > time2,
             _ => false,
         }
+    }
+}
+
+#[cfg(feature="prusti")]
+#[pure]
+fn as_nanos_spec(time: &Option<DateTime<Utc>>) -> bool {
+    match time {
+        Some(t) => t.timestamp_nanos() >= 0,
+        None => true
     }
 }
 

--- a/relayer/src/light_client/tendermint.rs
+++ b/relayer/src/light_client/tendermint.rs
@@ -1,3 +1,6 @@
+#[cfg(feature="prusti")]
+use prusti_contracts::*;
+
 use itertools::Itertools;
 
 use tendermint_light_client::{
@@ -40,6 +43,196 @@ pub struct LightClient {
     io: components::io::ProdIo,
 }
 
+#[cfg(feature="prusti")]
+#[extern_spec]
+mod tendermint {
+    mod Time {
+
+        use prusti_contracts::*;
+        use tendermint_light_client::types::Time;
+
+        #[pure]
+        pub fn now() -> Time;
+    }
+}
+
+#[cfg(feature="prusti")]
+#[extern_spec]
+impl tendermint_light_client::state::State {
+    #[ensures(
+        forall(|i : usize| (i < result.len() ==>
+        target.signed_header.header.time > get_lightblock_header_time(&result, i)
+        ))
+    )]
+    #[ensures(
+        forall(|i: usize, j: usize| i < j ==> get_lightblock_height(&result, i) >= get_lightblock_height(&result, j))
+    )]
+    #[ensures(
+        forall(|i: usize, j: usize| i < j ==> get_lightblock_header_time(&result, i) >= get_lightblock_header_time(&result, j))
+    )]
+    pub fn get_trace_for_target(&self, target: &LightBlock) -> Vec<LightBlock>;
+}
+
+#[cfg(feature="prusti")]
+#[extern_spec]
+impl ibc::ics02_client::client_state::AnyClientState {
+    #[pure]
+    #[ensures(matches!(self, AnyClientState::Tendermint(_)) ==> result == get_trusting_period(self))]
+    pub fn trusting_period(&self) -> Duration;
+}
+
+#[cfg(feature="prusti")]
+#[extern_spec]
+impl <T, A: std::alloc::Allocator> std::vec::Vec<T, A> {
+
+    #[pure]
+    pub fn len(&self) -> usize;
+
+    #[ensures(self.len() == old(self.len()) + 1)]
+    pub fn push(&mut self, value: T);
+}
+
+#[cfg(feature="prusti")]
+#[extern_spec]
+impl tendermint_light_client::light_client::LightClient {
+
+    #[ensures(result.options.trusting_period == options.trusting_period)]
+    pub fn new(
+       options: TmOptions
+    ) -> tendermint_light_client::light_client::LightClient;
+
+    #[ensures(
+        result.is_ok() ==>
+        is_within_trust_period(
+          unwrap_verified(&result),
+          self.options.trusting_period,
+          0
+        )
+    )]
+    pub fn verify_to_target(
+        &self,
+        target_height: tendermint::block::Height,
+        state: &mut tendermint_light_client::state::State,
+    ) -> Result<LightBlock, tendermint_light_client::errors::Error>;
+}
+
+#[cfg(feature="prusti")]
+#[pure]
+#[trusted]
+fn get_lightblock_height(m: &Vec<LightBlock>, i: usize) -> Height {
+    m[i].height()
+}
+
+#[cfg(feature="prusti")]
+#[extern_spec]
+mod tendermint_light_client {
+    mod contracts {
+
+        use prusti_contracts::*;
+        use tendermint_light_client::types::Time;
+        use tendermint_light_client::types::LightBlock;
+        use crate::light_client::tendermint::header_within_trust_period;
+
+        #[pure]
+        #[ensures(header_within_trust_period(&light_block.signed_header, trusting_period, now))]
+        pub fn is_within_trust_period(
+            light_block: &LightBlock,
+            trusting_period: i32,
+            now: i32) -> bool;
+    }
+}
+
+#[cfg(feature="prusti")]
+#[pure]
+#[requires(matches!(v, Ok(_)))]
+fn get_options(v: &Result<TmLightClient, Error>) -> TmOptions {
+  match v {
+      Ok(r) => r.options,
+      Err(_) => unreachable!()
+  }
+}
+
+#[cfg(feature="prusti")]
+#[pure]
+fn get_witness(m: &AnyMisbehaviour) -> &SignedHeader {
+   match m {
+       AnyMisbehaviour::Tendermint(t) => &t.header2.signed_header,
+       _ => unreachable!()
+   }
+}
+
+#[cfg(feature="prusti")]
+#[pure]
+fn get_witness_time(m: &AnyMisbehaviour) -> Time {
+    match m {
+        AnyMisbehaviour::Tendermint(t) => t.header2.signed_header.header.time,
+        _ => unreachable!()
+    }
+}
+
+#[cfg(feature="prusti")]
+predicate! {
+   fn verify_spec_internal(target: &LightBlock, supporting: &Vec<LightBlock>) -> bool {
+    forall(|i: usize| (0 <= i && i < supporting.len()) ==>
+           target.signed_header.header.time >
+            get_lightblock_header_time(&supporting, i)
+    )
+   }
+}
+
+#[cfg(feature="prusti")]
+predicate! {
+    fn verify_spec(r: &Result<Verified<LightBlock>, Error>) -> bool {
+        match r {
+            Ok(v) => verify_spec_internal(&v.target, &v.supporting)
+            _ => true
+        }
+    }
+}
+
+#[cfg(feature="prusti")]
+predicate! {
+    fn check_misbehaviour_spec(client_state: &AnyClientState, r: &Result<Option<MisbehaviourEvidence>, Error>) -> bool {
+        match r {
+            Ok(Some(m)) =>
+                misbehaviour_invariant(m) &&
+                header_within_trust_period(&get_witness(&m.misbehaviour), client_state.trusting_period(), 0),
+            _ => true
+        }
+    }
+}
+
+#[cfg(feature="prusti")]
+predicate! {
+    fn misbehaviour_invariant(m: &MisbehaviourEvidence) -> bool {
+    forall(
+        |i : usize|
+        (0 <= i && i < m.supporting_headers.len() ==>
+          get_supporting_header_time(&m.supporting_headers, i) < get_witness_time(&m.misbehaviour)))
+    }
+}
+
+#[cfg(feature="prusti")]
+predicate! {
+    fn adjust_headers_time_spec(header: &TmHeader, sup: &Vec<TmHeader>) -> bool {
+        forall(|i: usize| (0 <= i && i < sup.len()) ==>
+            header.signed_header.header.time > get_header_time(sup, i)
+        )
+    }
+}
+
+#[cfg(feature="prusti")]
+predicate! {
+    fn adjust_headers_spec(target: &LightBlock, r: &Result<(TmHeader, Vec<TmHeader>), Error>) -> bool {
+        match r {
+            Ok((header, sup)) => header.signed_header == target.signed_header &&
+                adjust_headers_time_spec(header, sup),
+            _ => true
+        }
+    }
+}
+
+
 impl super::LightClient<CosmosSdkChain> for LightClient {
     fn header_and_minimal_set(
         &mut self,
@@ -52,6 +245,14 @@ impl super::LightClient<CosmosSdkChain> for LightClient {
         Ok(Verified { target, supporting })
     }
 
+    #[cfg_attr(feature="prusti", ensures(result.is_ok() ==>
+        is_within_trust_period(
+          &get_verified_target(&result),
+          client_state.trusting_period(),
+          0
+        )
+     ))]
+    #[cfg_attr(feature="prusti", ensures(verify_spec(&result)))]
     fn verify(
         &mut self,
         trusted: ibc::Height,
@@ -98,6 +299,7 @@ impl super::LightClient<CosmosSdkChain> for LightClient {
     ///
     /// ## TODO
     /// - [ ] Return intermediate headers as well
+    #[cfg_attr(feature="prusti", ensures(check_misbehaviour_spec(old(client_state), &result)))]
     fn check_misbehaviour(
         &mut self,
         update: UpdateClient,
@@ -177,6 +379,7 @@ impl LightClient {
         })
     }
 
+    #[cfg_attr(feature="prusti", ensures(result.is_ok() ==> get_options(&result).trusting_period == client_state.trusting_period()))]
     fn prepare_client(&self, client_state: &AnyClientState) -> Result<TmLightClient, Error> {
         let clock = components::clock::SystemClock;
         let hasher = operations::hasher::ProdHasher;
@@ -228,6 +431,11 @@ impl LightClient {
             .map_err(|e| Error::light_client_io(self.chain_id.to_string(), e))
     }
 
+    #[cfg_attr(feature="prusti", requires(
+        forall(|i : usize| (0 <= i && i < supporting.len()) ==>
+               target.signed_header.header.time > get_lightblock_header_time(&supporting, i)
+        )))]
+    #[cfg_attr(feature="prusti", ensures(adjust_headers_spec(old(&target), &result)))]
     fn adjust_headers(
         &mut self,
         trusted_height: ibc::Height,


### PR DESCRIPTION
For the past few months I've been looking at using [Prusti](https://www.pm.inf.ethz.ch/research/prusti.html) to verify the correctness of `ibc-rs`, in particular the `modules` and `relayer` crates. The purpose of this PR is just to share a bit of what I've been able to accomplish so far and explain what an integration would look like. Also please let me know if you have any feedback or questions. __This PR is not intended to be merged__.

The Prusti verification operates on entire crates, and is done via an external tool. Prusti verification does not require introducing any new dependencies on the project. Specifications can be encoded as attributes that are only enabled when the "prusti" flag is set, i.e. `#[cfg_attr(feature="prusti", <spec>)]`. The specification syntax is a superset of Rust, with extensions to support `forall` expressions etc.

However, Prusti does not currently support all Rust language features and datatypes. So, it is also possible to provide different implementations for Prusti verification only (i.e. to work-around unsupported language features), without changing the actual implementation.

The following describes what I've done so far. A large caveat is that verification required changes to the code to remove unsupported features and datatypes; and some parts of the code containing unsupported features were excluded from verification entirely. The code in this PR only includes the added specifications, without the changes, in order to clearly demonstrate the annotation syntax and invariants. As a result, Prusti won't be able to verify the code in this PR; a version that has removed unsupported features is available [here](https://github.com/zgrannan/ibc-rs/tree/prusti). Note that it is still a bit messy.

## Verification of Safety Properties

Prusti was able to verify safety properties on the `modules` and `relayer` crate, with the caveat the properties may not hold for code unsupported by Prusti.

### No function will trigger `panic!`

For example in [context.rs](https://github.com/zgrannan/ibc-rs/blob/921d11763f14e028cde4b01d2b16abda18023873/modules/src/mock/context.rs):

```rust
#[cfg_attr(feature="prusti", requires(self.max_history_size > 0))]
#[cfg_attr(feature="prusti", requires(target_height.revision_height <= u64::MAX))]
#[cfg_attr(feature="prusti", requires(target_height.revision_number == self.latest_height.revision_number))]
#[cfg_attr(feature="prusti", requires(target_height.revision_height >= self.latest_height.revision_height))]
pub fn with_height(self, target_height: Height) -> Self {
    if target_height.revision_number > self.latest_height.revision_number {
        unimplemented!()
    } else if target_height.revision_number < self.latest_height.revision_number {
        panic!("Cannot rewind history of the chain to a smaller revision number!")
    } else if target_height.revision_height < self.latest_height.revision_height {
        panic!("Cannot rewind history of the chain to a smaller revision height!")
    } else if target_height.revision_height > self.latest_height.revision_height {
        // Repeatedly advance the host chain height till we hit the desired height
        let mut ctx = MockContext { ..self };
        while ctx.latest_height.revision_height < target_height.revision_height {
            ctx.advance_host_chain_height()
        }
        ctx
    } else {
        // Both the revision number and height match
        self
    }
}
```

The annotations ensure that the function `with_height()` will not panic, and introduces an obligation on the caller to ensure preconditions are satisfied.

### Calls to `Option.unwrap` and `Result.unwrap` will not panic

For example, for serialization:

```rust
#[cfg_attr(feature="prusti", requires(Hex::upper_case().encode_to_string(data).is_ok()))]
pub fn ser_hex_upper<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
where
    S: Serializer,
    T: AsRef<[u8]>,
{
    let hex = Hex::upper_case().encode_to_string(data).unwrap();
    hex.serialize(serializer)
}
```

### Arithmetic Operations will not overflow

This is useful, for example, operations on `Height`, to ensure that it is monotonically increasing.

```rust
#[cfg_attr(feature="prusti", requires(u64::MAX - self.revision_height >= delta))]
pub fn add(&self, delta: u64) -> Height {
    Height {
        revision_number: self.revision_number,
        revision_height: self.revision_height + delta,
    }
}

#[cfg_attr(feature="prusti", requires(self.revision_height < u64::MAX))]
pub fn increment(&self) -> Height {
    self.add(1)
}
```

## Functional Correctness

It was also possible to prove domain-specific invariants and correctness properties.

### Misbehavior Detection

In [tendermint.rs](https://github.com/zgrannan/ibc-rs/blob/921d11763f14e028cde4b01d2b16abda18023873/relayer/src/light_client/tendermint.rs) we have proven that:

- In the event of misbehaviour, the timestamp for the witness header is after the timestamp of all of the supporting headers
  
The invariant is specified as:
```rust
predicate! {
    fn misbehaviour_invariant(m: &MisbehaviourEvidence) -> bool {
    forall(
        |i : usize|
        (0 <= i && i < m.supporting_headers.len() ==>
          get_supporting_header_time(&m.supporting_headers, i) < get_witness_time(&m.misbehaviour)))
    }
}
```
  
- The witness header is within the trust period

This invariant asserts `header_within_trust_period` from the Tendermint crate.

Proving these invariants require adding and proving additional invariants of other functions.

### Client Keeper

In [ibc.rs](https://github.com/zgrannan/ibc-rs/blob/921d11763f14e028cde4b01d2b16abda18023873/ibc.rs), we prove that `store_client_result` in `ClientKeeper`, will correctly maintain an invariant about the stored client data. This is done out of the codebase, because the separation of `ClientKeeper` and `ClientReader` traits.

The client invariant corresponds to:

```rust
fn client_invariant(client: &MockClientRecord) {
    match client.client_state {
        Some(cs) =>
            match client.consensus_states.keys().max() {
                Some(max_height) => cs.latest_height() == max_height,
                None => false
            },
        None => client.consensus_states.is_empty()
    }
}
```
