### PR TITLE
Fix consensus proof verification

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1745-fix-consensus-proof-verification.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1745-fix-consensus-proof-verification.md
@@ -1,0 +1,2 @@
+- Fix consensus proof verification
+  ([#1745](https://github.com/informalsystems/ibc-rs/issues/1745))

--- a/modules/src/core/ics03_connection/handler/verify.rs
+++ b/modules/src/core/ics03_connection/handler/verify.rs
@@ -153,6 +153,8 @@ pub fn verify_consensus_proof(
     // Fetch the expected consensus state from the historical (local) header data.
     let expected_consensus = ctx.host_consensus_state(proof.height())?;
 
+    let consensus_state = ctx.client_consensus_state(connection_end.client_id(), height)?;
+
     let client = AnyClient::from_client_type(client_state.client_type());
 
     client
@@ -161,7 +163,7 @@ pub fn verify_consensus_proof(
             height,
             connection_end.counterparty().prefix(),
             proof.proof(),
-            expected_consensus.root(),
+            consensus_state.root(),
             connection_end.counterparty().client_id(),
             proof.height(),
             &expected_consensus,


### PR DESCRIPTION
Closes: #1745 

## Description
Client consensus proof verification must be performed against the client's consensus state root and not the host's state root. This was a bug in our impl. 
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).