### PR TITLE
Improved error messages for client state/consensus queries

### DIFF
--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -82,7 +82,7 @@ define_error! {
             },
 
         EmptyConsensusStateResponse
-            | _ | { "the client state was not found" },
+            | _ | { "the client consensus state was not found" },
 
         UnknownHeaderType
             { header_type: String }

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -1055,7 +1055,12 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
             .dst_chain
             .query_consensus_state(self.id.clone(), height, Height::zero())
             .map_err(|e| {
-                ForeignClientError::client_consensus_query(self.id.clone(), self.dst_chain.id(), height, e)
+                ForeignClientError::client_consensus_query(
+                    self.id.clone(),
+                    self.dst_chain.id(),
+                    height,
+                    e,
+                )
             })?;
 
         Ok(res)

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -139,8 +139,20 @@ define_error! {
             }
             [ RelayerError ]
             |e| {
-                format_args!("failed while querying Tx for client {0} on chain id: {1}",
+                format_args!("failed while querying for client {0} on chain id {1}",
                     e.client_id, e.chain_id)
+            },
+
+        ClientConsensusQuery
+            {
+                client_id: ClientId,
+                chain_id: ChainId,
+                height: Height
+            }
+            [ RelayerError ]
+            |e| {
+                format_args!("failed while querying for client consensus state {0} on chain id {1} for height {2}",
+                    e.client_id, e.chain_id, e.height)
             },
 
         ClientUpgrade
@@ -1043,7 +1055,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
             .dst_chain
             .query_consensus_state(self.id.clone(), height, Height::zero())
             .map_err(|e| {
-                ForeignClientError::client_query(self.id.clone(), self.dst_chain.id(), e)
+                ForeignClientError::client_consensus_query(self.id.clone(), self.dst_chain.id(), height, e)
             })?;
 
         Ok(res)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

While debugging with a relayer operator this log message:

> Jan 20 02:43:40 Imperator-Relayer hermes[751041]: 2022-01-20T02:43:40.107723Z  WARN ThreadId(73) task RefreshClientWorker(sentinelhub-2 -> osmosis-1:07-tendermint-645) encountered ignorable error: failed while querying Tx for client 07-tendermint-645 on chain id: osmosis-1: error decoding protobuf: error converting message type into domain type: the client state was not found

We found out that Hermes logs generic messages and we cannot debug without additional refinement on the error types of ForeignClient. This PR addresses that. 


______

### PR author checklist:
- [ ] ~~Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).~~
- [ ] ~~Added tests: integration (for Hermes) or unit/mock tests (for modules).~~
- [ ] ~~Linked to GitHub issue.~~
- [ ] ~~Updated code comments and documentation (e.g., `docs/`).~~

### Reviewer checklist:

- [X] Reviewed `Files changed` in the GitHub PR explorer.
- [X] Manually tested (in case integration/unit/mock tests are absent).