### PR TITLE
Allow overriding tracing filter with `RUST_LOG` env var

### DIFF
--- a/.changelog/unreleased/features/ibc-relayer-cli/1895-rust-log.md
+++ b/.changelog/unreleased/features/ibc-relayer-cli/1895-rust-log.md
@@ -1,0 +1,2 @@
+- Allow overriding the tracing filter with `RUST_LOG` environment variable
+  ([#1895](https://github.com/informalsystems/ibc-rs/issues/1895))

--- a/relayer-cli/src/commands/start.rs
+++ b/relayer-cli/src/commands/start.rs
@@ -33,7 +33,7 @@ impl Runnable for StartCmd {
         let config = (*app_config()).clone();
         let config = Arc::new(RwLock::new(config));
 
-        let supervisor_handle = make_supervisor::<ProdChainHandle>(config.clone(), self.full_scan)
+        let supervisor_handle = make_supervisor::<ProdChainHandle>(config, self.full_scan)
             .unwrap_or_else(|e| {
                 Output::error(format!("Hermes failed to start, last error: {}", e)).exit()
             });

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -75,7 +75,7 @@ pub fn enable_ansi() -> bool {
 /// Builds a tracing filter based on the input `log_level`.
 /// Enables tracing exclusively for the relayer crates.
 /// Returns error if the filter failed to build.
-fn build_tracing_filter(log_level: LogLevel) -> Result<EnvFilter, FrameworkError> {
+fn build_tracing_filter(default_level: LogLevel) -> Result<EnvFilter, FrameworkError> {
     let directive = std::env::var(HERMES_LOG_VAR).unwrap_or_else(|_| {
         let target_crates = ["ibc_relayer", "ibc_relayer_cli"];
 

--- a/relayer-cli/src/components.rs
+++ b/relayer-cli/src/components.rs
@@ -92,7 +92,7 @@ fn build_tracing_filter(default_level: LogLevel) -> Result<EnvFilter, FrameworkE
         Ok(out) => Ok(out),
         Err(e) => {
             eprintln!(
-                "Unable to initialize Hermes from filter directive {:?}: {}",
+                "ERROR: unable to initialize Hermes with log filtering directive {:?}: {}",
                 directive, e
             );
 

--- a/relayer-cli/src/config.rs
+++ b/relayer-cli/src/config.rs
@@ -28,12 +28,11 @@ define_error! {
         ZeroChain
             |_| { "config file does not specify any chain" },
 
-        InvalidLogLevel
-            { log_level: String, }
+        InvalidLogDirective
+            { directive: String, }
             [ TraceError<ParseError> ]
             |e| {
-                format!("config file specifies an invalid log level ('{0}'), caused by",
-                    e.log_level)
+                format!("invalid log directive: {0:?}", e.directive)
             },
 
         InvalidMode

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -265,7 +265,7 @@ impl Default for Packets {
 /// Log levels are wrappers over [`tracing_core::Level`].
 ///
 /// [`tracing_core::Level`]: https://docs.rs/tracing-core/0.1.17/tracing_core/struct.Level.html
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     Trace,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1895

## Usage

With this PR, one can set the `RUST_LOG` variable to `tendermint_rpc=debug,ibc_relayer=info,ibc_relayer_cli=info` in order to enable debug output for `tendermint-rpc` and info output for the relayer.

```shell
RUST_LOG=tendermint_rpc=debug,ibc_relayer=info,ibc_relayer_cli=info hermes start
```

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).