### PR TITLE
Fix conversion to Protocol Buffers of `ClientState`'s `frozen_height` field

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1710-fix-frozen-height-proto-conv.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1710-fix-frozen-height-proto-conv.md
@@ -1,0 +1,2 @@
+- Fix frozen-height proto conversion.
+  ([#1710](https://github.com/informalsystems/ibc-rs/issues/1710))

--- a/.changelog/unreleased/bug-fixes/ibc/1710-fix-frozen-height-proto-conv.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1710-fix-frozen-height-proto-conv.md
@@ -1,2 +1,2 @@
-- Fix frozen-height proto conversion.
+- Fix conversion to Protocol Buffers of `ClientState`'s `frozen_height` field.
   ([#1710](https://github.com/informalsystems/ibc-rs/issues/1710))

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -300,7 +300,7 @@ impl From<ClientState> for RawClientState {
             trusting_period: Some(value.trusting_period.into()),
             unbonding_period: Some(value.unbonding_period.into()),
             max_clock_drift: Some(value.max_clock_drift.into()),
-            frozen_height: Some(value.frozen_height.unwrap_or(Height::zero()).into()),
+            frozen_height: Some(value.frozen_height.unwrap_or_else(Height::zero).into()),
             latest_height: Some(value.latest_height.into()),
             proof_specs: value.proof_specs.into(),
             allow_update_after_expiry: value.allow_update.after_expiry,

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -300,7 +300,7 @@ impl From<ClientState> for RawClientState {
             trusting_period: Some(value.trusting_period.into()),
             unbonding_period: Some(value.unbonding_period.into()),
             max_clock_drift: Some(value.max_clock_drift.into()),
-            frozen_height: value.frozen_height.map(|h| h.into()),
+            frozen_height: Some(value.frozen_height.unwrap_or(Height::zero()).into()),
             latest_height: Some(value.latest_height.into()),
             proof_specs: value.proof_specs.into(),
             allow_update_after_expiry: value.allow_update.after_expiry,


### PR DESCRIPTION
Closes: #1710 

## Description
The fix in https://github.com/informalsystems/ibc-rs/pull/1640 was incomplete, so we basically needed to make sure that we serialize domain type frozen height `None` as `Some(Height::zero())`, because that's what ibc-go expects.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).