### PR TITLE
Add assertion for non-zero trust-level in Tendermint client initialization

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1697-assert-non-zero-trust-level.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1697-assert-non-zero-trust-level.md
@@ -1,0 +1,2 @@
+- Add missing assertion for non-zero trust-level in Tendermint client initialization.
+  ([#1697](https://github.com/informalsystems/ibc-rs/issues/1697))

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -84,6 +84,14 @@ impl ClientState {
             ));
         }
 
+        // `TrustThreshold` is guaranteed to be in the range `[0, 1)`, but a `TrustThreshold::ZERO`
+        // value is invalid in this context
+        if trust_level == TrustThreshold::ZERO {
+            return Err(Error::validation(
+                "ClientState trust-level cannot be zero".to_string(),
+            ));
+        }
+
         // Disallow empty proof-specs
         if proof_specs.is_empty() {
             return Err(Error::validation(


### PR DESCRIPTION
Closes: #1697

## Description
Add assertion for non-zero trust-level in Tendermint client initialization. Note, that the check isn't added to the `TrustThreshold` newtype to allow for a `ZERO` value.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).