### PR TITLE
Update safe-regex to v2.0.5 for no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "safe-regex"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954950893b0d83c719cb5325bf3941bae7b1c6590d923c70f78bdfed101179b5"
+checksum = "a15289bf322e0673d52756a18194167f2378ec1a15fe884af6e2d2cb934822b0"
 dependencies = [
  "safe-regex-macro",
 ]

--- a/ci/no-std-check/Cargo.lock
+++ b/ci/no-std-check/Cargo.lock
@@ -1466,7 +1466,8 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 [[package]]
 name = "safe-proc-macro2"
 version = "1.0.36"
-source = "git+https://github.com/informalsystems/safe-regex.git?branch=no-std#32fcb90914cd1bc6f0958cc200aa0c65936051c4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814c536dcd27acf03296c618dab7ad62d28e70abd7ba41d3f34a2ce707a2c666"
 dependencies = [
  "unicode-xid",
 ]
@@ -1474,23 +1475,26 @@ dependencies = [
 [[package]]
 name = "safe-quote"
 version = "1.0.15"
-source = "git+https://github.com/informalsystems/safe-regex.git?branch=no-std#32fcb90914cd1bc6f0958cc200aa0c65936051c4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
 dependencies = [
  "safe-proc-macro2",
 ]
 
 [[package]]
 name = "safe-regex"
-version = "0.2.4"
-source = "git+https://github.com/informalsystems/safe-regex.git?branch=no-std#32fcb90914cd1bc6f0958cc200aa0c65936051c4"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15289bf322e0673d52756a18194167f2378ec1a15fe884af6e2d2cb934822b0"
 dependencies = [
  "safe-regex-macro",
 ]
 
 [[package]]
 name = "safe-regex-compiler"
-version = "0.2.4"
-source = "git+https://github.com/informalsystems/safe-regex.git?branch=no-std#32fcb90914cd1bc6f0958cc200aa0c65936051c4"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba76fae590a2aa665279deb1f57b5098cbace01a0c5e60e262fcf55f7c51542"
 dependencies = [
  "safe-proc-macro2",
  "safe-quote",
@@ -1498,8 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "safe-regex-macro"
-version = "0.2.3"
-source = "git+https://github.com/informalsystems/safe-regex.git?branch=no-std#32fcb90914cd1bc6f0958cc200aa0c65936051c4"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c2e96b5c03f158d1b16ba79af515137795f4ad4e8de3f790518aae91f1d127"
 dependencies = [
  "safe-proc-macro2",
  "safe-regex-compiler",

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -35,8 +35,3 @@ substrate-std = [
 tendermint                        = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
 tendermint-proto                  = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
 tendermint-light-client-verifier  = { git = "https://github.com/informalsystems/tendermint-rs", branch = "v0.23.x" }
-safe-regex          = { git = "https://github.com/informalsystems/safe-regex.git", branch = "no-std" }
-safe-regex-macro    = { git = "https://github.com/informalsystems/safe-regex.git", branch = "no-std" }
-safe-regex-compiler = { git = "https://github.com/informalsystems/safe-regex.git", branch = "no-std" }
-safe-quote          = { git = "https://github.com/informalsystems/safe-regex.git", branch = "no-std" }
-safe-proc-macro2    = { git = "https://github.com/informalsystems/safe-regex.git", branch = "no-std" }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -37,7 +37,7 @@ tracing = { version = "0.1.30", default-features = false }
 prost = { version = "0.9", default-features = false }
 prost-types = { version = "0.9", default-features = false }
 bytes = { version = "1.1.0", default-features = false }
-safe-regex = { version = "0.2.4", default-features = false }
+safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
 sha2 = { version = "0.10.1", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }


### PR DESCRIPTION
Closes: #1858

## Description

A new version of `safe-regex` has been released with no_std support. With this, we only need to wait for new version of tendermint-rs to be released to have full no_std support on ibc-rs without needing patches.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).