### PR TITLE
Rename application-handled -h CLI flags to -H

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/1576-update-abscissa.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/1576-update-abscissa.md
@@ -2,4 +2,5 @@
   `--help` flags in subcommands and improving help and usage printouts.
   The `--version` option of the `create channel` subcommand has been renamed
   to `--channel-version`, with the old name still supported as an alias.
-  ([#1576](https://github.com/informalsystems/ibc-rs/pull/1576))
+  ([#1576](https://github.com/informalsystems/ibc-rs/pull/1576),
+   [#1743](https://github.com/informalsystems/ibc-rs/pull/1743))

--- a/guide/src/commands/path-setup/clients.md
+++ b/guide/src/commands/path-setup/clients.md
@@ -67,7 +67,7 @@ POSITIONAL ARGUMENTS:
     dst_client_id             identifier of the client to be updated on destination chain
 
 FLAGS:
-    -h, --target-height TARGET-HEIGHT
+    -H, --target-height TARGET-HEIGHT
     -t, --trusted-height TRUSTED-HEIGHT
 ```
 

--- a/guide/src/commands/queries/channel.md
+++ b/guide/src/commands/queries/channel.md
@@ -79,7 +79,7 @@ POSITIONAL ARGUMENTS:
     channel_id                identifier of the channel to query
 
 FLAGS:
-    -h, --height HEIGHT       height of the state to query
+    -H, --height HEIGHT       height of the state to query
 ```
 
 __Example__
@@ -131,7 +131,7 @@ POSITIONAL ARGUMENTS:
     channel_id                identifier of the channel to query
 
 FLAGS:
-    -h, --height HEIGHT       height of the state to query
+    -H, --height HEIGHT       height of the state to query
     -v, --verbose             enable verbose output, displaying all details of channels, connections & clients
 ```
 

--- a/guide/src/commands/queries/client.md
+++ b/guide/src/commands/queries/client.md
@@ -100,7 +100,7 @@ POSITIONAL ARGUMENTS:
     client_id                 identifier of the client to query
 
 FLAGS:
-    -h, --height HEIGHT       the chain height which this query should reflect
+    -H, --height HEIGHT       the chain height which this query should reflect
 ```
 
 __Example__
@@ -159,7 +159,7 @@ POSITIONAL ARGUMENTS:
 FLAGS:
     -c, --consensus-height    CONSENSUS-HEIGHT
     -s, --heights-only        show only consensus heights
-    -h, --height HEIGHT       the chain height context to be used, applicable only to a specific height
+    -H, --height HEIGHT       the chain height context to be used, applicable only to a specific height
 ```
 
 __Example__
@@ -235,7 +235,7 @@ POSITIONAL ARGUMENTS:
     client_id                 identifier of the client to query
 
 FLAGS:
-    -h, --height HEIGHT       the chain height which this query should reflect
+    -H, --height HEIGHT       the chain height which this query should reflect
 ```
 
 __Example__
@@ -268,7 +268,7 @@ POSITIONAL ARGUMENTS:
     consensus_height          height of header to query
 
 FLAGS:
-    -h, --height HEIGHT       the chain height context for the query
+    -H, --height HEIGHT       the chain height context for the query
 ```
 
 __Example__

--- a/guide/src/commands/queries/connection.md
+++ b/guide/src/commands/queries/connection.md
@@ -68,7 +68,7 @@ POSITIONAL ARGUMENTS:
     connection_id             identifier of the connection to query
 
 FLAGS:
-    -h, --height HEIGHT       height of the state to query
+    -H, --height HEIGHT       height of the state to query
 ```
 
 __Example__

--- a/guide/src/commands/queries/packet.md
+++ b/guide/src/commands/queries/packet.md
@@ -82,7 +82,7 @@ POSITIONAL ARGUMENTS:
     sequence                  sequence of packet to query
 
 FLAGS:
-    -h, --height HEIGHT       height of the state to query
+    -H, --height HEIGHT       height of the state to query
 ```
 
 __Example__
@@ -154,7 +154,7 @@ POSITIONAL ARGUMENTS:
     sequence                  sequence of packet to query
 
 FLAGS:
-    -h, --height HEIGHT       height of the state to query
+    -H, --height HEIGHT       height of the state to query
 ```
 
 __Example__

--- a/guide/src/commands/raw/client.md
+++ b/guide/src/commands/raw/client.md
@@ -63,7 +63,7 @@ POSITIONAL ARGUMENTS:
     dst_client_id             identifier of the client to be updated on destination chain
 
 FLAGS:
-    -h, --target-height TARGET-HEIGHT
+    -H, --target-height TARGET-HEIGHT
     -t, --trusted-height TRUSTED-HEIGHT
 ```
 

--- a/relayer-cli/src/commands/query/channel.rs
+++ b/relayer-cli/src/commands/query/channel.rs
@@ -24,8 +24,7 @@ pub struct QueryChannelEndCmd {
     #[clap(required = true, about = "identifier of the channel to query")]
     channel_id: ChannelId,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "height of the state to query")]
+    #[clap(short = 'H', long, about = "height of the state to query")]
     height: Option<u64>,
 }
 

--- a/relayer-cli/src/commands/query/channel.rs
+++ b/relayer-cli/src/commands/query/channel.rs
@@ -1,7 +1,6 @@
 use alloc::sync::Arc;
 
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::core::ics24_host::identifier::ChainId;
@@ -13,7 +12,6 @@ use crate::prelude::*;
 use ibc::core::ics04_channel::channel::State;
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryChannelEndCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,

--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -27,7 +27,7 @@ pub struct QueryChannelEndsCmd {
     channel_id: ChannelId,
 
     // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "height of the state to query")]
+    #[clap(short = 'H', long, about = "height of the state to query")]
     height: Option<u64>,
 
     #[clap(

--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -24,7 +24,6 @@ pub struct QueryChannelEndsCmd {
     #[clap(required = true, about = "identifier of the channel to query")]
     channel_id: ChannelId,
 
-    // FIXME: rename the short option to avoid confusion with --help?
     #[clap(short = 'H', long, about = "height of the state to query")]
     height: Option<u64>,
 

--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -1,5 +1,4 @@
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 use serde::{Deserialize, Serialize};
 
 use ibc::core::ics02_client::client_state::{AnyClientState, ClientState};
@@ -15,7 +14,6 @@ use crate::conclude::Output;
 use crate::prelude::*;
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryChannelEndsCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -1,7 +1,6 @@
 use alloc::sync::Arc;
 
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 use tokio::runtime::Runtime as TokioRuntime;
 use tracing::debug;
 
@@ -22,7 +21,6 @@ use crate::conclude::{exit_with_unrecoverable_error, Output};
 
 /// Query client state command
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryClientStateCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,
@@ -160,7 +158,6 @@ impl Runnable for QueryClientConsensusCmd {
 }
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryClientHeaderCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,

--- a/relayer-cli/src/commands/query/client.rs
+++ b/relayer-cli/src/commands/query/client.rs
@@ -30,8 +30,7 @@ pub struct QueryClientStateCmd {
     #[clap(required = true, about = "identifier of the client to query")]
     client_id: ClientId,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "the chain height context for the query")]
+    #[clap(short = 'H', long, about = "the chain height context for the query")]
     height: Option<u64>,
 }
 
@@ -84,7 +83,7 @@ pub struct QueryClientConsensusCmd {
     heights_only: bool,
 
     #[clap(
-        short = 'h',
+        short = 'H',
         long,
         about = "the chain height context to be used, applicable only to a specific height"
     )]
@@ -172,8 +171,7 @@ pub struct QueryClientHeaderCmd {
     #[clap(required = true, about = "height of header to query")]
     consensus_height: u64,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "the chain height context for the query")]
+    #[clap(short = 'H', long, about = "the chain height context for the query")]
     height: Option<u64>,
 }
 
@@ -239,7 +237,7 @@ pub struct QueryClientConnectionsCmd {
     client_id: ClientId,
 
     #[clap(
-        short = 'h',
+        short = 'H',
         long,
         about = "the chain height which this query should reflect"
     )]

--- a/relayer-cli/src/commands/query/connection.rs
+++ b/relayer-cli/src/commands/query/connection.rs
@@ -25,8 +25,7 @@ pub struct QueryConnectionEndCmd {
     #[clap(required = true, about = "identifier of the connection to query")]
     connection_id: ConnectionId,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "height of the state to query")]
+    #[clap(short = 'H', long, about = "height of the state to query")]
     height: Option<u64>,
 }
 

--- a/relayer-cli/src/commands/query/connection.rs
+++ b/relayer-cli/src/commands/query/connection.rs
@@ -1,7 +1,6 @@
 use alloc::sync::Arc;
 
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::core::{
@@ -17,7 +16,6 @@ use crate::error::Error;
 use crate::prelude::*;
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryConnectionEndCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,

--- a/relayer-cli/src/commands/query/packet/ack.rs
+++ b/relayer-cli/src/commands/query/packet/ack.rs
@@ -27,8 +27,7 @@ pub struct QueryPacketAcknowledgmentCmd {
     #[clap(required = true, about = "sequence of packet to query")]
     sequence: Sequence,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "height of the state to query")]
+    #[clap(short = 'H', long, about = "height of the state to query")]
     height: Option<u64>,
 }
 

--- a/relayer-cli/src/commands/query/packet/ack.rs
+++ b/relayer-cli/src/commands/query/packet/ack.rs
@@ -1,5 +1,4 @@
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 use subtle_encoding::{Encoding, Hex};
 
 use ibc::core::ics04_channel::packet::{PacketMsgType, Sequence};
@@ -13,7 +12,6 @@ use crate::error::Error;
 use crate::prelude::*;
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryPacketAcknowledgmentCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,

--- a/relayer-cli/src/commands/query/packet/commitment.rs
+++ b/relayer-cli/src/commands/query/packet/commitment.rs
@@ -1,5 +1,4 @@
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 use serde::Serialize;
 use subtle_encoding::{Encoding, Hex};
 
@@ -20,7 +19,6 @@ struct PacketSeqs {
 }
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct QueryPacketCommitmentCmd {
     #[clap(required = true, about = "identifier of the chain to query")]
     chain_id: ChainId,

--- a/relayer-cli/src/commands/query/packet/commitment.rs
+++ b/relayer-cli/src/commands/query/packet/commitment.rs
@@ -34,8 +34,7 @@ pub struct QueryPacketCommitmentCmd {
     #[clap(required = true, about = "sequence of packet to query")]
     sequence: Sequence,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "height of the state to query")]
+    #[clap(short = 'H', long, about = "height of the state to query")]
     height: Option<u64>,
 }
 

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 
 use abscissa_core::{Clap, Command, Runnable};
-use clap::AppSettings::DisableHelpFlag;
 
 use ibc::core::ics02_client::client_state::ClientState;
 use ibc::core::ics24_host::identifier::{ChainId, ClientId};
@@ -55,7 +54,6 @@ impl Runnable for TxCreateClientCmd {
 }
 
 #[derive(Clone, Command, Debug, Clap)]
-#[clap(setting(DisableHelpFlag))]
 pub struct TxUpdateClientCmd {
     #[clap(required = true, about = "identifier of the destination chain")]
     dst_chain_id: ChainId,

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -66,8 +66,7 @@ pub struct TxUpdateClientCmd {
     )]
     dst_client_id: ClientId,
 
-    // FIXME: rename the short option to avoid confusion with --help?
-    #[clap(short = 'h', long, about = "the target height of the client update")]
+    #[clap(short = 'H', long, about = "the target height of the client update")]
     target_height: Option<u64>,
 
     #[clap(short = 't', long, about = "the trusted height of the client update")]


### PR DESCRIPTION
Closes: #1611

## Description

Cherry-picked 60829af18b60f8b944cc028d28031724b8070e88 and re-enabled the built-in `-h`/`--help` flags.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- ~Updated code comments and documentation (e.g., `docs/`).~

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).