### PR TITLE
Fix `ibc-proto` build by enabling required `tonic` features when `std` is enabled

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -34,4 +34,4 @@ default-features = false
 
 [features]
 default = ["std"]
-std = ["tonic"]
+std = ["tonic", "tonic/codegen", "tonic/transport", "tonic/prost"]


### PR DESCRIPTION

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).