### PR TITLE
Support Gaia v5 in integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -43,6 +43,7 @@ jobs:
       matrix:
         gaiad:
           - gaia4
+          - gaia5
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
+ "anyhow",
  "eyre",
  "paste",
 ]
@@ -1386,6 +1387,7 @@ dependencies = [
  "crossbeam-channel 0.5.1",
  "env_logger",
  "eyre",
+ "flex-error",
  "hex",
  "ibc",
  "ibc-proto",
@@ -1395,8 +1397,10 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.8.4",
+ "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.9.8",
  "subtle-encoding",
  "tendermint",
@@ -1682,6 +1686,12 @@ name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -2797,6 +2807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "serial_test"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +3921,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/relayer/src/util/task.rs
+++ b/relayer/src/util/task.rs
@@ -90,6 +90,8 @@ pub fn spawn_background_task<E: Display>(
     interval_pause: Option<Duration>,
     mut step_runner: impl FnMut() -> Result<(), TaskError<E>> + Send + Sync + 'static,
 ) -> TaskHandle {
+    info!("spawning new background task {}", task_name);
+
     let stopped = Arc::new(RwLock::new(false));
     let write_stopped = stopped.clone();
 

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = "0.9.0"
 hex = "0.4.3"
 serde = "1.0"
 serde_json = "1"
+serde_yaml = "0.8.23"
 itertools = "0.10"
 toml = "0.5"
 subtle-encoding = "0.5.1"
@@ -38,6 +39,8 @@ sha2 = "0.9.8"
 crossbeam-channel = "0.5.1"
 prost = { version = "0.9", default-features = false }
 prost-types = { version = "0.9", default-features = false }
+semver = "1.0.4"
+flex-error = "0.4.4"
 
 [features]
 default = []

--- a/tools/integration-test/src/bootstrap/single.rs
+++ b/tools/integration-test/src/bootstrap/single.rs
@@ -86,12 +86,6 @@ pub fn bootstrap_single_node(
         Ok(())
     })?;
 
-    // chain_driver.update_chain_config("app.toml", |config| {
-    //     config::set_grpc_port(config, chain_driver.grpc_port)?;
-
-    //     Ok(())
-    // })?;
-
     let process = chain_driver.start()?;
 
     chain_driver.assert_eventual_wallet_amount(&relayer, initial_amount, &denom)?;

--- a/tools/integration-test/src/bootstrap/single.rs
+++ b/tools/integration-test/src/bootstrap/single.rs
@@ -42,7 +42,7 @@ pub fn bootstrap_single_node(
     let denom = Denom(format!("coin{:x}", random_u32()));
     let initial_amount = random_u64_range(1_000_000_000_000, 9_000_000_000_000);
 
-    let chain_driver = builder.new_chain(prefix);
+    let chain_driver = builder.new_chain(prefix)?;
 
     chain_driver.initialize()?;
 
@@ -74,7 +74,7 @@ pub fn bootstrap_single_node(
 
     let log_level = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
 
-    chain_driver.update_chain_config(|config| {
+    chain_driver.update_chain_config("config.toml", |config| {
         config::set_log_level(config, &log_level)?;
         config::set_rpc_port(config, chain_driver.rpc_port)?;
         config::set_p2p_port(config, chain_driver.p2p_port)?;
@@ -85,6 +85,12 @@ pub fn bootstrap_single_node(
 
         Ok(())
     })?;
+
+    // chain_driver.update_chain_config("app.toml", |config| {
+    //     config::set_grpc_port(config, chain_driver.grpc_port)?;
+
+    //     Ok(())
+    // })?;
 
     let process = chain_driver.start()?;
 

--- a/tools/integration-test/src/chain/builder.rs
+++ b/tools/integration-test/src/chain/builder.rs
@@ -4,7 +4,8 @@
 
 use ibc::core::ics24_host::identifier::ChainId;
 
-use super::driver::ChainDriver;
+use crate::chain::driver::ChainDriver;
+use crate::error::Error;
 use crate::types::config::TestConfig;
 use crate::util::random::{random_u32, random_unused_tcp_port};
 
@@ -67,23 +68,27 @@ impl ChainBuilder {
        a [`ChainDriver`] configured with a chain ID  like
        `"ibc-alpha-f5a2a988"`.
     */
-    pub fn new_chain(&self, prefix: &str) -> ChainDriver {
+    pub fn new_chain(&self, prefix: &str) -> Result<ChainDriver, Error> {
         let chain_num = random_u32();
         let chain_id = ChainId::from_string(&format!("ibc-{}-{:x}", prefix, chain_num));
 
         let rpc_port = random_unused_tcp_port();
         let grpc_port = random_unused_tcp_port();
+        let grpc_web_port = random_unused_tcp_port();
         let p2p_port = random_unused_tcp_port();
 
         let home_path = format!("{}/{}", self.base_store_dir, chain_id);
 
-        ChainDriver::new(
+        let driver = ChainDriver::create(
             self.command_path.clone(),
             chain_id,
             home_path,
             rpc_port,
             grpc_port,
+            grpc_web_port,
             p2p_port,
-        )
+        )?;
+
+        Ok(driver)
     }
 }

--- a/tools/integration-test/src/chain/config.rs
+++ b/tools/integration-test/src/chain/config.rs
@@ -25,6 +25,17 @@ pub fn set_rpc_port(config: &mut Value, port: u16) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn set_grpc_port(config: &mut Value, port: u16) -> Result<(), Error> {
+    config
+        .get_mut("grpc-web")
+        .ok_or_else(|| eyre!("expect grpc-web section"))?
+        .as_table_mut()
+        .ok_or_else(|| eyre!("expect object"))?
+        .insert("address".to_string(), format!("0.0.0.0:{}", port).into());
+
+    Ok(())
+}
+
 /// Set the `p2p` field in the full node config.
 pub fn set_p2p_port(config: &mut Value, port: u16) -> Result<(), Error> {
     config

--- a/tools/integration-test/src/chain/driver.rs
+++ b/tools/integration-test/src/chain/driver.rs
@@ -7,15 +7,18 @@ use core::time::Duration;
 use eyre::eyre;
 use ibc::core::ics24_host::identifier::ChainId;
 use ibc_relayer::keyring::{HDPath, KeyEntry, KeyFile};
+use semver::Version;
 use serde_json as json;
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::str;
 use toml;
-use tracing::{debug, trace};
+use tracing::debug;
 
-use crate::error::Error;
+use crate::chain::exec::{simple_exec, ExecOutput};
+use crate::chain::version::get_chain_command_version;
+use crate::error::{handle_generic_error, Error};
 use crate::ibc::denom::Denom;
 use crate::types::env::{EnvWriter, ExportEnv};
 use crate::types::process::ChildProcess;
@@ -52,6 +55,8 @@ pub struct ChainDriver {
     */
     pub command_path: String,
 
+    pub command_version: Version,
+
     /**
        The ID of the chain.
     */
@@ -72,6 +77,8 @@ pub struct ChainDriver {
     */
     pub grpc_port: u16,
 
+    pub grpc_web_port: u16,
+
     /**
        The port used for P2P. (Currently unused other than for setup)
     */
@@ -89,22 +96,27 @@ impl ExportEnv for ChainDriver {
 
 impl ChainDriver {
     /// Create a new [`ChainDriver`]
-    pub fn new(
+    pub fn create(
         command_path: String,
         chain_id: ChainId,
         home_path: String,
         rpc_port: u16,
         grpc_port: u16,
+        grpc_web_port: u16,
         p2p_port: u16,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, Error> {
+        let command_version = get_chain_command_version(&command_path)?;
+
+        Ok(Self {
             command_path,
+            command_version,
             chain_id,
             home_path,
             rpc_port,
             grpc_port,
+            grpc_web_port,
             p2p_port,
-        }
+        })
     }
 
     /// Returns the full URL for the RPC address.
@@ -156,28 +168,8 @@ impl ChainDriver {
        executed, so that users can manually re-run the commands by
        copying from the logs.
     */
-    pub fn exec(&self, args: &[&str]) -> Result<String, Error> {
-        debug!(
-            "Executing command: {} {}",
-            self.command_path,
-            itertools::join(args, " ")
-        );
-
-        let output = Command::new(&self.command_path).args(args).output()?;
-
-        if output.status.success() {
-            let message = str::from_utf8(&output.stdout)?.to_string();
-            trace!("command executed successfully with output: {}", message);
-
-            Ok(message)
-        } else {
-            let message = str::from_utf8(&output.stderr)?.to_string();
-            Err(eyre!(
-                "command exited with error status {:?} and message: {}",
-                output.status.code(),
-                message
-            ))
-        }
+    pub fn exec(&self, args: &[&str]) -> Result<ExecOutput, Error> {
+        simple_exec(&self.command_path, args)
     }
 
     /**
@@ -238,7 +230,7 @@ impl ChainDriver {
        Add a wallet with the given ID to the full node's keyring.
     */
     pub fn add_wallet(&self, wallet_id: &str) -> Result<Wallet, Error> {
-        let seed_content = self.exec(&[
+        let output = self.exec(&[
             "--home",
             self.home_path.as_str(),
             "keys",
@@ -250,7 +242,15 @@ impl ChainDriver {
             "json",
         ])?;
 
-        let json_val: json::Value = json::from_str(&seed_content)?;
+        // gaia6 somehow displays result in stderr instead of stdout
+        let seed_content = if output.stdout.is_empty() {
+            output.stderr
+        } else {
+            output.stdout
+        };
+
+        let json_val: json::Value = json::from_str(&seed_content).map_err(handle_generic_error)?;
+
         let wallet_address = json_val
             .get("address")
             .ok_or_else(|| eyre!("expect address string field to be present in json result"))?
@@ -264,9 +264,9 @@ impl ChainDriver {
         let hd_path = HDPath::from_str(COSMOS_HD_PATH)
             .map_err(|e| eyre!("failed to create HDPath: {:?}", e))?;
 
-        let key_file: KeyFile = json::from_str(&seed_content)?;
+        let key_file: KeyFile = json::from_str(&seed_content).map_err(handle_generic_error)?;
 
-        let key = KeyEntry::from_key_file(key_file, &hd_path)?;
+        let key = KeyEntry::from_key_file(key_file, &hd_path).map_err(handle_generic_error)?;
 
         Ok(Wallet::new(wallet_id.to_string(), wallet_address, key))
     }
@@ -339,15 +339,16 @@ impl ChainDriver {
     */
     pub fn update_chain_config(
         &self,
+        file: &str,
         cont: impl FnOnce(&mut toml::Value) -> Result<(), Error>,
     ) -> Result<(), Error> {
-        let config1 = self.read_file("config/config.toml")?;
+        let config1 = self.read_file(&format!("config/{}", file))?;
 
-        let mut config2 = toml::from_str(&config1)?;
+        let mut config2 = toml::from_str(&config1).map_err(handle_generic_error)?;
 
         cont(&mut config2)?;
 
-        let config3 = toml::to_string_pretty(&config2)?;
+        let config3 = toml::to_string_pretty(&config2).map_err(handle_generic_error)?;
 
         self.write_file("config/config.toml", &config3)?;
 
@@ -361,18 +362,35 @@ impl ChainDriver {
        value is dropped.
     */
     pub fn start(&self) -> Result<ChildProcess, Error> {
+        let base_args = [
+            "--home",
+            &self.home_path,
+            "start",
+            "--pruning",
+            "nothing",
+            "--grpc.address",
+            &self.grpc_listen_address(),
+            "--rpc.laddr",
+            &self.rpc_listen_address(),
+        ];
+
+        // Gaia v6 requires the GRPC web port to be unique,
+        // but the argument is not available in earlier version
+        let extra_args = [
+            "--grpc-web.address",
+            &format!("localhost:{}", self.grpc_web_port),
+        ];
+
+        let args: Vec<&str> = if self.command_version.major >= 6 {
+            let mut list = base_args.to_vec();
+            list.extend_from_slice(&extra_args);
+            list
+        } else {
+            base_args.to_vec()
+        };
+
         let mut child = Command::new(&self.command_path)
-            .args(&[
-                "--home",
-                &self.home_path,
-                "start",
-                "--pruning",
-                "nothing",
-                "--grpc.address",
-                &self.grpc_listen_address(),
-                "--rpc.laddr",
-                &self.rpc_listen_address(),
-            ])
+            .args(&args)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -398,27 +416,30 @@ impl ChainDriver {
        Query for the balances for a given wallet address and denomination
     */
     pub fn query_balance(&self, wallet_id: &WalletAddress, denom: &Denom) -> Result<u64, Error> {
-        let res = self.exec(&[
-            "--node",
-            &self.rpc_listen_address(),
-            "query",
-            "bank",
-            "balances",
-            &wallet_id.0,
-            "--denom",
-            denom.0.as_str(),
-            "--output",
-            "json",
-        ])?;
+        let res = self
+            .exec(&[
+                "--node",
+                &self.rpc_listen_address(),
+                "query",
+                "bank",
+                "balances",
+                &wallet_id.0,
+                "--denom",
+                denom.0.as_str(),
+                "--output",
+                "json",
+            ])?
+            .stdout;
 
-        let amount_str = json::from_str::<json::Value>(&res)?
+        let amount_str = json::from_str::<json::Value>(&res)
+            .map_err(handle_generic_error)?
             .get("amount")
             .ok_or_else(|| eyre!("expected amount field"))?
             .as_str()
             .ok_or_else(|| eyre!("expected string field"))?
             .to_string();
 
-        let amount = u64::from_str(&amount_str)?;
+        let amount = u64::from_str(&amount_str).map_err(handle_generic_error)?;
 
         Ok(amount)
     }
@@ -443,11 +464,11 @@ impl ChainDriver {
                 if amount == target_amount {
                     Ok(())
                 } else {
-                    Err(eyre!(
+                    Err(Error::generic(eyre!(
                         "current balance amount {} does not match the target amount {}",
                         amount,
                         target_amount
-                    ))
+                    )))
                 }
             },
         )?;

--- a/tools/integration-test/src/chain/driver/query_txs.rs
+++ b/tools/integration-test/src/chain/driver/query_txs.rs
@@ -3,8 +3,9 @@
 */
 
 use serde_json as json;
+use serde_yaml as yaml;
 
-use crate::error::Error;
+use crate::error::{handle_generic_error, Error};
 use crate::types::wallet::WalletAddress;
 
 use super::ChainDriver;
@@ -17,18 +18,41 @@ pub fn query_recipient_transactions(
     driver: &ChainDriver,
     recipient_address: &WalletAddress,
 ) -> Result<json::Value, Error> {
-    let res = driver.exec(&[
-        "--node",
-        &driver.rpc_listen_address(),
-        "query",
-        "txs",
-        "--events",
-        &format!("transfer.recipient={}", recipient_address),
-    ])?;
+    let res = driver
+        .exec(&[
+            "--node",
+            &driver.rpc_listen_address(),
+            "query",
+            "txs",
+            "--events",
+            &format!("transfer.recipient={}", recipient_address),
+        ])?
+        .stdout;
 
-    // tracing::debug!("parsing tx result: {}", res);
+    tracing::debug!("parsing tx result: {}", res);
 
-    let json_res = json::from_str(&res)?;
+    match json::from_str(&res) {
+        Ok(res) => Ok(res),
+        _ => {
+            let value: yaml::Value = yaml::from_str(&res).map_err(handle_generic_error)?;
+            Ok(yaml_to_json_value(value)?)
+        }
+    }
+}
 
-    Ok(json_res)
+// Hack to convert yaml::Value to json::Value. Unfortunately there is
+// no builtin conversion provided even though both Value types are
+// essentially the same. We just convert the two types to and from
+// strings as a shortcut.
+//
+// TODO: properly implement a common trait that is implemented by
+// dynamic types like json::Value, yaml::Value, and toml::Value.
+// That way we can write generic functions that work with any of
+// the dynamic value types for testing purposes.
+fn yaml_to_json_value(value: yaml::Value) -> Result<json::Value, Error> {
+    let json_str = json::to_string(&value).map_err(handle_generic_error)?;
+
+    let parsed = json::from_str(&json_str).map_err(handle_generic_error)?;
+
+    Ok(parsed)
 }

--- a/tools/integration-test/src/chain/exec.rs
+++ b/tools/integration-test/src/chain/exec.rs
@@ -1,0 +1,50 @@
+use eyre::eyre;
+use std::process::Command;
+use std::str;
+use tracing::{debug, trace};
+
+use crate::error::{handle_exec_error, handle_generic_error, Error};
+
+pub struct ExecOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub fn simple_exec(command_path: &str, args: &[&str]) -> Result<ExecOutput, Error> {
+    debug!(
+        "Executing command: {} {}",
+        command_path,
+        itertools::join(args, " ")
+    );
+
+    let output = Command::new(&command_path)
+        .args(args)
+        .output()
+        .map_err(handle_exec_error(command_path))?;
+
+    if output.status.success() {
+        let stdout = str::from_utf8(&output.stdout)
+            .map_err(handle_generic_error)?
+            .to_string();
+
+        let stderr = str::from_utf8(&output.stderr)
+            .map_err(handle_generic_error)?
+            .to_string();
+
+        trace!(
+            "command executed successfully with stdout: {}, stderr: {}",
+            stdout,
+            stderr
+        );
+
+        Ok(ExecOutput { stdout, stderr })
+    } else {
+        let message = str::from_utf8(&output.stderr).map_err(handle_generic_error)?;
+
+        Err(Error::generic(eyre!(
+            "command exited with error status {:?} and message: {}",
+            output.status.code(),
+            message
+        )))
+    }
+}

--- a/tools/integration-test/src/chain/mod.rs
+++ b/tools/integration-test/src/chain/mod.rs
@@ -17,3 +17,5 @@
 pub mod builder;
 pub mod config;
 pub mod driver;
+pub mod exec;
+pub mod version;

--- a/tools/integration-test/src/chain/version.rs
+++ b/tools/integration-test/src/chain/version.rs
@@ -1,0 +1,27 @@
+use semver::Version;
+use tracing::debug;
+
+use crate::chain::exec::simple_exec;
+use crate::error::{handle_generic_error, Error};
+
+pub fn get_chain_command_version(command: &str) -> Result<Version, Error> {
+    let output = simple_exec(command, &["version"])?;
+
+    // gaia6 somehow outputs version string result in STDERR
+    let raw_version_str = if output.stdout.is_empty() {
+        output.stderr
+    } else {
+        output.stdout
+    };
+
+    let version_str = match raw_version_str.strip_prefix('v') {
+        Some(str) => str.trim(),
+        None => raw_version_str.trim(),
+    };
+
+    debug!("parsing version string: {}", version_str);
+
+    let version = Version::parse(version_str).map_err(handle_generic_error)?;
+
+    Ok(version)
+}

--- a/tools/integration-test/src/framework/binary/chain.rs
+++ b/tools/integration-test/src/framework/binary/chain.rs
@@ -208,7 +208,9 @@ where
                 .get_overrides()
                 .spawn_supervisor(&chains.config, &chains.registry);
 
-            self.test.run(config, chains)?;
+            self.test
+                .run(config, chains)
+                .map_err(config.hang_on_error())?;
         }
 
         Ok(())
@@ -271,7 +273,9 @@ where
 
         let _drop_handle = DropChainHandle(chains.handle_a.clone());
 
-        self.test.run(config, chains)?;
+        self.test
+            .run(config, chains)
+            .map_err(config.hang_on_error())?;
 
         Ok(())
     }

--- a/tools/integration-test/src/framework/binary/channel.rs
+++ b/tools/integration-test/src/framework/binary/channel.rs
@@ -149,10 +149,9 @@ where
 
         info!("written channel environment to {}", env_path.display());
 
-        self.test.run(config, chains, channels)?;
-
-        // No use suspending the test on owned failures, as the chains and channels
-        // are dropped in the inner test already.
+        self.test
+            .run(config, chains, channels)
+            .map_err(config.hang_on_error())?;
 
         Ok(())
     }

--- a/tools/integration-test/src/tests/supervisor.rs
+++ b/tools/integration-test/src/tests/supervisor.rs
@@ -60,7 +60,9 @@ impl BinaryChainTest for SupervisorTest {
                     .value()
                     .state_matches(&ConnectionState::Open)
                 {
-                    return Err(eyre!("expected connection end A to be in open state"));
+                    return Err(Error::generic(eyre!(
+                        "expected connection end B to be in open state"
+                    )));
                 }
 
                 let connection_id_a = connection_end_b
@@ -76,7 +78,9 @@ impl BinaryChainTest for SupervisorTest {
                     .value()
                     .state_matches(&ConnectionState::Open)
                 {
-                    return Err(eyre!("expected connection end B to be in open state"));
+                    return Err(Error::generic(eyre!(
+                        "expected connection end A to be in open state"
+                    )));
                 }
 
                 Ok(connection_id_a)
@@ -85,6 +89,8 @@ impl BinaryChainTest for SupervisorTest {
 
         let port_a = tagged_transfer_port();
         let port_b = tagged_transfer_port();
+
+        info!("performing init channel");
 
         let channel_id_b = init_channel(
             &chains.handle_a,
@@ -105,8 +111,13 @@ impl BinaryChainTest for SupervisorTest {
                 let channel_end_b =
                     query_channel_end(&chains.handle_b, &channel_id_b.as_ref(), &port_b.as_ref())?;
 
+                let state_b = channel_end_b.value().state();
+                info!("channel b state: {:?}", state_b);
+
                 if !channel_end_b.value().state_matches(&ChannelState::Open) {
-                    return Err(eyre!("expected channel end A to be in open state"));
+                    return Err(Error::generic(eyre!(
+                        "expected channel end A to be in open state"
+                    )));
                 }
 
                 let channel_id_a =
@@ -120,7 +131,9 @@ impl BinaryChainTest for SupervisorTest {
                     query_channel_end(&chains.handle_a, &channel_id_a.as_ref(), &port_a.as_ref())?;
 
                 if !channel_end_a.value().state_matches(&ChannelState::Open) {
-                    return Err(eyre!("expected channel end B to be in open state"));
+                    return Err(Error::generic(eyre!(
+                        "expected channel end B to be in open state"
+                    )));
                 }
 
                 Ok(channel_id_a)

--- a/tools/integration-test/src/util/retry.rs
+++ b/tools/integration-test/src/util/retry.rs
@@ -5,7 +5,7 @@
 use core::time::Duration;
 use eyre::eyre;
 use std::thread::sleep;
-use tracing::debug;
+use tracing::trace;
 
 use crate::error::Error;
 
@@ -26,15 +26,15 @@ pub fn assert_eventually_succeed<R>(
         match task() {
             Ok(res) => return Ok(res),
             Err(e) => {
-                debug!("retrying task that failed with error: {}", e);
+                trace!("retrying task that failed with error: {}", e);
                 sleep(interval)
             }
         }
     }
 
-    Err(eyre!(
+    Err(Error::generic(eyre!(
         "Expected task to eventually succeeed, but failed after {} attempts: {}",
         attempts,
         task_name
-    ))
+    )))
 }


### PR DESCRIPTION
Partially Closes: #1578

## Description

This PR adds support for the integration tests to pass with Gaia v5. 

The PR also makes most of the tests pass on Gaia v6, however the supervisor test is failing as there is a bug in Gaia6 that cause the `ChannelOpenInit` event to not fired, causing the channel worker to not pick up and finish the channel handshake. The issue has been fixed in https://github.com/cosmos/ibc-go/pull/624, but the changes have not been merged into Gaia v6.0.0. So we will still disable the tests for Gaia v6 until the fix is merged.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).