### PR TITLE
Allow channel order to be overridden in integration tests

### DIFF
--- a/tools/integration-test/src/bootstrap/binary/channel.rs
+++ b/tools/integration-test/src/bootstrap/binary/channel.rs
@@ -28,6 +28,7 @@ pub fn bootstrap_channel_with_chains<ChainA: ChainHandle, ChainB: ChainHandle>(
     chains: &ConnectedChains<ChainA, ChainB>,
     port_a: &PortId,
     port_b: &PortId,
+    order: Order,
     bootstrap_with_random_ids: bool,
 ) -> Result<ConnectedChannel<ChainA, ChainB>, Error> {
     let channel = bootstrap_channel(
@@ -35,6 +36,7 @@ pub fn bootstrap_channel_with_chains<ChainA: ChainHandle, ChainB: ChainHandle>(
         &chains.client_a_to_b,
         &DualTagged::new(port_a),
         &DualTagged::new(port_b),
+        order,
         bootstrap_with_random_ids,
     )?;
 
@@ -50,6 +52,7 @@ pub fn bootstrap_channel<ChainA: ChainHandle, ChainB: ChainHandle>(
     client_a_to_b: &ForeignClient<ChainB, ChainA>,
     port_a: &TaggedPortIdRef<ChainA, ChainB>,
     port_b: &TaggedPortIdRef<ChainB, ChainA>,
+    order: Order,
     bootstrap_with_random_ids: bool,
 ) -> Result<ConnectedChannel<ChainA, ChainB>, Error> {
     let connection = bootstrap_connection(client_b_to_a, client_a_to_b, bootstrap_with_random_ids)?;
@@ -60,6 +63,7 @@ pub fn bootstrap_channel<ChainA: ChainHandle, ChainB: ChainHandle>(
         connection,
         port_a,
         port_b,
+        order,
         bootstrap_with_random_ids,
     )
 }
@@ -73,6 +77,7 @@ pub fn bootstrap_channel_with_connection<ChainA: ChainHandle, ChainB: ChainHandl
     connection: ConnectedConnection<ChainA, ChainB>,
     port_a: &TaggedPortIdRef<ChainA, ChainB>,
     port_b: &TaggedPortIdRef<ChainB, ChainA>,
+    order: Order,
     bootstrap_with_random_ids: bool,
 ) -> Result<ConnectedChannel<ChainA, ChainB>, Error> {
     if bootstrap_with_random_ids {
@@ -82,7 +87,7 @@ pub fn bootstrap_channel_with_connection<ChainA: ChainHandle, ChainB: ChainHandl
 
     let channel = Channel::new(
         connection.connection.clone(),
-        Order::Unordered,
+        order,
         port_a.0.clone(),
         port_b.0.clone(),
         None,

--- a/tools/integration-test/src/framework/overrides.rs
+++ b/tools/integration-test/src/framework/overrides.rs
@@ -2,6 +2,7 @@
    Constructs for implementing overrides for test cases.
 */
 
+use ibc::core::ics04_channel::channel::Order;
 use ibc::core::ics24_host::identifier::PortId;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::Config;
@@ -14,7 +15,7 @@ use crate::error::Error;
 use crate::framework::base::HasOverrides;
 use crate::framework::base::TestConfigOverride;
 use crate::framework::binary::chain::{RelayerConfigOverride, SupervisorOverride};
-use crate::framework::binary::channel::PortsOverride;
+use crate::framework::binary::channel::{ChannelOrderOverride, PortsOverride};
 use crate::framework::binary::node::NodeConfigOverride;
 use crate::types::config::TestConfig;
 
@@ -108,6 +109,10 @@ pub trait TestOverrides {
     fn channel_port_b(&self) -> PortId {
         PortId::transfer()
     }
+
+    fn channel_order(&self) -> Order {
+        Order::Unordered
+    }
 }
 
 impl<Test: TestOverrides> HasOverrides for Test {
@@ -153,5 +158,11 @@ impl<Test: TestOverrides> PortsOverride for Test {
 
     fn channel_port_b(&self) -> PortId {
         TestOverrides::channel_port_b(self)
+    }
+}
+
+impl<Test: TestOverrides> ChannelOrderOverride for Test {
+    fn channel_order(&self) -> Order {
+        TestOverrides::channel_order(self)
     }
 }

--- a/tools/integration-test/src/prelude.rs
+++ b/tools/integration-test/src/prelude.rs
@@ -4,6 +4,7 @@
 
 pub use core::time::Duration;
 pub use eyre::eyre;
+pub use ibc::core::ics04_channel::channel::Order;
 pub use ibc::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
 pub use ibc_relayer::chain::handle::ChainHandle;
 pub use ibc_relayer::config::Config;

--- a/tools/integration-test/src/tests/client_expiration.rs
+++ b/tools/integration-test/src/tests/client_expiration.rs
@@ -298,7 +298,13 @@ impl BinaryChainTest for PacketExpirationTest {
             let _refresh_task_b = spawn_refresh_client(chains.client_a_to_b.clone())
                 .ok_or_else(|| eyre!("expect refresh task spawned"))?;
 
-            bootstrap_channel_with_chains(&chains, &PortId::transfer(), &PortId::transfer(), false)?
+            bootstrap_channel_with_chains(
+                &chains,
+                &PortId::transfer(),
+                &PortId::transfer(),
+                Order::Unordered,
+                false,
+            )?
         };
 
         wait_for_client_expiry();
@@ -419,6 +425,7 @@ impl BinaryChainTest for CreateOnExpiredClientTest {
             connection,
             &DualTagged::new(&PortId::transfer()),
             &DualTagged::new(&PortId::transfer()),
+            Order::Unordered,
             false,
         );
 


### PR DESCRIPTION
## Description

This can be merged to master so that it is easier to test ordered channel issues like #1835.

Note that this PR itself does not activate any ordered channel test. It only allow new tests to be written with the channel order overridden to `Order::Ordered`.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).