### PR TITLE
Run link checker nightly instead of on every PR

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,10 +1,8 @@
 name: Check Markdown links
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
 


### PR DESCRIPTION
The link checker yields false positives way too often and therefore breaks the CI status for no reason.

Let's move it to nightly and check on it from time to time.