### PR TITLE
Deterministic host timestamp

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/1770-deterministic-host-timestamp.md
+++ b/.changelog/unreleased/bug-fixes/ibc/1770-deterministic-host-timestamp.md
@@ -1,0 +1,2 @@
+- IBC handlers now retrieve the host timestamp from the latest host consensus
+  state ([#1770](https://github.com/informalsystems/ibc-rs/issues/1770))

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -70,7 +70,15 @@ pub trait ChannelReader {
     fn host_height(&self) -> Height;
 
     /// Returns the current timestamp of the local chain.
-    fn host_timestamp(&self) -> Timestamp;
+    fn host_timestamp(&self) -> Timestamp {
+        let latest_consensus_state = self
+            .host_consensus_state(self.host_height())
+            .expect("host must have latest consensus state");
+        latest_consensus_state.timestamp()
+    }
+
+    /// Returns the ConsensusState of the host (local) chain at a specific height.
+    fn host_consensus_state(&self, height: Height) -> Result<AnyConsensusState, Error>;
 
     /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
     fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error>;


### PR DESCRIPTION
Closes: #1770 

## Description
`ChannelReader::host_timestamp()` is now a provided method that fetches the latest host consensus state using `ChannelReader::host_consensus_state()` and uses it's timestamp. 
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).