### PR TITLE
Improve help and documentation on clock drift

### DIFF
--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -27,10 +27,11 @@ pub struct TxCreateClientCmd {
 
     /// Override the default clock drift specified in the configuration.
     ///
-    /// The clock drift is a correction parameter dealing with only approximately synchronized clocks.
-    /// The local clock should always be ahead of timestamps from the blockchain; this
-    /// is the maximum amount that the local clock may drift behind a timestamp from the
-    /// blockchain.
+    /// The clock drift is a correction parameter. It helps deal with clocks
+    /// that are only approximately synchronized between the source and destination chains
+    /// of this client.
+    /// The destination chain for this client uses the clock drift parameter when deciding
+    /// to accept or reject a new header (originating from the source chain) for this client.
     #[clap(short = 'd', long)]
     clock_drift: Option<humantime::Duration>,
 
@@ -38,7 +39,6 @@ pub struct TxCreateClientCmd {
     ///
     /// The trusting period specifies how long a validator set is trusted for
     /// (must be shorter than the chain's unbonding period).
-
     #[clap(short = 'p', long)]
     trusting_period: Option<humantime::Duration>,
 

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -389,10 +389,12 @@ pub struct ChainConfig {
     #[serde(default)]
     pub max_tx_size: MaxTxSize,
 
-    /// A correction parameter dealing with only approximately synchronized clocks.
-    /// The local clock should always be ahead of timestamps from the blockchain; this
-    /// is the maximum amount that the local clock may drift behind a timestamp from the
-    /// blockchain.
+    /// A correction parameter that helps deal with clocks that are only approximately synchronized
+    /// between the source and destination chains for a client.
+    /// This parameter is used when deciding to accept or reject a new header
+    /// (originating from the source chain) for any client with the destination chain
+    /// that uses this configuration, unless it is overridden by the client-specific
+    /// clock drift option.
     #[serde(default = "default::clock_drift", with = "humantime_serde")]
     pub clock_drift: Duration,
 


### PR DESCRIPTION
Closes: #1823

## Description

Changed the help text for the `--clock-drift` option of the `create client`/`tx raw create-client` commands
per suggestions by @adizere in https://github.com/informalsystems/ibc-rs/pull/1807#discussion_r792798936

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~
- [x] Linked to GitHub issue.
- ~Updated code comments and documentation (e.g., `docs/`).~

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).