### PR TITLE
Handle non-standard ports in channel handshake

### DIFF
--- a/.changelog/unreleased/improvements/1837-non-standard-ports.md
+++ b/.changelog/unreleased/improvements/1837-non-standard-ports.md
@@ -1,0 +1,2 @@
+- Handle non-standard ports in channel handshake
+  ([#1837](https://github.com/informalsystems/ibc-rs/issues/1837))

--- a/relayer/src/channel.rs
+++ b/relayer/src/channel.rs
@@ -724,7 +724,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
             self.ordering,
             counterparty,
             vec![self.dst_connection_id().clone()],
-            version, // NOTE: This field is deprecated since IBC v3
+            version,
         );
 
         // Build the domain type message

--- a/relayer/src/channel.rs
+++ b/relayer/src/channel.rs
@@ -716,7 +716,8 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
 
         let counterparty = Counterparty::new(self.src_port_id().clone(), None);
 
-        let version = version::default_by_port(self.dst_port_id())?;
+        // If the port is not know, use the default (empty) version
+        let version = version::default_by_port(self.dst_port_id()).unwrap_or_default();
 
         let channel = ChannelEnd::new(
             State::Init,
@@ -866,7 +867,8 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
         let counterparty =
             Counterparty::new(self.src_port_id().clone(), self.src_channel_id().cloned());
 
-        let version = version::default_by_port(self.dst_port_id())?;
+        // Re-use the version that was either set on ChanOpenInit or overwritten by the application.
+        let version = src_channel.version().clone();
 
         let channel = ChannelEnd::new(
             State::TryOpen,

--- a/relayer/src/channel/error.rs
+++ b/relayer/src/channel/error.rs
@@ -191,14 +191,6 @@ define_error! {
                 format_args!("channel object cannot be built from event: {}",
                     e.event)
             },
-
-        UnknownPortId
-            { port_id: PortId }
-            | e | {
-                format_args!("could not resolve channel version because the port is not known: {0}",
-                    e.port_id)
-            },
-
     }
 }
 

--- a/relayer/src/channel/error.rs
+++ b/relayer/src/channel/error.rs
@@ -192,10 +192,10 @@ define_error! {
                     e.event)
             },
 
-        InvalidPortId
+        UnknownPortId
             { port_id: PortId }
             | e | {
-                format_args!("could not resolve channel version because the port is invalid: {0}",
+                format_args!("could not resolve channel version because the port is not known: {0}",
                     e.port_id)
             },
 

--- a/relayer/src/channel/version.rs
+++ b/relayer/src/channel/version.rs
@@ -4,32 +4,24 @@
 //! channel version to be used in a channel open
 //! handshake.
 
-use tracing::warn;
-
 use ibc::{
     applications::{ics20_fungible_token_transfer, ics27_interchain_accounts},
     core::{ics04_channel::Version, ics24_host::identifier::PortId},
 };
 
-use crate::channel::ChannelError;
-
-/// Returns the default channel version, depending on the the given [`PortId`].
-pub fn default_by_port(port_id: &PortId) -> Result<Version, ChannelError> {
-    if port_id.as_str() == ics20_fungible_token_transfer::PORT_ID {
-        // https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#forwards-compatibility
-        Ok(Version::ics20())
-    } else if port_id
-        .as_str()
-        .starts_with(ics27_interchain_accounts::PORT_ID_PREFIX)
-    {
-        // https://github.com/cosmos/ibc/tree/master/spec/app/ics-027-interchain-accounts#channel-lifecycle-management
-        Ok(Version::ics27())
-    } else {
-        warn!(
-            port = %port_id,
-            "cannot resolve channel version for unknown port",
-        );
-
-        Err(ChannelError::invalid_port_id(port_id.clone()))
+/// Returns the default channel version, for the given [`PortId`].
+///
+/// Currently only ICS20 and ICS27 ports are recognized.
+pub fn default_by_port(port_id: &PortId) -> Option<Version> {
+    match port_id.as_str() {
+        ics20_fungible_token_transfer::PORT_ID => {
+            // https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#forwards-compatibility
+            Some(Version::ics20())
+        }
+        port_id if port_id.starts_with(ics27_interchain_accounts::PORT_ID_PREFIX) => {
+            // https://github.com/cosmos/ibc/tree/master/spec/app/ics-027-interchain-accounts#channel-lifecycle-management
+            Some(Version::ics27())
+        }
+        _ => None,
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1837

## Description

Handle non-standard ports in channel handshake by using the empty version string when the port is unknown, and leave it to the application to negotiate the proper version in the `OnChanOpenTry` callback.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).