### PR TITLE
Disable config reload and throw a warning on receiving SIGHUP

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer-cli/1885-disable-config-reload.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer-cli/1885-disable-config-reload.md
@@ -1,0 +1,1 @@
+- Disable reloading of configuration upon receiving a SIGHUP signal. ([#1885](https://github.com/informalsystems/ibc-rs/issues/1885))

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -71,7 +71,7 @@ fn register_signals(tx_cmd: Sender<SupervisorCmd>) -> Result<(), io::Error> {
     std::thread::spawn(move || {
         for signal in &mut signals {
             match signal {
-                SIGHUP => warn!("configuration reloading via SIGHUP has been disabled and will be deprecated in the future"),
+                SIGHUP => warn!("configuration reloading via SIGHUP has been disabled. The signal handler will be removed in the future"),
                 SIGUSR1 => {
                     info!("Dumping state (triggered by SIGUSR1)");
 

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -9,7 +9,6 @@ use abscissa_core::{Command, Runnable};
 use crossbeam_channel::Sender;
 
 use ibc_relayer::chain::handle::{ChainHandle, ProdChainHandle};
-use ibc_relayer::config::reload::ConfigReload;
 use ibc_relayer::config::Config;
 use ibc_relayer::registry::SharedRegistry;
 use ibc_relayer::rest;
@@ -40,10 +39,8 @@ impl Runnable for StartCmd {
             });
 
         match crate::config::config_path() {
-            Some(config_path) => {
-                let reload =
-                    ConfigReload::new(config_path, config, supervisor_handle.sender.clone());
-                register_signals(reload, supervisor_handle.sender.clone()).unwrap_or_else(|e| {
+            Some(_) => {
+                register_signals(supervisor_handle.sender.clone()).unwrap_or_else(|e| {
                     warn!("failed to install signal handler: {}", e);
                 });
             }
@@ -61,7 +58,7 @@ impl Runnable for StartCmd {
 /// Register the SIGHUP and SIGUSR1 signals, and notify the supervisor.
 /// - [DEPRECATED] SIGHUP: Trigger a reload of the configuration.
 /// - SIGUSR1: Ask the supervisor to dump its state and print it to the console.
-fn register_signals(_reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Result<(), io::Error> {
+fn register_signals(tx_cmd: Sender<SupervisorCmd>) -> Result<(), io::Error> {
     use signal_hook::{consts::signal::*, iterator::Signals};
 
     let sigs = vec![

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -74,7 +74,7 @@ fn register_signals(_reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Res
     std::thread::spawn(move || {
         for signal in &mut signals {
             match signal {
-                SIGHUP => info!("configuration reloading via SIGHUP has been disabled and will be deprecated in the future"),
+                SIGHUP => warn!("configuration reloading via SIGHUP has been disabled and will be deprecated in the future"),
                 SIGUSR1 => {
                     info!("Dumping state (triggered by SIGUSR1)");
 

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -59,9 +59,9 @@ impl Runnable for StartCmd {
 }
 
 /// Register the SIGHUP and SIGUSR1 signals, and notify the supervisor.
-/// - SIGHUP: Trigger a reload of the configuration.
+/// - [DEPRECATED] SIGHUP: Trigger a reload of the configuration.
 /// - SIGUSR1: Ask the supervisor to dump its state and print it to the console.
-fn register_signals(reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Result<(), io::Error> {
+fn register_signals(_reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Result<(), io::Error> {
     use signal_hook::{consts::signal::*, iterator::Signals};
 
     let sigs = vec![
@@ -74,14 +74,7 @@ fn register_signals(reload: ConfigReload, tx_cmd: Sender<SupervisorCmd>) -> Resu
     std::thread::spawn(move || {
         for signal in &mut signals {
             match signal {
-                SIGHUP => {
-                    info!("reloading configuration (triggered by SIGHUP)");
-                    match reload.reload() {
-                        Ok(true) => info!("configuration successfully reloaded"),
-                        Ok(false) => info!("configuration did not change"),
-                        Err(e) => error!("failed to reload configuration: {}", e),
-                    }
-                }
+                SIGHUP => info!("configuration reloading via SIGHUP has been disabled and will be deprecated in the future"),
                 SIGUSR1 => {
                     info!("Dumping state (triggered by SIGUSR1)");
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1885

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Disables configuration reloading upon receiving a SIGHUP signal and throws a warning notifying the user of this fact and that the feature will be deprecated in the future. 

When a SIGHUP signal is sent to Hermes, the logs now look like this
```
2022-02-18T16:04:12.715032Z  INFO ThreadId(01) Hermes has started
2022-02-18T16:04:24.764642Z  WARN ThreadId(25) configuration reloading via SIGHUP has been disabled and will be deprecated in the future
```
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).