### PR TITLE
Cleanup access to state handler

### DIFF
--- a/modules/src/core/ics02_client/handler/create_client.rs
+++ b/modules/src/core/ics02_client/handler/create_client.rs
@@ -49,7 +49,7 @@ pub fn process(
         client_id: client_id.clone(),
         client_type: msg.client_state.client_type(),
         client_state: msg.client_state.clone(),
-        consensus_state: msg.consensus_state.clone(),
+        consensus_state: msg.consensus_state,
         processed_time: ctx.host_timestamp(),
         processed_height: ctx.host_height(),
     });

--- a/modules/src/core/ics02_client/handler/create_client.rs
+++ b/modules/src/core/ics02_client/handler/create_client.rs
@@ -36,8 +36,8 @@ pub fn process(
 
     // Construct this client's identifier
     let id_counter = ctx.client_counter()?;
-    let client_id = ClientId::new(msg.client_state().client_type(), id_counter).map_err(|e| {
-        Error::client_identifier_constructor(msg.client_state().client_type(), id_counter, e)
+    let client_id = ClientId::new(msg.client_state.client_type(), id_counter).map_err(|e| {
+        Error::client_identifier_constructor(msg.client_state.client_type(), id_counter, e)
     })?;
 
     output.log(format!(
@@ -47,9 +47,9 @@ pub fn process(
 
     let result = ClientResult::Create(Result {
         client_id: client_id.clone(),
-        client_type: msg.client_state().client_type(),
-        client_state: msg.client_state(),
-        consensus_state: msg.consensus_state(),
+        client_type: msg.client_state.client_type(),
+        client_state: msg.client_state.clone(),
+        consensus_state: msg.consensus_state.clone(),
         processed_time: ctx.host_timestamp(),
         processed_height: ctx.host_height(),
     });
@@ -120,8 +120,8 @@ mod tests {
                     ClientResult::Create(create_result) => {
                         assert_eq!(create_result.client_type, ClientType::Mock);
                         assert_eq!(create_result.client_id, expected_client_id);
-                        assert_eq!(create_result.client_state, msg.client_state());
-                        assert_eq!(create_result.consensus_state, msg.consensus_state());
+                        assert_eq!(create_result.client_state, msg.client_state);
+                        assert_eq!(create_result.consensus_state, msg.consensus_state);
                     }
                     _ => {
                         panic!("unexpected result type: expected ClientResult::CreateResult!");
@@ -208,10 +208,10 @@ mod tests {
                     );
                     match result {
                         ClientResult::Create(create_res) => {
-                            assert_eq!(create_res.client_type, msg.client_state().client_type());
+                            assert_eq!(create_res.client_type, msg.client_state.client_type());
                             assert_eq!(create_res.client_id, expected_client_id);
-                            assert_eq!(create_res.client_state, msg.client_state());
-                            assert_eq!(create_res.consensus_state, msg.consensus_state());
+                            assert_eq!(create_res.client_state, msg.client_state);
+                            assert_eq!(create_res.consensus_state, msg.consensus_state);
                         }
                         _ => {
                             panic!("expected result of type ClientResult::CreateResult");
@@ -273,8 +273,8 @@ mod tests {
                     ClientResult::Create(create_res) => {
                         assert_eq!(create_res.client_type, ClientType::Tendermint);
                         assert_eq!(create_res.client_id, expected_client_id);
-                        assert_eq!(create_res.client_state, msg.client_state());
-                        assert_eq!(create_res.consensus_state, msg.consensus_state());
+                        assert_eq!(create_res.client_state, msg.client_state);
+                        assert_eq!(create_res.consensus_state, msg.consensus_state);
                     }
                     _ => {
                         panic!("expected result of type ClientResult::CreateResult");

--- a/modules/src/core/ics02_client/msgs/create_client.rs
+++ b/modules/src/core/ics02_client/msgs/create_client.rs
@@ -40,14 +40,6 @@ impl MsgCreateAnyClient {
             signer,
         })
     }
-
-    pub fn client_state(&self) -> AnyClientState {
-        self.client_state.clone()
-    }
-
-    pub fn consensus_state(&self) -> AnyConsensusState {
-        self.consensus_state.clone()
-    }
 }
 
 impl Msg for MsgCreateAnyClient {

--- a/modules/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -23,34 +23,34 @@ pub(crate) fn process(
     check_client_consensus_height(ctx, msg.consensus_height())?;
 
     // Validate the connection end.
-    let mut conn_end = ctx.connection_end(msg.connection_id())?;
+    let mut conn_end = ctx.connection_end(&msg.connection_id)?;
     // A connection end must be Init or TryOpen; otherwise we return an error.
     let state_is_consistent = conn_end.state_matches(&State::Init)
-        && conn_end.versions().contains(msg.version())
+        && conn_end.versions().contains(&msg.version)
         || conn_end.state_matches(&State::TryOpen)
-            && conn_end.versions().get(0).eq(&Some(msg.version()));
+            && conn_end.versions().get(0).eq(&Some(&msg.version));
 
     if !state_is_consistent {
         // Old connection end is in incorrect state, propagate the error.
-        return Err(Error::connection_mismatch(msg.connection_id().clone()));
+        return Err(Error::connection_mismatch(msg.connection_id.clone()));
     }
 
     // Set the connection ID of the counterparty
     let prev_counterparty = conn_end.counterparty();
     let counterparty = Counterparty::new(
         prev_counterparty.client_id().clone(),
-        Some(msg.connection_id().clone()),
+        Some(msg.connection_id.clone()),
         prev_counterparty.prefix().clone(),
     );
     conn_end.set_state(State::Open);
-    conn_end.set_version(msg.version().clone());
+    conn_end.set_version(msg.version.clone());
     conn_end.set_counterparty(counterparty);
 
     // The counterparty is the local chain.
     let counterparty = Counterparty::new(
         conn_end.client_id().clone(), // The local client identifier.
-        Some(msg.counterparty_connection_id().clone()), // This chain's connection id as known on counterparty.
-        ctx.commitment_prefix(),                        // Local commitment prefix.
+        Some(msg.counterparty_connection_id.clone()), // This chain's connection id as known on counterparty.
+        ctx.commitment_prefix(),                      // Local commitment prefix.
     );
 
     // Proof verification.
@@ -58,24 +58,24 @@ pub(crate) fn process(
         State::TryOpen,
         conn_end.counterparty().client_id().clone(),
         counterparty,
-        vec![msg.version().clone()],
+        vec![msg.version.clone()],
         conn_end.delay_period(),
     );
 
     // 2. Pass the details to the verification function.
     verify_proofs(
         ctx,
-        msg.client_state(),
-        msg.proofs().height(),
+        msg.client_state.clone(),
+        msg.proofs.height(),
         &conn_end,
         &expected_conn,
-        msg.proofs(),
+        &msg.proofs,
     )?;
 
     output.log("success: connection verification passed");
 
     let result = ConnectionResult {
-        connection_id: msg.connection_id().clone(),
+        connection_id: msg.connection_id.clone(),
         connection_id_state: ConnectionIdState::Reused,
         connection_end: conn_end,
     };
@@ -144,10 +144,10 @@ mod tests {
             client_id.clone(),
             Counterparty::new(
                 client_id.clone(),
-                Some(msg_ack.counterparty_connection_id().clone()),
+                Some(msg_ack.counterparty_connection_id.clone()),
                 CommitmentPrefix::try_from(b"ibc".to_vec()).unwrap(),
             ),
-            vec![msg_ack.version().clone()],
+            vec![msg_ack.version.clone()],
             ZERO_DURATION,
         );
 

--- a/modules/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -32,7 +32,7 @@ pub(crate) fn process(
 
     if !state_is_consistent {
         // Old connection end is in incorrect state, propagate the error.
-        return Err(Error::connection_mismatch(msg.connection_id.clone()));
+        return Err(Error::connection_mismatch(msg.connection_id));
     }
 
     // Set the connection ID of the counterparty
@@ -75,7 +75,7 @@ pub(crate) fn process(
     output.log("success: connection verification passed");
 
     let result = ConnectionResult {
-        connection_id: msg.connection_id.clone(),
+        connection_id: msg.connection_id,
         connection_id_state: ConnectionIdState::Reused,
         connection_end: conn_end,
     };

--- a/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -18,11 +18,11 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Validate the connection end.
-    let mut conn_end = ctx.connection_end(msg.connection_id())?;
+    let mut conn_end = ctx.connection_end(&msg.connection_id)?;
     // A connection end must be in TryOpen state; otherwise return error.
     if !conn_end.state_matches(&State::TryOpen) {
         // Old connection end is in incorrect state, propagate the error.
-        return Err(Error::connection_mismatch(msg.connection_id().clone()));
+        return Err(Error::connection_mismatch(msg.connection_id.clone()));
     }
 
     // Verify proofs. Assemble the connection end as we expect to find it on the counterparty.
@@ -32,7 +32,7 @@ pub(crate) fn process(
         Counterparty::new(
             // The counterparty is the local chain.
             conn_end.client_id().clone(), // The local client identifier.
-            Some(msg.connection_id().clone()), // Local connection id.
+            Some(msg.connection_id.clone()), // Local connection id.
             ctx.commitment_prefix(),      // Local commitment prefix.
         ),
         conn_end.versions(),
@@ -43,10 +43,10 @@ pub(crate) fn process(
     verify_proofs(
         ctx,
         None,
-        msg.proofs().height(),
+        msg.proofs.height(),
         &conn_end,
         &expected_conn,
-        msg.proofs(),
+        &msg.proofs,
     )?;
 
     output.log("success: connection verification passed");
@@ -55,7 +55,7 @@ pub(crate) fn process(
     conn_end.set_state(State::Open);
 
     let result = ConnectionResult {
-        connection_id: msg.connection_id().clone(),
+        connection_id: msg.connection_id.clone(),
         connection_id_state: ConnectionIdState::Reused,
         connection_end: conn_end,
     };
@@ -103,7 +103,7 @@ mod tests {
             MsgConnectionOpenConfirm::try_from(get_dummy_raw_msg_conn_open_confirm()).unwrap();
         let counterparty = Counterparty::new(
             client_id.clone(),
-            Some(msg_confirm.connection_id().clone()),
+            Some(msg_confirm.connection_id.clone()),
             CommitmentPrefix::try_from(b"ibc".to_vec()).unwrap(),
         );
 
@@ -132,10 +132,7 @@ mod tests {
                 ctx: context
                     .clone()
                     .with_client(&client_id, Height::new(0, 10))
-                    .with_connection(
-                        msg_confirm.connection_id().clone(),
-                        incorrect_conn_end_state,
-                    ),
+                    .with_connection(msg_confirm.connection_id.clone(), incorrect_conn_end_state),
                 msg: ConnectionMsg::ConnectionOpenConfirm(msg_confirm.clone()),
                 want_pass: false,
             },
@@ -143,7 +140,7 @@ mod tests {
                 name: "Processing successful".to_string(),
                 ctx: context
                     .with_client(&client_id, Height::new(0, 10))
-                    .with_connection(msg_confirm.connection_id().clone(), correct_conn_end),
+                    .with_connection(msg_confirm.connection_id.clone(), correct_conn_end),
                 msg: ConnectionMsg::ConnectionOpenConfirm(msg_confirm.clone()),
                 want_pass: true,
             },

--- a/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -22,7 +22,7 @@ pub(crate) fn process(
     // A connection end must be in TryOpen state; otherwise return error.
     if !conn_end.state_matches(&State::TryOpen) {
         // Old connection end is in incorrect state, propagate the error.
-        return Err(Error::connection_mismatch(msg.connection_id.clone()));
+        return Err(Error::connection_mismatch(msg.connection_id));
     }
 
     // Verify proofs. Assemble the connection end as we expect to find it on the counterparty.
@@ -55,7 +55,7 @@ pub(crate) fn process(
     conn_end.set_state(State::Open);
 
     let result = ConnectionResult {
-        connection_id: msg.connection_id.clone(),
+        connection_id: msg.connection_id,
         connection_id_state: ConnectionIdState::Reused,
         connection_end: conn_end,
     };

--- a/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -141,7 +141,7 @@ mod tests {
                 ctx: context
                     .with_client(&client_id, Height::new(0, 10))
                     .with_connection(msg_confirm.connection_id.clone(), correct_conn_end),
-                msg: ConnectionMsg::ConnectionOpenConfirm(msg_confirm.clone()),
+                msg: ConnectionMsg::ConnectionOpenConfirm(msg_confirm),
                 want_pass: true,
             },
         ]

--- a/modules/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_init.rs
@@ -18,12 +18,12 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // An IBC client running on the local (host) chain should exist.
-    ctx.client_state(msg.client_id())?;
+    ctx.client_state(&msg.client_id)?;
 
     let new_connection_end = ConnectionEnd::new(
         State::Init,
-        msg.client_id().clone(),
-        msg.counterparty().clone(),
+        msg.client_id.clone(),
+        msg.counterparty.clone(),
         ctx.get_compatible_versions(),
         msg.delay_period,
     );
@@ -89,7 +89,7 @@ mod tests {
             },
             Test {
                 name: "Good parameters".to_string(),
-                ctx: context.with_client(msg_conn_init.client_id(), Height::new(0, 10)),
+                ctx: context.with_client(&msg_conn_init.client_id, Height::new(0, 10)),
                 msg: ConnectionMsg::ConnectionOpenInit(msg_conn_init.clone()),
                 want_pass: true,
             },

--- a/modules/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -27,31 +27,6 @@ pub struct MsgConnectionOpenAck {
 }
 
 impl MsgConnectionOpenAck {
-    /// Getter for accessing the connection identifier of this message.
-    pub fn connection_id(&self) -> &ConnectionId {
-        &self.connection_id
-    }
-
-    /// Getter for accessing the counterparty's connection identifier from this message.
-    pub fn counterparty_connection_id(&self) -> &ConnectionId {
-        &self.counterparty_connection_id
-    }
-
-    /// Getter for accessing the client state.
-    pub fn client_state(&self) -> Option<AnyClientState> {
-        self.client_state.clone()
-    }
-
-    /// Getter for accessing (borrow) the proofs in this message.
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
-
-    /// Getter for the version field.
-    pub fn version(&self) -> &Version {
-        &self.version
-    }
-
     /// Getter for accessing the `consensus_height` field from this message. Returns the special
     /// value `Height(0)` if this field is not set.
     pub fn consensus_height(&self) -> Height {

--- a/modules/src/core/ics03_connection/msgs/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_confirm.rs
@@ -22,18 +22,6 @@ pub struct MsgConnectionOpenConfirm {
     pub signer: Signer,
 }
 
-impl MsgConnectionOpenConfirm {
-    /// Getter for accessing the connection identifier of this message.
-    pub fn connection_id(&self) -> &ConnectionId {
-        &self.connection_id
-    }
-
-    /// Getter for accessing (borrow) the proofs in this message.
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
-}
-
 impl Msg for MsgConnectionOpenConfirm {
     type ValidationError = Error;
     type Raw = RawMsgConnectionOpenConfirm;

--- a/modules/src/core/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_init.rs
@@ -26,18 +26,6 @@ pub struct MsgConnectionOpenInit {
     pub signer: Signer,
 }
 
-impl MsgConnectionOpenInit {
-    /// Getter: borrow the `client_id` from this message.
-    pub fn client_id(&self) -> &ClientId {
-        &self.client_id
-    }
-
-    /// Getter: borrow the `counterparty` from this message.
-    pub fn counterparty(&self) -> &Counterparty {
-        &self.counterparty
-    }
-}
-
 impl Msg for MsgConnectionOpenInit {
     type ValidationError = Error;
     type Raw = RawMsgConnectionOpenInit;

--- a/modules/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -38,36 +38,6 @@ pub struct MsgConnectionOpenTry {
 }
 
 impl MsgConnectionOpenTry {
-    /// Getter for accessing the previous connection identifier of this message.
-    pub fn previous_connection_id(&self) -> &Option<ConnectionId> {
-        &self.previous_connection_id
-    }
-
-    /// Getter for accessing the client identifier from this message.
-    pub fn client_id(&self) -> &ClientId {
-        &self.client_id
-    }
-
-    /// Getter for accessing the client state.
-    pub fn client_state(&self) -> Option<AnyClientState> {
-        self.client_state.clone()
-    }
-
-    /// Getter for accesing the whole counterparty of this message. Returns a `clone()`.
-    pub fn counterparty(&self) -> Counterparty {
-        self.counterparty.clone()
-    }
-
-    /// Getter for accessing the versions from this message. Returns a `clone()`.
-    pub fn counterparty_versions(&self) -> Vec<Version> {
-        self.counterparty_versions.clone()
-    }
-
-    /// Getter for accessing the proofs in this message.
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
-
     /// Getter for accessing the `consensus_height` field from this message. Returns the special
     /// value `0` if this field is not set.
     pub fn consensus_height(&self) -> Height {

--- a/modules/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/acknowledgement.rs
@@ -78,9 +78,9 @@ pub fn process(
         ctx,
         msg.proofs.height(),
         packet,
-        msg.acknowledgement().clone(),
+        msg.acknowledgement.clone(),
         &connection_end,
-        msg.proofs(),
+        &msg.proofs,
     )?;
 
     let result = if source_channel_end.order_matches(&Order::Ordered) {

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -22,7 +22,7 @@ pub(crate) fn process(
 
     // Validate that the channel end is in a state where it can be closed.
     if channel_end.state_matches(&State::Closed) {
-        return Err(Error::channel_closed(msg.channel_id.clone()));
+        return Err(Error::channel_closed(msg.channel_id));
     }
 
     // Channel capabilities
@@ -88,7 +88,7 @@ pub(crate) fn process(
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id.clone()),
+        channel_id: Some(msg.channel_id),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseConfirmChannel(event_attributes.into()));

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -18,15 +18,15 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Retrieve the old channel end and validate it against the message.
-    let mut channel_end = ctx.channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))?;
+    let mut channel_end = ctx.channel_end(&(msg.port_id.clone(), msg.channel_id.clone()))?;
 
     // Validate that the channel end is in a state where it can be closed.
     if channel_end.state_matches(&State::Closed) {
-        return Err(Error::channel_closed(msg.channel_id().clone()));
+        return Err(Error::channel_closed(msg.channel_id.clone()));
     }
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id().clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id)?;
 
     // An OPEN IBC connection running on the local (host) chain should exist.
     if channel_end.connection_hops().len() != 1 {
@@ -48,7 +48,7 @@ pub(crate) fn process(
     // 1. Setup: build the Channel as we expect to find it on the other party.
 
     let expected_counterparty =
-        Counterparty::new(msg.port_id().clone(), Some(msg.channel_id().clone()));
+        Counterparty::new(msg.port_id.clone(), Some(msg.channel_id.clone()));
 
     let counterparty = conn.counterparty();
     let ccid = counterparty.connection_id().ok_or_else(|| {
@@ -67,11 +67,11 @@ pub(crate) fn process(
 
     verify_channel_proofs(
         ctx,
-        msg.proofs().height(),
+        msg.proofs.height(),
         &channel_end,
         &conn,
         &expected_channel_end,
-        msg.proofs(),
+        &msg.proofs,
     )?;
 
     output.log("success: channel close confirm ");
@@ -80,15 +80,15 @@ pub(crate) fn process(
     channel_end.set_state(State::Closed);
 
     let result = ChannelResult {
-        port_id: msg.port_id().clone(),
-        channel_id: msg.channel_id().clone(),
+        port_id: msg.port_id.clone(),
+        channel_id: msg.channel_id.clone(),
         channel_id_state: ChannelIdState::Reused,
         channel_cap,
         channel_end,
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id().clone()),
+        channel_id: Some(msg.channel_id.clone()),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseConfirmChannel(event_attributes.into()));

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -21,7 +21,7 @@ pub(crate) fn process(
     // Validate that the channel end is in a state where it can be closed.
     if channel_end.state_matches(&State::Closed) {
         return Err(Error::invalid_channel_state(
-            msg.channel_id.clone(),
+            msg.channel_id,
             channel_end.state,
         ));
     }
@@ -59,7 +59,7 @@ pub(crate) fn process(
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id.clone()),
+        channel_id: Some(msg.channel_id),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseInitChannel(event_attributes.into()));

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -16,18 +16,18 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let mut channel_end = ctx.channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))?;
+    let mut channel_end = ctx.channel_end(&(msg.port_id.clone(), msg.channel_id.clone()))?;
 
     // Validate that the channel end is in a state where it can be closed.
     if channel_end.state_matches(&State::Closed) {
         return Err(Error::invalid_channel_state(
-            msg.channel_id().clone(),
+            msg.channel_id.clone(),
             channel_end.state,
         ));
     }
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id().clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id)?;
     // An OPEN IBC connection running on the local (host) chain should exist.
 
     if channel_end.connection_hops().len() != 1 {
@@ -51,15 +51,15 @@ pub(crate) fn process(
     channel_end.set_state(State::Closed);
 
     let result = ChannelResult {
-        port_id: msg.port_id().clone(),
-        channel_id: msg.channel_id().clone(),
+        port_id: msg.port_id.clone(),
+        channel_id: msg.channel_id.clone(),
         channel_id_state: ChannelIdState::Reused,
         channel_cap,
         channel_end,
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id().clone()),
+        channel_id: Some(msg.channel_id.clone()),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseInitChannel(event_attributes.into()));

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -23,7 +23,7 @@ pub(crate) fn process(
     // Validate that the channel end is in a state where it can be ack.
     if !channel_end.state_matches(&State::Init) && !channel_end.state_matches(&State::TryOpen) {
         return Err(Error::invalid_channel_state(
-            msg.channel_id.clone(),
+            msg.channel_id,
             channel_end.state,
         ));
     }
@@ -97,7 +97,7 @@ pub(crate) fn process(
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id.clone()),
+        channel_id: Some(msg.channel_id),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenAckChannel(event_attributes.into()));

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -153,11 +153,11 @@ mod tests {
 
         let conn_end = ConnectionEnd::new(
             ConnectionState::Open,
-            msg_conn_init.client_id().clone(),
+            msg_conn_init.client_id.clone(),
             ConnectionCounterparty::new(
-                msg_conn_init.counterparty().client_id().clone(),
+                msg_conn_init.counterparty.client_id().clone(),
                 Some(ConnectionId::from_str("defaultConnection-1").unwrap()),
-                msg_conn_init.counterparty().prefix().clone(),
+                msg_conn_init.counterparty.prefix().clone(),
             ),
             get_compatible_versions(),
             msg_conn_init.delay_period,
@@ -224,7 +224,7 @@ mod tests {
                 ctx: context
                     .clone()
                     .with_client(
-                        msg_conn_try.client_id(),
+                        &msg_conn_try.client_id,
                         Height::new(0, client_consensus_state_height),
                     )
                     .with_port_capability(msg_chan_ack.port_id().clone())
@@ -242,7 +242,7 @@ mod tests {
                 ctx: context
                     .clone()
                     .with_client(
-                        msg_conn_try.client_id(),
+                        &msg_conn_try.client_id,
                         Height::new(0, client_consensus_state_height),
                     )
                     .with_connection(cid.clone(), conn_end.clone())
@@ -259,7 +259,7 @@ mod tests {
                 ctx: context
                     .clone()
                     .with_client(
-                        msg_conn_try.client_id(),
+                        &msg_conn_try.client_id,
                         Height::new(0, client_consensus_state_height),
                     )
                     .with_port_capability(msg_chan_ack.port_id().clone())
@@ -289,7 +289,7 @@ mod tests {
                 name: "Good parameters".to_string(),
                 ctx: context //  .clone()
                     .with_client(
-                        msg_conn_try.client_id(),
+                        &msg_conn_try.client_id,
                         Height::new(0, client_consensus_state_height),
                     )
                     .with_connection(cid, conn_end)

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -18,18 +18,18 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let mut channel_end = ctx.channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))?;
+    let mut channel_end = ctx.channel_end(&(msg.port_id.clone(), msg.channel_id.clone()))?;
 
     // Validate that the channel end is in a state where it can be ack.
     if !channel_end.state_matches(&State::Init) && !channel_end.state_matches(&State::TryOpen) {
         return Err(Error::invalid_channel_state(
-            msg.channel_id().clone(),
+            msg.channel_id.clone(),
             channel_end.state,
         ));
     }
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id().clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id)?;
 
     // An OPEN IBC connection running on the local (host) chain should exist.
 
@@ -52,7 +52,7 @@ pub(crate) fn process(
     // 1. Setup: build the Channel as we expect to find it on the other party.
 
     let expected_counterparty =
-        Counterparty::new(msg.port_id().clone(), Some(msg.channel_id().clone()));
+        Counterparty::new(msg.port_id.clone(), Some(msg.channel_id.clone()));
 
     let counterparty = conn.counterparty();
     let ccid = counterparty.connection_id().ok_or_else(|| {
@@ -66,7 +66,7 @@ pub(crate) fn process(
         *channel_end.ordering(),
         expected_counterparty,
         expected_connection_hops,
-        msg.counterparty_version().clone(),
+        msg.counterparty_version.clone(),
     );
 
     // set the counterparty channel id to verify against it
@@ -75,29 +75,29 @@ pub(crate) fn process(
     //2. Verify proofs
     verify_channel_proofs(
         ctx,
-        msg.proofs().height(),
+        msg.proofs.height(),
         &channel_end,
         &conn,
         &expected_channel_end,
-        msg.proofs(),
+        &msg.proofs,
     )?;
 
     output.log("success: channel open ack ");
 
     // Transition the channel end to the new state & pick a version.
     channel_end.set_state(State::Open);
-    channel_end.set_version(msg.counterparty_version().clone());
+    channel_end.set_version(msg.counterparty_version.clone());
 
     let result = ChannelResult {
-        port_id: msg.port_id().clone(),
-        channel_id: msg.channel_id().clone(),
+        port_id: msg.port_id.clone(),
+        channel_id: msg.channel_id.clone(),
         channel_id_state: ChannelIdState::Reused,
         channel_cap,
         channel_end,
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id().clone()),
+        channel_id: Some(msg.channel_id.clone()),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenAckChannel(event_attributes.into()));
@@ -194,8 +194,8 @@ mod tests {
             State::Init,
             *msg_chan_try.channel.ordering(),
             Counterparty::new(
-                msg_chan_ack.port_id().clone(),
-                Some(msg_chan_ack.channel_id().clone()),
+                msg_chan_ack.port_id.clone(),
+                Some(msg_chan_ack.channel_id.clone()),
             ),
             connection_vec0.clone(),
             msg_chan_try.channel.version().clone(),
@@ -205,8 +205,8 @@ mod tests {
             State::Open,
             *msg_chan_try.channel.ordering(),
             Counterparty::new(
-                msg_chan_ack.port_id().clone(),
-                Some(msg_chan_ack.channel_id().clone()),
+                msg_chan_ack.port_id.clone(),
+                Some(msg_chan_ack.channel_id.clone()),
             ),
             connection_vec0,
             msg_chan_try.channel.version().clone(),
@@ -227,10 +227,10 @@ mod tests {
                         &msg_conn_try.client_id,
                         Height::new(0, client_consensus_state_height),
                     )
-                    .with_port_capability(msg_chan_ack.port_id().clone())
+                    .with_port_capability(msg_chan_ack.port_id.clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        msg_chan_ack.port_id.clone(),
+                        msg_chan_ack.channel_id.clone(),
                         failed_chan_end,
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -247,8 +247,8 @@ mod tests {
                     )
                     .with_connection(cid.clone(), conn_end.clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        msg_chan_ack.port_id.clone(),
+                        msg_chan_ack.channel_id.clone(),
                         chan_end.clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -262,10 +262,10 @@ mod tests {
                         &msg_conn_try.client_id,
                         Height::new(0, client_consensus_state_height),
                     )
-                    .with_port_capability(msg_chan_ack.port_id().clone())
+                    .with_port_capability(msg_chan_ack.port_id.clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        msg_chan_ack.port_id.clone(),
+                        msg_chan_ack.channel_id.clone(),
                         chan_end.clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -276,10 +276,10 @@ mod tests {
                 ctx: context
                     .clone()
                     .with_connection(cid.clone(), conn_end.clone())
-                    .with_port_capability(msg_chan_ack.port_id().clone())
+                    .with_port_capability(msg_chan_ack.port_id.clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        msg_chan_ack.port_id.clone(),
+                        msg_chan_ack.channel_id.clone(),
                         chan_end.clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack.clone()),
@@ -293,10 +293,10 @@ mod tests {
                         Height::new(0, client_consensus_state_height),
                     )
                     .with_connection(cid, conn_end)
-                    .with_port_capability(msg_chan_ack.port_id().clone())
+                    .with_port_capability(msg_chan_ack.port_id.clone())
                     .with_channel(
-                        msg_chan_ack.port_id().clone(),
-                        msg_chan_ack.channel_id().clone(),
+                        msg_chan_ack.port_id.clone(),
+                        msg_chan_ack.channel_id.clone(),
                         chan_end,
                     ),
                 msg: ChannelMsg::ChannelOpenAck(msg_chan_ack),

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -18,18 +18,18 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let mut channel_end = ctx.channel_end(&(msg.port_id().clone(), msg.channel_id().clone()))?;
+    let mut channel_end = ctx.channel_end(&(msg.port_id.clone(), msg.channel_id.clone()))?;
 
     // Validate that the channel end is in a state where it can be confirmed.
     if !channel_end.state_matches(&State::TryOpen) {
         return Err(Error::invalid_channel_state(
-            msg.channel_id().clone(),
+            msg.channel_id.clone(),
             channel_end.state,
         ));
     }
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id().clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id)?;
 
     // An OPEN IBC connection running on the local (host) chain should exist.
     if channel_end.connection_hops().len() != 1 {
@@ -51,7 +51,7 @@ pub(crate) fn process(
     // 1. Setup: build the Channel as we expect to find it on the other party.
 
     let expected_counterparty =
-        Counterparty::new(msg.port_id().clone(), Some(msg.channel_id().clone()));
+        Counterparty::new(msg.port_id.clone(), Some(msg.channel_id.clone()));
 
     let connection_counterparty = conn.counterparty();
     let ccid = connection_counterparty.connection_id().ok_or_else(|| {
@@ -70,11 +70,11 @@ pub(crate) fn process(
     //2. Verify proofs
     verify_channel_proofs(
         ctx,
-        msg.proofs().height(),
+        msg.proofs.height(),
         &channel_end,
         &conn,
         &expected_channel_end,
-        msg.proofs(),
+        &msg.proofs,
     )
     .map_err(Error::chan_open_confirm_proof_verification)?;
 
@@ -84,15 +84,15 @@ pub(crate) fn process(
     channel_end.set_state(State::Open);
 
     let result = ChannelResult {
-        port_id: msg.port_id().clone(),
-        channel_id: msg.channel_id().clone(),
+        port_id: msg.port_id.clone(),
+        channel_id: msg.channel_id.clone(),
         channel_id_state: ChannelIdState::Reused,
         channel_cap,
         channel_end,
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id().clone()),
+        channel_id: Some(msg.channel_id.clone()),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenConfirmChannel(event_attributes.into()));
@@ -157,8 +157,8 @@ mod tests {
             State::TryOpen,
             Order::default(),
             Counterparty::new(
-                msg_chan_confirm.port_id().clone(),
-                Some(msg_chan_confirm.channel_id().clone()),
+                msg_chan_confirm.port_id.clone(),
+                Some(msg_chan_confirm.channel_id.clone()),
             ),
             vec![conn_id.clone()],
             Version::default(),
@@ -169,10 +169,10 @@ mod tests {
             ctx: context
                 .with_client(&client_id, Height::new(0, client_consensus_state_height))
                 .with_connection(conn_id, conn_end)
-                .with_port_capability(msg_chan_confirm.port_id().clone())
+                .with_port_capability(msg_chan_confirm.port_id.clone())
                 .with_channel(
-                    msg_chan_confirm.port_id().clone(),
-                    msg_chan_confirm.channel_id().clone(),
+                    msg_chan_confirm.port_id.clone(),
+                    msg_chan_confirm.channel_id.clone(),
                     chan_end,
                 ),
             msg: ChannelMsg::ChannelOpenConfirm(msg_chan_confirm),

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -23,7 +23,7 @@ pub(crate) fn process(
     // Validate that the channel end is in a state where it can be confirmed.
     if !channel_end.state_matches(&State::TryOpen) {
         return Err(Error::invalid_channel_state(
-            msg.channel_id.clone(),
+            msg.channel_id,
             channel_end.state,
         ));
     }
@@ -92,7 +92,7 @@ pub(crate) fn process(
     };
 
     let event_attributes = Attributes {
-        channel_id: Some(msg.channel_id.clone()),
+        channel_id: Some(msg.channel_id),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenConfirmChannel(event_attributes.into()));

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -115,8 +115,8 @@ mod tests {
 
         let init_conn_end = ConnectionEnd::new(
             ConnectionState::Init,
-            msg_conn_init.client_id().clone(),
-            msg_conn_init.counterparty().clone(),
+            msg_conn_init.client_id.clone(),
+            msg_conn_init.counterparty.clone(),
             get_compatible_versions(),
             msg_conn_init.delay_period,
         );

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -60,7 +60,7 @@ pub(crate) fn process(
     output.log("success: no channel found");
 
     let result = ChannelResult {
-        port_id: msg.port_id.clone(),
+        port_id: msg.port_id,
         channel_id: chan_id.clone(),
         channel_end: new_channel_end,
         channel_id_state: ChannelIdState::Generated,

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -18,24 +18,24 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id().clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id)?;
 
-    if msg.channel().connection_hops().len() != 1 {
+    if msg.channel.connection_hops().len() != 1 {
         return Err(Error::invalid_connection_hops_length(
             1,
-            msg.channel().connection_hops().len(),
+            msg.channel.connection_hops().len(),
         ));
     }
 
     // An IBC connection running on the local (host) chain should exist.
-    let conn = ctx.connection_end(&msg.channel().connection_hops()[0])?;
+    let conn = ctx.connection_end(&msg.channel.connection_hops()[0])?;
     let get_versions = conn.versions();
     let version = match get_versions.as_slice() {
         [version] => version,
         _ => return Err(Error::invalid_version_length_connection()),
     };
 
-    let channel_feature = msg.channel().ordering().to_string();
+    let channel_feature = msg.channel.ordering().to_string();
     if !version.is_supported_feature(channel_feature) {
         return Err(Error::channel_feature_not_suported_by_connection());
     }
@@ -51,16 +51,16 @@ pub(crate) fn process(
 
     let new_channel_end = ChannelEnd::new(
         State::Init,
-        *msg.channel().ordering(),
-        msg.channel().counterparty().clone(),
-        msg.channel().connection_hops().clone(),
-        msg.channel().version().clone(),
+        *msg.channel.ordering(),
+        msg.channel.counterparty().clone(),
+        msg.channel.connection_hops().clone(),
+        msg.channel.version().clone(),
     );
 
     output.log("success: no channel found");
 
     let result = ChannelResult {
-        port_id: msg.port_id().clone(),
+        port_id: msg.port_id.clone(),
         channel_id: chan_id.clone(),
         channel_end: new_channel_end,
         channel_id_state: ChannelIdState::Generated,
@@ -146,7 +146,7 @@ mod tests {
                     .with_port_capability(
                         MsgChannelOpenInit::try_from(get_dummy_raw_msg_chan_open_init())
                             .unwrap()
-                            .port_id()
+                            .port_id
                             .clone(),
                     ),
                 msg: ChannelMsg::ChannelOpenInit(msg_chan_init),
@@ -177,7 +177,7 @@ mod tests {
                     let msg_init = test.msg.clone();
 
                     if let ChannelMsg::ChannelOpenInit(msg_init) = msg_init {
-                        assert_eq!(res.port_id.clone(), msg_init.port_id().clone());
+                        assert_eq!(res.port_id.clone(), msg_init.port_id.clone());
                     }
 
                     for e in proto_output.events.iter() {

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -146,8 +146,7 @@ mod tests {
                     .with_port_capability(
                         MsgChannelOpenInit::try_from(get_dummy_raw_msg_chan_open_init())
                             .unwrap()
-                            .port_id
-                            .clone(),
+                            .port_id,
                     ),
                 msg: ChannelMsg::ChannelOpenInit(msg_chan_init),
                 want_pass: true,

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -20,9 +20,9 @@ pub(crate) fn process(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end (if any) and validate it against the message.
-    let (mut new_channel_end, channel_id) = match msg.previous_channel_id() {
+    let (mut new_channel_end, channel_id) = match &msg.previous_channel_id {
         Some(prev_id) => {
-            let old_channel_end = ctx.channel_end(&(msg.port_id().clone(), prev_id.clone()))?;
+            let old_channel_end = ctx.channel_end(&(msg.port_id.clone(), prev_id.clone()))?;
 
             // Validate that existing channel end matches with the one we're trying to establish.
             if old_channel_end.state_matches(&State::Init)
@@ -45,7 +45,7 @@ pub(crate) fn process(
                 *msg.channel.ordering(),
                 msg.channel.counterparty().clone(),
                 msg.channel.connection_hops().clone(),
-                msg.counterparty_version().clone(),
+                msg.counterparty_version.clone(),
             );
 
             // Channel identifier construction.
@@ -69,7 +69,7 @@ pub(crate) fn process(
         ));
     }
 
-    let conn = ctx.connection_end(&msg.channel().connection_hops()[0])?;
+    let conn = ctx.connection_end(&msg.channel.connection_hops()[0])?;
     if !conn.state_matches(&ConnectionState::Open) {
         return Err(Error::connection_not_open(
             msg.channel.connection_hops()[0].clone(),
@@ -82,22 +82,22 @@ pub(crate) fn process(
         _ => return Err(Error::invalid_version_length_connection()),
     };
 
-    let channel_feature = msg.channel().ordering().to_string();
+    let channel_feature = msg.channel.ordering().to_string();
     if !version.is_supported_feature(channel_feature) {
         return Err(Error::channel_feature_not_suported_by_connection());
     }
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id().clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id.clone())?;
 
     // Proof verification in two steps:
     // 1. Setup: build the Channel as we expect to find it on the other party.
     //      the port should be identical with the port we're using; the channel id should not be set
     //      since the counterparty cannot know yet which ID did we choose.
-    let expected_counterparty = Counterparty::new(msg.port_id().clone(), None);
+    let expected_counterparty = Counterparty::new(msg.port_id.clone(), None);
     let counterparty = conn.counterparty();
     let ccid = counterparty.connection_id().ok_or_else(|| {
-        Error::undefined_connection_counterparty(msg.channel().connection_hops()[0].clone())
+        Error::undefined_connection_counterparty(msg.channel.connection_hops()[0].clone())
     })?;
     let expected_connection_hops = vec![ccid.clone()];
 
@@ -107,17 +107,17 @@ pub(crate) fn process(
         *msg.channel.ordering(),
         expected_counterparty,
         expected_connection_hops,
-        msg.counterparty_version().clone(),
+        msg.counterparty_version.clone(),
     );
 
     // 2. Actual proofs are verified now.
     verify_channel_proofs(
         ctx,
-        msg.proofs().height(),
+        msg.proofs.height(),
         &new_channel_end,
         &conn,
         &expected_channel_end,
-        msg.proofs(),
+        &msg.proofs,
     )?;
 
     output.log("success: channel open try ");
@@ -126,7 +126,7 @@ pub(crate) fn process(
     new_channel_end.set_state(State::TryOpen);
 
     let result = ChannelResult {
-        port_id: msg.port_id().clone(),
+        port_id: msg.port_id.clone(),
         channel_cap,
         channel_id_state: if matches!(msg.previous_channel_id, None) {
             ChannelIdState::Generated
@@ -272,7 +272,7 @@ mod tests {
                 msg: ChannelMsg::ChannelOpenTry(msg_vanilla.clone()),
                 want_pass: false,
                 match_error: {
-                    let connection_id = msg.channel().connection_hops()[0].clone();
+                    let connection_id = msg.channel.connection_hops()[0].clone();
                     Box::new(move |e| match e {
                         error::ErrorDetail::Ics03Connection(e) => {
                             assert_eq!(

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -88,7 +88,7 @@ pub(crate) fn process(
     }
 
     // Channel capabilities
-    let channel_cap = ctx.authenticated_capability(&msg.port_id.clone())?;
+    let channel_cap = ctx.authenticated_capability(&msg.port_id)?;
 
     // Proof verification in two steps:
     // 1. Setup: build the Channel as we expect to find it on the other party.

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -77,7 +77,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
 
     verify_packet_recv_proofs(
         ctx,
-        msg.proofs().height(),
+        msg.proofs.height(),
         packet,
         &connection_end,
         &msg.proofs,

--- a/modules/src/core/ics04_channel/handler/timeout.rs
+++ b/modules/src/core/ics04_channel/handler/timeout.rs
@@ -99,11 +99,11 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgTimeout) -> HandlerResult<Packet
         }
         verify_next_sequence_recv(
             ctx,
-            msg.proofs().height(),
+            msg.proofs.height(),
             &connection_end,
             packet.clone(),
             msg.next_sequence_recv,
-            &msg.proofs.clone(),
+            &msg.proofs,
         )?;
 
         source_channel_end.state = State::Closed;
@@ -116,10 +116,10 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgTimeout) -> HandlerResult<Packet
     } else {
         verify_packet_receipt_absence(
             ctx,
-            msg.proofs().height(),
+            msg.proofs.height(),
             &connection_end,
             packet.clone(),
-            &msg.proofs().clone(),
+            &msg.proofs,
         )?;
 
         PacketResult::Timeout(TimeoutPacketResult {

--- a/modules/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -79,11 +79,11 @@ pub fn process(
 
     verify_channel_proofs(
         ctx,
-        msg.proofs().height(),
+        msg.proofs.height(),
         &source_channel_end,
         &connection_end,
         &expected_channel_end,
-        &msg.proofs.clone(),
+        &msg.proofs,
     )?;
 
     let result = if source_channel_end.order_matches(&Order::Ordered) {
@@ -95,11 +95,11 @@ pub fn process(
         }
         verify_next_sequence_recv(
             ctx,
-            msg.proofs().height(),
+            msg.proofs.height(),
             &connection_end,
             packet.clone(),
             msg.next_sequence_recv,
-            &msg.proofs.clone(),
+            &msg.proofs,
         )?;
 
         PacketResult::Timeout(TimeoutPacketResult {
@@ -111,10 +111,10 @@ pub fn process(
     } else {
         verify_packet_receipt_absence(
             ctx,
-            msg.proofs().height(),
+            msg.proofs.height(),
             &connection_end,
             packet.clone(),
-            &msg.proofs.clone(),
+            &msg.proofs,
         )?;
 
         PacketResult::Timeout(TimeoutPacketResult {

--- a/modules/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -37,14 +37,6 @@ impl MsgAcknowledgement {
             signer,
         }
     }
-
-    pub fn acknowledgement(&self) -> &Vec<u8> {
-        &self.acknowledgement
-    }
-
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
 
 impl Msg for MsgAcknowledgement {

--- a/modules/src/core/ics04_channel/msgs/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_close_confirm.rs
@@ -33,17 +33,6 @@ impl MsgChannelCloseConfirm {
             signer,
         }
     }
-
-    /// Getter: borrow the `port_id` from this message.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
-    }
-    pub fn channel_id(&self) -> &ChannelId {
-        &self.channel_id
-    }
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
 
 impl Msg for MsgChannelCloseConfirm {

--- a/modules/src/core/ics04_channel/msgs/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_close_init.rs
@@ -29,14 +29,6 @@ impl MsgChannelCloseInit {
             signer,
         }
     }
-
-    /// Getter: borrow the `port_id` from this message.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
-    }
-    pub fn channel_id(&self) -> &ChannelId {
-        &self.channel_id
-    }
 }
 
 impl Msg for MsgChannelCloseInit {

--- a/modules/src/core/ics04_channel/msgs/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_ack.rs
@@ -42,26 +42,6 @@ impl MsgChannelOpenAck {
             signer,
         }
     }
-
-    /// Getter: borrow the `port_id` from this message.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
-    }
-    pub fn channel_id(&self) -> &ChannelId {
-        &self.channel_id
-    }
-
-    pub fn counterparty_channel_id(&self) -> &ChannelId {
-        &self.counterparty_channel_id
-    }
-
-    pub fn counterparty_version(&self) -> &Version {
-        &self.counterparty_version
-    }
-
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
 
 impl Msg for MsgChannelOpenAck {

--- a/modules/src/core/ics04_channel/msgs/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_confirm.rs
@@ -33,19 +33,6 @@ impl MsgChannelOpenConfirm {
     }
 }
 
-impl MsgChannelOpenConfirm {
-    /// Getter: borrow the `port_id` from this message.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
-    }
-    pub fn channel_id(&self) -> &ChannelId {
-        &self.channel_id
-    }
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
-}
-
 impl Msg for MsgChannelOpenConfirm {
     type ValidationError = Error;
     type Raw = RawMsgChannelOpenConfirm;

--- a/modules/src/core/ics04_channel/msgs/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_init.rs
@@ -28,16 +28,6 @@ impl MsgChannelOpenInit {
             signer,
         }
     }
-
-    /// Getter: borrow the `port_id` from this message.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
-    }
-
-    /// Getter: borrow the `channelEnd` from this message.
-    pub fn channel(&self) -> &ChannelEnd {
-        &self.channel
-    }
 }
 
 impl Msg for MsgChannelOpenInit {

--- a/modules/src/core/ics04_channel/msgs/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/msgs/chan_open_try.rs
@@ -46,24 +46,8 @@ impl MsgChannelOpenTry {
             signer,
         }
     }
-
-    /// Getter: borrow the `port_id` from this message.
-    pub fn port_id(&self) -> &PortId {
-        &self.port_id
-    }
-    pub fn previous_channel_id(&self) -> &Option<ChannelId> {
-        &self.previous_channel_id
-    }
-    pub fn counterparty_version(&self) -> &Version {
-        &self.counterparty_version
-    }
-    pub fn channel(&self) -> &ChannelEnd {
-        &self.channel
-    }
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
+
 impl Msg for MsgChannelOpenTry {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenTry;
@@ -77,7 +61,7 @@ impl Msg for MsgChannelOpenTry {
     }
 
     fn validate_basic(&self) -> Result<(), ValidationError> {
-        match self.channel().counterparty().channel_id() {
+        match self.channel.counterparty().channel_id() {
             None => Err(ValidationError::invalid_counterparty_channel_id()),
             Some(_c) => Ok(()),
         }

--- a/modules/src/core/ics04_channel/msgs/recv_packet.rs
+++ b/modules/src/core/ics04_channel/msgs/recv_packet.rs
@@ -30,10 +30,6 @@ impl MsgRecvPacket {
             signer,
         }
     }
-
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
 
 impl Msg for MsgRecvPacket {

--- a/modules/src/core/ics04_channel/msgs/timeout.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout.rs
@@ -37,10 +37,6 @@ impl MsgTimeout {
             signer,
         }
     }
-
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
 
 impl Msg for MsgTimeout {

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -36,10 +36,6 @@ impl MsgTimeoutOnClose {
             signer,
         }
     }
-
-    pub fn proofs(&self) -> &Proofs {
-        &self.proofs
-    }
 }
 
 impl Msg for MsgTimeoutOnClose {

--- a/modules/src/core/ics26_routing/handler.rs
+++ b/modules/src/core/ics26_routing/handler.rs
@@ -279,7 +279,7 @@ mod tests {
             res
         );
 
-        ctx.add_port(msg_chan_init.port_id().clone());
+        ctx.add_port(msg_chan_init.port_id.clone());
 
         // Figure out the ID of the client that was just created.
         let mut events = res.unwrap().events;


### PR DESCRIPTION

Closes: https://github.com/informalsystems/ibc-rs/issues/631

## Description

Remove getters from  client, connection and channel messages
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).