### PR TITLE
cli: ADR-006 options for the create client command

### DIFF
--- a/.changelog/unreleased/breaking-changes/ibc-relayer/1807-foreign-client-create-params.md
+++ b/.changelog/unreleased/breaking-changes/ibc-relayer/1807-foreign-client-create-params.md
@@ -1,0 +1,4 @@
+- `foreign_client::CreateParams` struct added, passed as the parameter to
+  `ForeignClient::build_create_client` and
+  `ForeignClient::build_create_client_and_send`.
+  ([#1807](https://github.com/informalsystems/ibc-rs/pull/1807))

--- a/.changelog/unreleased/improvements/ibc-relayer-cli/836-create-client-options.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/836-create-client-options.md
@@ -1,0 +1,2 @@
+- Add custom options to the `create client` command.
+  ([#836](https://github.com/informalsystems/ibc-rs/issues/836))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,7 @@ dependencies = [
  "flex-error",
  "futures",
  "hex",
+ "humantime",
  "ibc",
  "ibc-proto",
  "ibc-relayer",

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -34,6 +34,7 @@ ibc-relayer-rest = { version = "0.10.0", path = "../relayer-rest", optional = tr
 
 clap = { version = "3.0", features = ["cargo"] }
 clap_complete = "3.0"
+humantime = "2.1"
 serde = { version = "1.0", features = ["serde_derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.29"

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -259,9 +259,9 @@ impl TxUpgradeClientsCmd {
 }
 
 fn parse_trust_threshold(input: &str) -> Result<TrustThreshold, Error> {
-    let (num_part, denom_part) = input
-        .split_once('/')
-        .ok_or_else(|| Error::cli_arg("expected a fraction argument separated by '/'".into()))?;
+    let (num_part, denom_part) = input.split_once('/').ok_or_else(|| {
+        Error::cli_arg("expected a fractional argument, two numbers separated by '/'".into())
+    })?;
     let numerator = num_part
         .trim()
         .parse()

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -346,3 +346,23 @@ impl OutputBuffer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_trust_threshold;
+
+    #[test]
+    fn test_parse_trust_threshold() {
+        let threshold = parse_trust_threshold("3/5").unwrap();
+        assert_eq!(threshold.numerator(), 3);
+        assert_eq!(threshold.denominator(), 5);
+
+        let threshold = parse_trust_threshold("3 / 5").unwrap();
+        assert_eq!(threshold.numerator(), 3);
+        assert_eq!(threshold.denominator(), 5);
+
+        let threshold = parse_trust_threshold("\t3 / 5  ").unwrap();
+        assert_eq!(threshold.numerator(), 3);
+        assert_eq!(threshold.denominator(), 5);
+    }
+}

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -37,7 +37,7 @@ pub struct TxCreateClientCmd {
     /// Override the trusting period specified in the config.
     ///
     /// The trusting period specifies how long a validator set is trusted for
-    /// (must be shorter than the chain's unbonding period)
+    /// (must be shorter than the chain's unbonding period).
 
     #[clap(short = 'p', long)]
     trusting_period: Option<humantime::Duration>,

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -25,15 +25,27 @@ pub struct TxCreateClientCmd {
     #[clap(required = true, help = "identifier of the source chain")]
     src_chain_id: ChainId,
 
-    // FIXME: provide option doc
+    /// Override the default clock drift specified in the configuration.
+    ///
+    /// The clock drift is a correction parameter dealing with only approximately synchronized clocks.
+    /// The local clock should always be ahead of timestamps from the blockchain; this
+    /// is the maximum amount that the local clock may drift behind a timestamp from the
+    /// blockchain.
     #[clap(short = 'd', long)]
     clock_drift: Option<humantime::Duration>,
 
-    // FIXME: provide option doc
+    /// Override the trusting period specified in the config.
+    ///
+    /// The trusting period specifies how long a validator set is trusted for
+    /// (must be shorter than the chain's unbonding period)
+
     #[clap(short = 'p', long)]
     trusting_period: Option<humantime::Duration>,
 
-    // FIXME: provide option doc
+    /// Override the trust threshold specified in the configuration.
+    ///
+    /// The trust threshold defines what fraction of the total voting power of a known
+    /// and trusted validator set is sufficient for a commit to be accepted going forward.
     #[clap(short = 't', long, parse(try_from_str = parse_trust_threshold))]
     trust_threshold: Option<TrustThreshold>,
 }

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -383,18 +383,30 @@ pub struct ChainConfig {
     pub max_msg_num: MaxMsgNum,
     #[serde(default)]
     pub max_tx_size: MaxTxSize,
+
+    /// A correction parameter dealing with only approximately synchronized clocks.
+    /// The local clock should always be ahead of timestamps from the blockchain; this
+    /// is the maximum amount that the local clock may drift behind a timestamp from the
+    /// blockchain.
     #[serde(default = "default::clock_drift", with = "humantime_serde")]
     pub clock_drift: Duration,
+
     #[serde(default = "default::max_block_time", with = "humantime_serde")]
     pub max_block_time: Duration,
+
+    /// The trusting period specifies how long a validator set is trusted for
+    /// (must be shorter than the chain's unbonding period).
     #[serde(default, with = "humantime_serde")]
     pub trusting_period: Option<Duration>,
+
     #[serde(default)]
     pub memo_prefix: Memo,
     #[serde(default, with = "self::proof_specs")]
     pub proof_specs: ProofSpecs,
 
     // these two need to be last otherwise we run into `ValueAfterTable` error when serializing to TOML
+    /// The trust threshold defines what fraction of the total voting power of a known
+    /// and trusted validator set is sufficient for a commit to be accepted going forward.
     #[serde(default)]
     pub trust_threshold: TrustThreshold,
     pub gas_price: GasPrice,

--- a/tools/integration-test/src/bootstrap/binary/chain.rs
+++ b/tools/integration-test/src/bootstrap/binary/chain.rs
@@ -137,7 +137,7 @@ pub fn pad_client_ids<ChainA: ChainHandle, ChainB: ChainHandle>(
 
     for i in 0..random_u64_range(1, 6) {
         debug!("creating new client id {} on chain {}", i + 1, chain_b.id());
-        foreign_client.build_create_client_and_send()?;
+        foreign_client.build_create_client_and_send(&Default::default())?;
     }
 
     Ok(())
@@ -159,7 +159,7 @@ pub fn bootstrap_foreign_client<ChainA: ChainHandle, ChainB: ChainHandle>(
     let foreign_client =
         ForeignClient::restore(ClientId::default(), chain_b.clone(), chain_a.clone());
 
-    let event = foreign_client.build_create_client_and_send()?;
+    let event = foreign_client.build_create_client_and_send(&Default::default())?;
     let client_id = extract_client_id(&event)?.clone();
 
     info!(


### PR DESCRIPTION
Closes: #836

## Description

Add flags to the `tx raw create-client` CLI command (aliased as `create client`) to customize some of the parameters as described in [ADR-006](https://github.com/informalsystems/ibc-rs/blob/master/docs/architecture/adr-006-hermes-v0.2-usecases.md#decision).

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).