### PR TITLE
Skip config processing for the completions command

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer-cli/1822-skip-config-for-completions.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer-cli/1822-skip-config-for-completions.md
@@ -1,0 +1,2 @@
+- Do not require a config file to be present for the `completions` command.
+  ([#1822](https://github.com/informalsystems/ibc-rs/pull/1822))

--- a/relayer-cli/src/entry.rs
+++ b/relayer-cli/src/entry.rs
@@ -43,9 +43,13 @@ impl Runnable for EntryPoint {
 impl Configurable<Config> for EntryPoint {
     /// Path to the command's configuration file
     fn config_path(&self) -> Option<PathBuf> {
-        // Skip config processing for the legacy `version` subcommand
-        if matches!(&self.command, Some(CliCmd::Version(_))) {
-            return None;
+        // Skip config processing for `completions`
+        // and the legacy `version` subcommand.
+        match &self.command {
+            Some(CliCmd::Completions(_)) | Some(CliCmd::Version(_)) => {
+                return None;
+            }
+            _ => {}
         }
 
         match &self.config {


### PR DESCRIPTION
## Description

The `completions` command does not need the relayer configuration
to be processed.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).