### PR TITLE
Disable clap-provided -h flags on two subcommands

### DIFF
--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -66,6 +66,7 @@ impl Runnable for QueryClientStateCmd {
 
 /// Query client consensus command
 #[derive(Clone, Command, Debug, Clap)]
+#[clap(setting(DisableHelpFlag))]
 pub struct QueryClientConsensusCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,
@@ -231,6 +232,7 @@ impl Runnable for QueryClientHeaderCmd {
 
 /// Query client connections command
 #[derive(Clone, Command, Debug, Clap)]
+#[clap(setting(DisableHelpFlag))]
 pub struct QueryClientConnectionsCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,


### PR DESCRIPTION
## Description

The conflicting flags were overlooked during the original clap porting in #1576, resulting in panics when `query client consensus` and `query client connections` commands are invoked.

______

### PR author checklist:
- ~Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).~
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- ~Updated code comments and documentation (e.g., `docs/`).~

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).