### PR TITLE
Disallow empty CommitmentPrefix and CommitmentProofBytes

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -399,7 +399,7 @@ fn verify_membership(
     path: String,
     value: Vec<u8>,
 ) -> Result<(), Ics02Error> {
-    let merkle_path = apply_prefix(prefix, vec![path]).map_err(Error::ics23_error)?;
+    let merkle_path = apply_prefix(prefix, vec![path]);
     let merkle_proof: MerkleProof = RawMerkleProof::try_from(proof.clone())
         .map_err(Ics02Error::invalid_commitment_proof)?
         .into();
@@ -422,7 +422,7 @@ fn verify_non_membership(
     root: &CommitmentRoot,
     path: String,
 ) -> Result<(), Ics02Error> {
-    let merkle_path = apply_prefix(prefix, vec![path]).map_err(Error::ics23_error)?;
+    let merkle_path = apply_prefix(prefix, vec![path]);
     let merkle_proof: MerkleProof = RawMerkleProof::try_from(proof.clone())
         .map_err(Ics02Error::invalid_commitment_proof)?
         .into();

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -72,7 +72,6 @@ define_error! {
             | _ | { "the client state was not found" },
 
         EmptyPrefix
-            [ Ics23Error ]
             | _ | { "empty prefix" },
 
         UnknownConsensusStateType

--- a/modules/src/core/ics03_connection/connection.rs
+++ b/modules/src/core/ics03_connection/connection.rs
@@ -12,6 +12,7 @@ use ibc_proto::ibc::core::connection::v1::{
     IdentifiedConnection as RawIdentifiedConnection,
 };
 
+use crate::core::ics02_client::error::Error as ClientError;
 use crate::core::ics03_connection::error::Error;
 use crate::core::ics03_connection::version::Version;
 use crate::core::ics23_commitment::commitment::CommitmentPrefix;
@@ -262,7 +263,8 @@ impl TryFrom<RawCounterparty> for Counterparty {
                 .prefix
                 .ok_or_else(Error::missing_counterparty)?
                 .key_prefix
-                .into(),
+                .try_into()
+                .map_err(|_| Error::ics02_client(ClientError::empty_prefix()))?,
         ))
     }
 }

--- a/modules/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -85,17 +85,21 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
             .consensus_height
             .ok_or_else(Error::missing_consensus_height)?
             .into();
-        let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
-            .map_err(Error::invalid_proof)?;
+        let consensus_proof_obj = ConsensusProof::new(
+            msg.proof_consensus
+                .try_into()
+                .map_err(Error::invalid_proof)?,
+            consensus_height,
+        )
+        .map_err(Error::invalid_proof)?;
 
         let proof_height = msg
             .proof_height
             .ok_or_else(Error::missing_proof_height)?
             .into();
 
-        let client_proof = Some(msg.proof_client)
-            .filter(|x| !x.is_empty())
-            .map(CommitmentProofBytes::from);
+        let client_proof =
+            CommitmentProofBytes::try_from(msg.proof_client).map_err(Error::invalid_proof)?;
 
         Ok(Self {
             connection_id: msg
@@ -113,8 +117,8 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
                 .map_err(Error::ics02_client)?,
             version: msg.version.ok_or_else(Error::empty_versions)?.try_into()?,
             proofs: Proofs::new(
-                msg.proof_try.into(),
-                client_proof,
+                msg.proof_try.try_into().map_err(Error::invalid_proof)?,
+                Some(client_proof),
                 Option::from(consensus_proof_obj),
                 None,
                 proof_height,

--- a/modules/src/core/ics03_connection/msgs/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_confirm.rs
@@ -63,8 +63,14 @@ impl TryFrom<RawMsgConnectionOpenConfirm> for MsgConnectionOpenConfirm {
                 .connection_id
                 .parse()
                 .map_err(Error::invalid_identifier)?,
-            proofs: Proofs::new(msg.proof_ack.into(), None, None, None, proof_height)
-                .map_err(Error::invalid_proof)?,
+            proofs: Proofs::new(
+                msg.proof_ack.try_into().map_err(Error::invalid_proof)?,
+                None,
+                None,
+                None,
+                proof_height,
+            )
+            .map_err(Error::invalid_proof)?,
             signer: msg.signer.into(),
         })
     }

--- a/modules/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -108,17 +108,21 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
             .ok_or_else(Error::missing_consensus_height)?
             .into();
 
-        let consensus_proof_obj = ConsensusProof::new(msg.proof_consensus.into(), consensus_height)
-            .map_err(Error::invalid_proof)?;
+        let consensus_proof_obj = ConsensusProof::new(
+            msg.proof_consensus
+                .try_into()
+                .map_err(Error::invalid_proof)?,
+            consensus_height,
+        )
+        .map_err(Error::invalid_proof)?;
 
         let proof_height = msg
             .proof_height
             .ok_or_else(Error::missing_proof_height)?
             .into();
 
-        let client_proof = Some(msg.proof_client)
-            .filter(|x| !x.is_empty())
-            .map(CommitmentProofBytes::from);
+        let client_proof =
+            CommitmentProofBytes::try_from(msg.proof_client).map_err(Error::invalid_proof)?;
 
         let counterparty_versions = msg
             .counterparty_versions
@@ -144,8 +148,8 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
                 .try_into()?,
             counterparty_versions,
             proofs: Proofs::new(
-                msg.proof_init.into(),
-                client_proof,
+                msg.proof_init.try_into().map_err(Error::invalid_proof)?,
+                Some(client_proof),
                 Some(consensus_proof_obj),
                 None,
                 proof_height,

--- a/modules/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -67,7 +67,10 @@ impl TryFrom<RawMsgAcknowledgement> for MsgAcknowledgement {
 
     fn try_from(raw_msg: RawMsgAcknowledgement) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_acked.into(),
+            raw_msg
+                .proof_acked
+                .try_into()
+                .map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_close_confirm.rs
@@ -66,7 +66,10 @@ impl TryFrom<RawMsgChannelCloseConfirm> for MsgChannelCloseConfirm {
 
     fn try_from(raw_msg: RawMsgChannelCloseConfirm) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_init.into(),
+            raw_msg
+                .proof_init
+                .try_into()
+                .map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_ack.rs
@@ -84,7 +84,7 @@ impl TryFrom<RawMsgChannelOpenAck> for MsgChannelOpenAck {
 
     fn try_from(raw_msg: RawMsgChannelOpenAck) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_try.into(),
+            raw_msg.proof_try.try_into().map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_confirm.rs
@@ -66,7 +66,7 @@ impl TryFrom<RawMsgChannelOpenConfirm> for MsgChannelOpenConfirm {
 
     fn try_from(raw_msg: RawMsgChannelOpenConfirm) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_ack.into(),
+            raw_msg.proof_ack.try_into().map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_try.rs
@@ -91,7 +91,10 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
 
     fn try_from(raw_msg: RawMsgChannelOpenTry) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_init.into(),
+            raw_msg
+                .proof_init
+                .try_into()
+                .map_err(ChannelError::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/recv_packet.rs
+++ b/modules/src/core/ics04_channel/msgs/recv_packet.rs
@@ -56,7 +56,10 @@ impl TryFrom<RawMsgRecvPacket> for MsgRecvPacket {
 
     fn try_from(raw_msg: RawMsgRecvPacket) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_commitment.into(),
+            raw_msg
+                .proof_commitment
+                .try_into()
+                .map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/timeout.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout.rs
@@ -63,7 +63,10 @@ impl TryFrom<RawMsgTimeout> for MsgTimeout {
 
     fn try_from(raw_msg: RawMsgTimeout) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_unreceived.into(),
+            raw_msg
+                .proof_unreceived
+                .try_into()
+                .map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -62,7 +62,10 @@ impl TryFrom<RawMsgTimeoutOnClose> for MsgTimeoutOnClose {
 
     fn try_from(raw_msg: RawMsgTimeoutOnClose) -> Result<Self, Self::Error> {
         let proofs = Proofs::new(
-            raw_msg.proof_unreceived.into(),
+            raw_msg
+                .proof_unreceived
+                .try_into()
+                .map_err(Error::invalid_proof)?,
             None,
             None,
             None,

--- a/modules/src/core/ics23_commitment/merkle.rs
+++ b/modules/src/core/ics23_commitment/merkle.rs
@@ -14,15 +14,10 @@ use crate::core::ics23_commitment::commitment::{CommitmentPrefix, CommitmentRoot
 use crate::core::ics23_commitment::error::Error;
 use crate::core::ics23_commitment::specs::ProofSpecs;
 
-pub fn apply_prefix(prefix: &CommitmentPrefix, mut path: Vec<String>) -> Result<MerklePath, Error> {
-    if prefix.is_empty() {
-        return Err(Error::empty_commitment_prefix());
-    }
-
-    let mut result: Vec<String> = vec![format!("{:?}", prefix)];
-    result.append(&mut path);
-
-    Ok(MerklePath { key_path: result })
+pub fn apply_prefix(prefix: &CommitmentPrefix, mut path: Vec<String>) -> MerklePath {
+    let mut key_path: Vec<String> = vec![format!("{:?}", prefix)];
+    key_path.append(&mut path);
+    MerklePath { key_path }
 }
 
 impl From<CommitmentRoot> for MerkleRoot {

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -65,8 +65,7 @@ impl ClientDef for MockClient {
         }
         .to_string();
 
-        let _path =
-            apply_prefix(prefix, vec![client_prefixed_path]).map_err(Error::empty_prefix)?;
+        let _path = apply_prefix(prefix, vec![client_prefixed_path]);
 
         Ok(())
     }

--- a/modules/src/mock/context.rs
+++ b/modules/src/mock/context.rs
@@ -843,7 +843,7 @@ impl ConnectionReader for MockContext {
     }
 
     fn commitment_prefix(&self) -> CommitmentPrefix {
-        CommitmentPrefix::from(Vec::new())
+        CommitmentPrefix::try_from(b"mock".to_vec()).unwrap()
     }
 
     fn client_consensus_state(

--- a/modules/src/proofs.rs
+++ b/modules/src/proofs.rs
@@ -41,10 +41,6 @@ impl Proofs {
             return Err(ProofError::zero_height());
         }
 
-        if object_proof.is_empty() {
-            return Err(ProofError::empty_proof());
-        }
-
         Ok(Self {
             object_proof,
             client_proof,
@@ -95,9 +91,6 @@ impl ConsensusProof {
     ) -> Result<Self, ProofError> {
         if consensus_height.is_zero() {
             return Err(ProofError::zero_height());
-        }
-        if consensus_proof.is_empty() {
-            return Err(ProofError::empty_proof());
         }
 
         Ok(Self {

--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -39,6 +39,7 @@ use ibc::core::ics02_client::client_consensus::{
 };
 use ibc::core::ics02_client::client_state::{AnyClientState, IdentifiedAnyClientState};
 use ibc::core::ics02_client::client_type::ClientType;
+use ibc::core::ics02_client::error::Error as ClientError;
 use ibc::core::ics02_client::events as ClientEvents;
 use ibc::core::ics03_connection::connection::{ConnectionEnd, IdentifiedConnectionEnd};
 use ibc::core::ics04_channel;
@@ -1190,9 +1191,8 @@ impl ChainEndpoint for CosmosSdkChain {
         crate::time!("query_commitment_prefix");
 
         // TODO - do a real chain query
-        Ok(CommitmentPrefix::from(
-            self.config().store_prefix.as_bytes().to_vec(),
-        ))
+        CommitmentPrefix::try_from(self.config().store_prefix.as_bytes().to_vec())
+            .map_err(|_| Error::ics02(ClientError::empty_prefix()))
     }
 
     /// Query the chain status


### PR DESCRIPTION
Partially addresses: #1696

## Description
Disallow empty CommitmentPrefix and CommitmentProofBytes, i.e. empty values for these types should not be constructible.
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).