### PR TITLE
Clean up packets clearing logic in `RelayPath`

### DIFF
--- a/.changelog/unreleased/bug-fixes/relayer/1872-clear-packets.md
+++ b/.changelog/unreleased/bug-fixes/relayer/1872-clear-packets.md
@@ -1,1 +1,2 @@
-- Fixed clear_on_start bug ([#1872](https://github.com/informalsystems/ibc-rs/issues/1872))
+- Fixed bug where Hermes cleared packets at startup, despite
+ `clear_on_start = false` ([#1872](https://github.com/informalsystems/ibc-rs/issues/1872))

--- a/.changelog/unreleased/bug-fixes/relayer/1872-clear-packets.md
+++ b/.changelog/unreleased/bug-fixes/relayer/1872-clear-packets.md
@@ -1,0 +1,1 @@
+- Fixed clear_on_start bug ([#1872](https://github.com/informalsystems/ibc-rs/issues/1872))

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -1,6 +1,5 @@
 use alloc::collections::BTreeMap as HashMap;
 use alloc::collections::VecDeque;
-use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Instant;
 
@@ -51,7 +50,6 @@ use crate::link::pending::PendingTxs;
 use crate::link::relay_sender::{AsyncReply, SubmitReply};
 use crate::link::relay_summary::RelaySummary;
 use crate::link::{pending, relay_sender};
-use crate::util::lock::LockExt;
 use crate::util::queue::Queue;
 
 const MAX_RETRIES: usize = 5;
@@ -64,11 +62,6 @@ pub struct RelayPath<ChainA: ChainHandle, ChainB: ChainHandle> {
 
     dst_channel_id: ChannelId,
     dst_port_id: PortId,
-
-    // Marks whether this path has already cleared pending packets.
-    // Packets should be cleared once (at startup), then this
-    // flag turns to `false`.
-    clear_packets: Arc<RwLock<bool>>,
 
     // Operational data, targeting both the source and destination chain.
     // These vectors of operational data are ordered decreasingly by
@@ -122,7 +115,6 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
             dst_channel_id: dst_channel_id.clone(),
             dst_port_id: dst_port_id.clone(),
 
-            clear_packets: Arc::new(RwLock::new(true)),
             src_operational_data: Queue::new(),
             dst_operational_data: Queue::new(),
 
@@ -309,34 +301,18 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
         Err(LinkError::old_packet_clearing_failed())
     }
 
-    fn should_clear_packets(&self) -> bool {
-        *self.clear_packets.acquire_read()
-    }
+    /// Clears any packets that were sent before `height`.
+    pub fn schedule_packet_clearing(&self, height: Option<Height>) -> Result<(), LinkError> {
+        let span = span!(Level::DEBUG, "clear");
+        let _enter = span.enter();
 
-    /// Clears any packets that were sent before `height`, either if the `clear_packets` flag
-    /// is set or if clearing is forced by the caller.
-    pub fn schedule_packet_clearing(
-        &self,
-        height: Option<Height>,
-        force: bool,
-    ) -> Result<(), LinkError> {
-        if self.should_clear_packets() || force {
-            let span = span!(Level::DEBUG, "clear", f = ?force);
-            let _enter = span.enter();
+        let clear_height = height
+            .map(|h| h.decrement().map_err(|e| LinkError::decrement_height(h, e)))
+            .transpose()?;
 
-            // Disable further clearing of old packets by default.
-            // Clearing may still happen: upon new blocks, when `force = true`.
-            *self.clear_packets.acquire_write() = false;
+        self.relay_pending_packets(clear_height)?;
 
-            let clear_height = height
-                .map(|h| h.decrement().map_err(|e| LinkError::decrement_height(h, e)))
-                .transpose()?;
-
-            self.relay_pending_packets(clear_height)?;
-
-            debug!(height = ?clear_height, "done scheduling");
-        }
-
+        debug!(height = ?clear_height, "done scheduling");
         Ok(())
     }
 

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -148,16 +148,17 @@ fn handle_packet_cmd<ChainA: ChainHandle, ChainB: ChainHandle>(
             height,
             new_block: _,
         } => {
-            let do_clear_packet =
-                should_clear_packets(is_first_run, clear_on_start, clear_interval, height);
-
-            // Schedule the clearing of pending packets. This may happen once at start,
-            // and may be _forced_ at predefined block intervals.
-            link.a_to_b
-                .schedule_packet_clearing(Some(height), do_clear_packet)
+            // Decide if packet clearing should be scheduled.
+            // Packet clearing may happen once at start,
+            // and then at predefined block intervals.
+            if should_clear_packets(is_first_run, clear_on_start, clear_interval, height) {
+                link.a_to_b.schedule_packet_clearing(Some(height))
+            } else {
+                Ok(())
+            }
         }
 
-        WorkerCmd::ClearPendingPackets => link.a_to_b.schedule_packet_clearing(None, true),
+        WorkerCmd::ClearPendingPackets => link.a_to_b.schedule_packet_clearing(None),
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1872 

## Description


The bug reported in #1872 exposed a regression: the a bug is that the `clear_on_start` option from Hermes config is ignored, and Hermes always clears packets when it starts up.

The bug appeared because we introduced duplicate logic for keeping track of the `clear_on_start` toggle:

1. we kept track of this toggle in the RelayPath, which was _incorrectly_ initialized to `true` https://github.com/informalsystems/ibc-rs/blob/1a3c1d2c50a8f207c93cce4b19b267ca6d7f3cfb/relayer/src/link/relay_path.rs#L125

2. we kept track of this toggle additionally in the packet command worker task, which was _correctly_ initialized with the `clear_on_start` value configured in the Hermes config.toml
https://github.com/informalsystems/ibc-rs/blob/b65baa9456b25500c49bf34896e79d2939c2ef65/relayer/src/worker.rs#L114-L121

The fix in this PR is to remove the logic from (1) RelayPath, and proposes to keep only the logic from (2) packet command worker. The nice benefit of adopting this fix is that it also simplifies slightly the code in RelayPath (which is one of the most complex parts of the relayer).


## How to test this PR

### Reproduce the problem
First, please follow the "Steps to Reproduce" from the original issue #1872 to confirm you can reproduce the problem on your local setup.


### Test the solution from the present PR

#### Test that disabling `clear_on_start` works

1. Setup a two chain network using `gm`. Suppose the two networks and `ibc-0` and `ibc-1`.
2. Setup a `channel-0` between the two networks.
3. Trigger and `ft-transfer` on `channel-0` of `ibc-0`
    - >  ./target/debug/hermes --json tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 100 -d samoleans -t 1800 -n 1
    - __take note of the packet sequence number provided in the output__ for example:
    - > "sequence":9
4. Configure `clear_on_start` to be `false` in the config.toml of Hermes.
    - Make sure your log level is set to `log_level = 'debug'`.
    - Also set `clear_interval = 0` to completely disable periodic packet clearing.
5. Do `hermes start`.
   - Notice the log output and it should be visible that Hermes will __not__ clear the outstanding packets.
   - Hermes should not have any activity.
6. In a parallel terminal, trigger and `ft-transfer` using a second Hermes instance (similar to step 3)
    - >  ./target/debug/hermes --json tx raw ft-transfer ibc-1 ibc-0 transfer channel-0 100 -d samoleans -t 1800 -n 1
    - __take note of the packet sequence number provided in the output__:
    - > "sequence":10
7. In the first terminal where Hermes `start` is running, observe the log output, we should now notice some Hermes activity
    - the important part is we should see that the second packet (sequence number 10) is being relayed.
    - the first packet (sequence number 9 triggered at step 3) should remain unrelayed.
    - example log output
    - > 2022-02-15T10:20:02.962841Z DEBUG ThreadId(22) packet_cmd{src_chain=ibc-0 src_port=transfer src_channel=channel-0 dst_chain=ibc-1}:generate{id=tiLSMMUOjC}: /ibc.core.channel.v1.MsgRecvPacket from SendPacketEv(SendPacket - h:0-30551, seq:10, path:channel-0/transfer->channel-0/transfer, toh:0-0, tos:Timestamp(2022-02-15T10:49:52.478069Z)))

#### Test that enabling `clear_on_start` works

Redo the test from above, with the following adjustments:

- at step 4: Configure `clear_on_start` to be `true` (not `false`)
- at step 5: You should see that Hermes _has_ activity and should be relaying the old packet (triggered at step 3).

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).