### PR TITLE
Improve worker spawning time by querying a single commitment to decide whether or not to spawn a packet worker

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -86,6 +86,13 @@ pub mod cosmos {
                         ..Default::default()
                     })
                 }
+
+                pub fn first(limit: u64) -> Option<PageRequest> {
+                    Some(PageRequest {
+                        limit,
+                        ..Default::default()
+                    })
+                }
             }
         }
         pub mod reflection {

--- a/relayer-cli/src/commands/query/packet/commitments.rs
+++ b/relayer-cli/src/commands/query/packet/commitments.rs
@@ -37,7 +37,7 @@ impl QueryPacketCommitmentsCmd {
 
         let chain = spawn_chain_runtime(&config, &self.chain_id)?;
 
-        commitments_on_chain(&chain, &self.port_id, &self.channel_id)
+        commitments_on_chain(&chain, &self.port_id, &self.channel_id, None)
             .map_err(Error::supervisor)
             .map(|(seqs_vec, height)| PacketSeqs {
                 height,

--- a/relayer-cli/src/commands/query/packet/commitments.rs
+++ b/relayer-cli/src/commands/query/packet/commitments.rs
@@ -27,6 +27,13 @@ pub struct QueryPacketCommitmentsCmd {
 
     #[clap(required = true, help = "identifier of the channel to query")]
     channel_id: ChannelId,
+
+    #[clap(
+        short = 'l',
+        long,
+        help = "limit the number of commitments to retrieve"
+    )]
+    limit: Option<u64>,
 }
 
 impl QueryPacketCommitmentsCmd {
@@ -37,12 +44,9 @@ impl QueryPacketCommitmentsCmd {
 
         let chain = spawn_chain_runtime(&config, &self.chain_id)?;
 
-        commitments_on_chain(&chain, &self.port_id, &self.channel_id, None)
+        commitments_on_chain(&chain, &self.port_id, &self.channel_id, self.limit)
             .map_err(Error::supervisor)
-            .map(|(seqs_vec, height)| PacketSeqs {
-                height,
-                seqs: seqs_vec,
-            })
+            .map(|(seqs, height)| PacketSeqs { height, seqs })
     }
 }
 

--- a/relayer/src/chain/counterparty.rs
+++ b/relayer/src/chain/counterparty.rs
@@ -515,27 +515,13 @@ pub fn unreceived_acknowledgements(
     Ok(sequences)
 }
 
-pub fn has_commitments_on_counterparty(
+pub fn has_commitments(
     chain: &impl ChainHandle,
-    counterparty_chain: &impl ChainHandle,
     channel: &IdentifiedChannelEnd,
 ) -> Result<bool, Error> {
-    let counterparty = channel.channel_end.counterparty();
+    // get the first commitment, if any
+    let (commitments, _) =
+        commitments_on_chain(chain, &channel.port_id, &channel.channel_id, Some(1))?;
 
-    let counterparty_channel_id = counterparty
-        .channel_id
-        .as_ref()
-        .ok_or_else(Error::missing_counterparty_channel_id)?;
-
-    let counterparty_port_id = &counterparty.port_id;
-
-    // get the first commitment, if any, on the counterparty chain
-    let (commitments_on_counterparty, _) = commitments_on_chain(
-        counterparty_chain,
-        counterparty_port_id,
-        counterparty_channel_id,
-        Some(1),
-    )?;
-
-    Ok(!commitments_on_counterparty.is_empty())
+    Ok(!commitments.is_empty())
 }

--- a/relayer/src/supervisor/scan.rs
+++ b/relayer/src/supervisor/scan.rs
@@ -34,7 +34,7 @@ use crate::{
     worker::WorkerMap,
 };
 
-use crate::chain::counterparty::has_commitments_on_counterparty;
+use crate::chain::counterparty::has_commitments;
 
 use crate::error::Error as RelayerError;
 use crate::registry::SpawnError;
@@ -459,12 +459,7 @@ impl<'a, Chain: ChainHandle> ChainScanner<'a, Chain> {
                     channel_on_destination(&channel, &scan.connection, &counterparty_chain)
                         .unwrap_or_default();
 
-                let has_commitments = if let Some(ref counterparty) = counterparty {
-                    has_commitments_on_counterparty(&counterparty_chain, chain, counterparty)
-                        .unwrap_or_default()
-                } else {
-                    false
-                };
+                let has_commitments = has_commitments(chain, &channel).unwrap_or_default();
 
                 let scan = ChannelScan::new(channel, counterparty, has_commitments);
 
@@ -652,12 +647,7 @@ fn scan_allowed_channel<Chain: ChainHandle>(
         "found counterparty connection state"
     );
 
-    let has_commitments = if let Some(ref counterparty_channel) = counterparty_channel {
-        has_commitments_on_counterparty(&counterparty_chain, chain, counterparty_channel)
-            .unwrap_or_default()
-    } else {
-        false
-    };
+    let has_commitments = has_commitments(chain, &channel).unwrap_or_default();
 
     Ok(ScannedChannel {
         channel,

--- a/relayer/src/supervisor/spawn.rs
+++ b/relayer/src/supervisor/spawn.rs
@@ -238,7 +238,7 @@ impl<'a, Chain: ChainHandle> SpawnContext<'a, Chain> {
                     .then(|| info!("spawned Client worker: {}", client_object.short_name()));
             }
 
-            // If packet mdoe is enabled and there are any outstanding commitments for packets or acks to send, spawn the worker
+            // If packet mode is enabled and there are any outstanding commitments for packets or acks to send, spawn the worker
             if mode.packets.enabled && channel_scan.has_commitments {
                 // Create the Packet object and spawn worker
                 let path_object = Object::Packet(Packet {
@@ -249,12 +249,7 @@ impl<'a, Chain: ChainHandle> SpawnContext<'a, Chain> {
                 });
 
                 self.workers
-                    .spawn(
-                        chain.clone(),
-                        counterparty_chain.clone(),
-                        &path_object,
-                        self.config,
-                    )
+                    .spawn(chain, counterparty_chain, &path_object, self.config)
                     .then(|| info!("spawned Packet worker: {}", path_object.short_name()));
             }
 


### PR DESCRIPTION
## Description

- Improve start time by querying a single commitment to decide whether or not to spawn a packet worker.
- Do away with the counterparty dance and query the commitments for the given channel directly without having to supply the counterparty channel.
- Add a `--limit` option to `query packet commitments`

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).