### PR TITLE
CLI auto-completions

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer-cli/1789-cli-completions.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/1789-cli-completions.md
@@ -1,0 +1,2 @@
+- Add `completions` CLI command to generate shell auto-completion scripts.
+  ([#1789](https://github.com/informalsystems/ibc-rs/pull/1789)) 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-log",
- "tracing-subscriber 0.3.5",
+ "tracing-subscriber",
  "wait-timeout",
 ]
 
@@ -1310,7 +1310,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1342,7 +1342,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1411,7 +1411,7 @@ dependencies = [
  "toml",
  "tonic",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
  "uint",
 ]
 
@@ -1422,6 +1422,7 @@ dependencies = [
  "abscissa_core",
  "atty",
  "clap",
+ "clap_complete",
  "color-eyre 0.6.0",
  "crossbeam-channel 0.5.2",
  "dirs-next",
@@ -1453,7 +1454,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1747,7 +1748,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
  "ureq",
 ]
 
@@ -3405,7 +3406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3436,17 +3437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "sharded-slab",
- "thread_local",
  "tracing-core",
 ]
 

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -33,6 +33,7 @@ ibc-telemetry    = { version = "0.10.0", path = "../telemetry", optional = true 
 ibc-relayer-rest = { version = "0.10.0", path = "../relayer-rest", optional = true }
 
 clap = { version = "3.0", features = ["cargo"] }
+clap_complete = "3.0"
 serde = { version = "1.0", features = ["serde_derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.29"

--- a/relayer-cli/src/commands.rs
+++ b/relayer-cli/src/commands.rs
@@ -5,6 +5,7 @@
 //! See the `impl Configurable` below for how to specify the path to the
 //! application's configuration file.
 
+mod completions;
 mod config;
 mod create;
 mod health;
@@ -19,9 +20,9 @@ mod upgrade;
 mod version;
 
 use self::{
-    config::ConfigCmd, create::CreateCmds, health::HealthCheckCmd, keys::KeysCmd,
-    listen::ListenCmd, misbehaviour::MisbehaviourCmd, query::QueryCmd, start::StartCmd, tx::TxCmd,
-    update::UpdateCmds, upgrade::UpgradeCmds, version::VersionCmd,
+    completions::CompletionsCmd, config::ConfigCmd, create::CreateCmds, health::HealthCheckCmd,
+    keys::KeysCmd, listen::ListenCmd, misbehaviour::MisbehaviourCmd, query::QueryCmd,
+    start::StartCmd, tx::TxCmd, update::UpdateCmds, upgrade::UpgradeCmds, version::VersionCmd,
 };
 
 use core::time::Duration;
@@ -86,6 +87,10 @@ pub enum CliCmd {
 
     /// Performs a health check of all chains in the the config
     HealthCheck(HealthCheckCmd),
+
+    /// Generate auto-complete scripts for different shells.
+    #[clap(display_order = 1000)]
+    Completions(CompletionsCmd),
 }
 
 /// This trait allows you to define how application configuration is loaded.

--- a/relayer-cli/src/commands.rs
+++ b/relayer-cli/src/commands.rs
@@ -5,22 +5,6 @@
 //! See the `impl Configurable` below for how to specify the path to the
 //! application's configuration file.
 
-use core::time::Duration;
-use std::path::PathBuf;
-
-use abscissa_core::clap::Parser;
-use abscissa_core::{config::Override, Command, Configurable, FrameworkError, Runnable};
-use tracing::{error, info};
-
-use crate::DEFAULT_CONFIG_PATH;
-use ibc_relayer::config::Config;
-
-use self::{
-    config::ConfigCmd, create::CreateCmds, health::HealthCheckCmd, keys::KeysCmd,
-    listen::ListenCmd, misbehaviour::MisbehaviourCmd, query::QueryCmd, start::StartCmd, tx::TxCmd,
-    update::UpdateCmds, upgrade::UpgradeCmds, version::VersionCmd,
-};
-
 mod config;
 mod create;
 mod health;
@@ -33,6 +17,22 @@ mod tx;
 mod update;
 mod upgrade;
 mod version;
+
+use self::{
+    config::ConfigCmd, create::CreateCmds, health::HealthCheckCmd, keys::KeysCmd,
+    listen::ListenCmd, misbehaviour::MisbehaviourCmd, query::QueryCmd, start::StartCmd, tx::TxCmd,
+    update::UpdateCmds, upgrade::UpgradeCmds, version::VersionCmd,
+};
+
+use core::time::Duration;
+use std::path::PathBuf;
+
+use abscissa_core::clap::Parser;
+use abscissa_core::{config::Override, Command, Configurable, FrameworkError, Runnable};
+use tracing::{error, info};
+
+use crate::DEFAULT_CONFIG_PATH;
+use ibc_relayer::config::Config;
 
 /// Default configuration file path
 pub fn default_config_file() -> Option<PathBuf> {

--- a/relayer-cli/src/commands/completions.rs
+++ b/relayer-cli/src/commands/completions.rs
@@ -1,0 +1,20 @@
+use crate::entry::EntryPoint;
+use abscissa_core::clap::Parser;
+use abscissa_core::Runnable;
+use clap::IntoApp;
+use clap_complete::Shell;
+use std::io;
+
+#[derive(Debug, Parser)]
+pub struct CompletionsCmd {
+    #[clap(arg_enum)]
+    shell: Shell,
+}
+
+impl Runnable for CompletionsCmd {
+    fn run(&self) {
+        let mut app = EntryPoint::into_app();
+        let app_name = app.get_name().to_owned();
+        clap_complete::generate(self.shell, &mut app, app_name, &mut io::stdout());
+    }
+}

--- a/relayer/src/chain.rs
+++ b/relayer/src/chain.rs
@@ -1,7 +1,6 @@
 use alloc::sync::Arc;
 use core::convert::TryFrom;
 
-use prost_types::Any;
 use tendermint::block::Height;
 use tokio::runtime::Runtime as TokioRuntime;
 


### PR DESCRIPTION
Closes: #1096

## Description

Add a `completions` command using the functionality of `clap_complete` to generate completion scripts for various shells.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).