### PR TITLE
Add a `--denom` option to the `tx raw upgrade-chain` command to make the deposit denomination configurable

### DIFF
--- a/.changelog/unreleased/breaking-changes/ibc-relayer/1662-configurable-upgrade-denom.md
+++ b/.changelog/unreleased/breaking-changes/ibc-relayer/1662-configurable-upgrade-denom.md
@@ -1,0 +1,2 @@
+- Added a `denom` member to `upgrade_chain::UpgradePlanOptions`.
+  ([#1662](https://github.com/informalsystems/ibc-rs/issues/1662))

--- a/.changelog/unreleased/improvements/ibc-relayer-cli/1662-configurable-upgrade-denom.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/1662-configurable-upgrade-denom.md
@@ -1,2 +1,2 @@
-- Make the deposit denomination configurable in `tx raw upgrade-chain`
+- Make the deposit denomination configurable in `tx raw upgrade-chain` via a new `--denom` flag.
   ([#1662](https://github.com/informalsystems/ibc-rs/issues/1662))

--- a/.changelog/unreleased/improvements/ibc-relayer-cli/1662-configurable-upgrade-denom.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/1662-configurable-upgrade-denom.md
@@ -1,0 +1,2 @@
+- Make the deposit denomination configurable in `tx raw upgrade-chain`
+  ([#1662](https://github.com/informalsystems/ibc-rs/issues/1662))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-log",
- "tracing-subscriber 0.3.5",
+ "tracing-subscriber",
  "wait-timeout",
 ]
 
@@ -1310,7 +1310,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1342,7 +1342,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1411,7 +1411,7 @@ dependencies = [
  "toml",
  "tonic",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
  "uint",
 ]
 
@@ -1453,7 +1453,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1747,7 +1747,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
  "ureq",
 ]
 
@@ -3405,7 +3405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.6",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3436,17 +3436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "sharded-slab",
- "thread_local",
  "tracing-core",
 ]
 

--- a/relayer-cli/src/commands/tx/upgrade.rs
+++ b/relayer-cli/src/commands/tx/upgrade.rs
@@ -100,12 +100,7 @@ impl TxIbcUpgradeChainCmd {
             src_chain_config: src_chain_config.clone(),
             src_client_id: self.src_client_id.clone(),
             amount: self.amount,
-            denom: self
-                .denom
-                .as_ref()
-                .map(|v| v.as_str())
-                .unwrap_or("stake")
-                .into(),
+            denom: self.denom.as_deref().unwrap_or("stake").into(),
             height_offset: self.height_offset,
             upgraded_chain_id: self
                 .new_chain_id

--- a/relayer-cli/src/commands/tx/upgrade.rs
+++ b/relayer-cli/src/commands/tx/upgrade.rs
@@ -65,6 +65,13 @@ pub struct TxIbcUpgradeChainCmd {
     upgrade_name: Option<String>,
 
     #[clap(
+        short = 'd',
+        long,
+        help = "denomination for the depoisit (default: 'stake')"
+    )]
+    denom: Option<String>,
+
+    #[clap(
         short = 'l',
         long,
         help = "use legacy upgrade proposal constructs (for chains built with Cosmos SDK < v0.43.0)"
@@ -93,6 +100,12 @@ impl TxIbcUpgradeChainCmd {
             src_chain_config: src_chain_config.clone(),
             src_client_id: self.src_client_id.clone(),
             amount: self.amount,
+            denom: self
+                .denom
+                .as_ref()
+                .map(|v| v.as_str())
+                .unwrap_or("stake")
+                .into(),
             height_offset: self.height_offset,
             upgraded_chain_id: self
                 .new_chain_id

--- a/relayer-cli/src/commands/tx/upgrade.rs
+++ b/relayer-cli/src/commands/tx/upgrade.rs
@@ -67,7 +67,7 @@ pub struct TxIbcUpgradeChainCmd {
     #[clap(
         short = 'd',
         long,
-        help = "denomination for the depoisit (default: 'stake')"
+        help = "denomination for the deposit (default: 'stake')"
     )]
     denom: Option<String>,
 

--- a/relayer/src/upgrade_chain.rs
+++ b/relayer/src/upgrade_chain.rs
@@ -54,6 +54,7 @@ pub struct UpgradePlanOptions {
     pub dst_chain_config: ChainConfig,
     pub src_client_id: ClientId,
     pub amount: u64,
+    pub denom: String,
     pub height_offset: u64,
     pub upgraded_chain_id: ChainId,
     pub upgraded_unbonding_period: Option<Duration>,
@@ -115,7 +116,7 @@ pub fn build_and_send_ibc_upgrade_proposal(
     let proposer = dst_chain.get_signer().map_err(UpgradeChainError::key)?;
 
     let coins = ibc_proto::cosmos::base::v1beta1::Coin {
-        denom: "stake".to_string(),
+        denom: opts.denom.clone(),
         amount: opts.amount.to_string(),
     };
 


### PR DESCRIPTION
Closes: #1662

## Description

Add an `--denom` option to the `tx raw upgrade-chain` command to make the deposit denomination configurable.
The default is "stake" as was previously hardcoded.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).