### PR TITLE
Run Security Audit job nightly only

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,10 +1,5 @@
 name: Security Audit
 on:
-  pull_request:
-    paths: Cargo.lock
-  push:
-    branches: master
-    paths: Cargo.lock
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Let's run the security audit job daily rather than on every PR and on master. We'll still get alerted of security issues via an issue and will recover the CI status to mean whether or not the various test suite have passed or not.

@mzabaluev What do you think?