### PR TITLE
`max_expected_time_per_block` in `ChannelReader` returns `Result`

### DIFF
--- a/.changelog/unreleased/improvements/ibc/1864-delay-height-error.md
+++ b/.changelog/unreleased/improvements/ibc/1864-delay-height-error.md
@@ -1,0 +1,2 @@
+- max_expected_time_per_block in ChannelReader returns Result
+  ([#1864](https://github.com/informalsystems/ibc-rs/issues/1864))

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -451,7 +451,9 @@ fn verify_delay_passed(
         .map_err(|_| Error::processed_height_not_found(client_id.clone(), height))?;
 
     let delay_period_time = connection_end.delay_period();
-    let delay_period_height = ctx.block_delay(delay_period_time);
+    let delay_period_height = ctx
+        .block_delay(delay_period_time)
+        .map_err(|_| Error::delay_height_error())?;
 
     ClientState::verify_delay_passed(
         current_timestamp,

--- a/modules/src/clients/ics07_tendermint/error.rs
+++ b/modules/src/clients/ics07_tendermint/error.rs
@@ -245,6 +245,9 @@ define_error! {
                     e.client_id, e.height)
             },
 
+        DelayHeightError
+            |_| { "getting the delay height failed" },
+
         Ics23Error
             [ Ics23Error ]
             | _ | { "ics23 commitment error" },

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -96,16 +96,18 @@ pub trait ChannelReader {
     fn channel_counter(&self) -> Result<u64, Error>;
 
     /// Returns the maximum expected time per block
-    fn max_expected_time_per_block(&self) -> Duration;
+    fn max_expected_time_per_block(&self) -> Result<Duration, Error>;
 
-    fn block_delay(&self, delay_period_time: Duration) -> u64 {
-        let expected_time_per_block = self.max_expected_time_per_block();
+    fn block_delay(&self, delay_period_time: Duration) -> Result<u64, Error> {
+        let expected_time_per_block = self.max_expected_time_per_block()?;
         if expected_time_per_block.is_zero() {
-            return 0;
+            return Ok(0);
         }
 
-        FloatCore::ceil(delay_period_time.as_secs_f64() / expected_time_per_block.as_secs_f64())
-            as u64
+        Ok(
+            FloatCore::ceil(delay_period_time.as_secs_f64() / expected_time_per_block.as_secs_f64())
+                as u64,
+        )
     }
 }
 

--- a/modules/src/mock/context.rs
+++ b/modules/src/mock/context.rs
@@ -741,8 +741,8 @@ impl ChannelReader for MockContext {
         Ok(self.channel_ids_counter)
     }
 
-    fn max_expected_time_per_block(&self) -> Duration {
-        self.block_time
+    fn max_expected_time_per_block(&self) -> Result<Duration, Ics04Error> {
+        Ok(self.block_time)
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1864

## Description
`max_expected_time_per_block` and `block_delay` return `Result`


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).