### PR TITLE
Nonallocating versions method

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/1880-nonallocating-verions-method.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/1880-nonallocating-verions-method.md
@@ -1,0 +1,1 @@
+- Changed `ConnectionEnd::versions` method to be non-allocating by having it return a `&[Version]` instead of `Vec<Version>`. ([#1880](https://github.com/informalsystems/ibc-rs/pull/1880))

--- a/modules/src/core/ics03_connection/connection.rs
+++ b/modules/src/core/ics03_connection/connection.rs
@@ -217,7 +217,7 @@ impl ConnectionEnd {
     }
 
     /// Getter for the list of versions in this connection end.
-    pub fn versions<'a>(&'a self) -> &'a [Version] {
+    pub fn versions(&self) -> &[Version] {
         &self.versions
     }
 

--- a/modules/src/core/ics03_connection/connection.rs
+++ b/modules/src/core/ics03_connection/connection.rs
@@ -217,8 +217,8 @@ impl ConnectionEnd {
     }
 
     /// Getter for the list of versions in this connection end.
-    pub fn versions(&self) -> Vec<Version> {
-        self.versions.clone()
+    pub fn versions<'a>(&'a self) -> &'a [Version] {
+        &self.versions
     }
 
     /// Getter for the counterparty.

--- a/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -35,7 +35,7 @@ pub(crate) fn process(
             Some(msg.connection_id.clone()), // Local connection id.
             ctx.commitment_prefix(),      // Local commitment prefix.
         ),
-        conn_end.versions(),
+        conn_end.versions().to_vec(),
         conn_end.delay_period(),
     );
 

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -30,7 +30,7 @@ pub(crate) fn process(
     // An IBC connection running on the local (host) chain should exist.
     let conn = ctx.connection_end(&msg.channel.connection_hops()[0])?;
     let get_versions = conn.versions();
-    let version = match get_versions.as_slice() {
+    let version = match get_versions {
         [version] => version,
         _ => return Err(Error::invalid_version_length_connection()),
     };

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -77,7 +77,7 @@ pub(crate) fn process(
     }
 
     let get_versions = conn.versions();
-    let version = match get_versions.as_slice() {
+    let version = match get_versions {
         [version] => version,
         _ => return Err(Error::invalid_version_length_connection()),
     };

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -891,7 +891,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
                 .query_compatible_versions()
                 .map_err(|e| ConnectionError::chain_query(self.src_chain().id(), e))?
         } else {
-            src_connection.versions()
+            src_connection.versions().to_vec()
         };
 
         // Get signer


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1880 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Changes `ConnectionEnd::versions` to be non-allocating by having it return a `&[Version]` instead of a `Vec<Version>`. 
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).