### PR TITLE
Remove Gaia v6 from integration tests CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,7 +46,6 @@ jobs:
         gaiad:
           - gaia4
           - gaia5
-          - gaia6
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v15


### PR DESCRIPTION

## Description

Because of https://github.com/cosmos/gaia/issues/1280, Gaia v6.0.3 is reverted to the same content as v6.0.0, which is broken in our integration test. To avoid getting locked into specific version of Gaia v6, we will remove the support for Gaia v6 on the CI until v6.0.4 is released with proper fixes.

This would also help in simplifying the version management in https://github.com/informalsystems/cosmos.nix/pull/64, so that we can still "upgrade" Gaia v6 in Cosmos.nix without breaking the CI on ibc-rs.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).