### PR TITLE
Initialize consensus metadata during client create

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1763-init-consensus-meta-on-client-create.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1763-init-consensus-meta-on-client-create.md
@@ -1,0 +1,2 @@
+- Initialize consensus metadata on client creation
+  ([#1763](https://github.com/informalsystems/ibc-rs/issues/1763))

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -78,6 +78,8 @@ pub trait ClientKeeper {
                     res.consensus_state,
                 )?;
                 self.increase_client_counter();
+                self.store_update_time(res.client_id.clone(), res.client_state.latest_height())?;
+                self.store_update_height(res.client_id, res.client_state.latest_height())?;
                 Ok(())
             }
             Update(res) => {

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -269,11 +269,11 @@ impl fmt::Display for OutputBuffer {
                         )?;
                         match inner_result {
                             Ok(events) => writeln!(f, "{:#?}", events)?,
-                            Err(e) => writeln!(f, "{}", e.to_string())?,
+                            Err(e) => writeln!(f, "{}", e)?,
                         }
                     }
                 }
-                Err(e) => writeln!(f, " {}", e.to_string())?,
+                Err(e) => writeln!(f, " {}", e)?,
             }
         }
         Ok(())


### PR DESCRIPTION
Partially addresses: #1696

## Description
Initialize `ClientState` metadata
 
 ______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).