### PR TITLE
Remove 1 second sleep in `generate_tm_block`

### DIFF
--- a/.changelog/unreleased/improvements/1687-remove-mock-sleep.md
+++ b/.changelog/unreleased/improvements/1687-remove-mock-sleep.md
@@ -1,0 +1,1 @@
+- Remove 1 second sleep in `generate_tm_block` during testing with mock context. [#1687](https://github.com/informalsystems/ibc-rs/issues/1687)

--- a/modules/src/mock/host.rs
+++ b/modules/src/mock/host.rs
@@ -60,11 +60,6 @@ impl HostBlock {
     }
 
     pub fn generate_tm_block(chain_id: ChainId, height: u64) -> TmLightBlock {
-        // Sleep is required otherwise the generator produces blocks with the
-        // same timestamp as two block can be generated per second.
-        let ten_millis = core::time::Duration::from_millis(1000);
-        std::thread::sleep(ten_millis);
-
         let time: Time = OffsetDateTime::now_utc().try_into().unwrap();
 
         TestgenLightBlock::new_default_with_time_and_chain_id(chain_id.to_string(), time, height)


### PR DESCRIPTION
Closes: #1687

## Description

With https://github.com/informalsystems/tendermint-rs/pull/1080 merged on `tendermint-rs` side, we can now remove the sleep statement in `generate_tm_block` and make the tests run much faster.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).