### PR TITLE
Fix unordered integration test CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,6 +44,9 @@ jobs:
     strategy:
       matrix:
         gaiad:
+          - gaia4
+          - gaia5
+          - gaia6_0_2
           - gaia6-ordered
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -47,7 +47,6 @@ jobs:
           - gaia4
           - gaia5
           - gaia6_0_2
-          - gaia6-ordered
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v15
@@ -72,6 +71,6 @@ jobs:
           RUST_LOG: info
           RUST_BACKTRACE: 1
         run: |
-          nix shell github:informalsystems/cosmos.nix/gaia-ordered#${{ matrix.gaiad }} -c cargo \
+          nix shell github:informalsystems/cosmos.nix#${{ matrix.gaiad }} -c cargo \
             test -p ibc-integration-test --no-fail-fast -- \
             --nocapture --test-threads=1

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -46,6 +46,7 @@ flex-error = "0.4.4"
 default = []
 example = []
 manual = []
+ordered = []
 experimental = []
 
 [[bin]]

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -8,9 +8,11 @@
 pub mod clear_packet;
 pub mod client_expiration;
 pub mod memo;
-pub mod ordered_channel;
 pub mod supervisor;
 pub mod transfer;
+
+#[cfg(any(doc, feature = "ordered"))]
+pub mod ordered_channel;
 
 #[cfg(any(doc, feature = "manual"))]
 pub mod manual;

--- a/tools/integration-test/src/tests/transfer.rs
+++ b/tools/integration-test/src/tests/transfer.rs
@@ -20,11 +20,7 @@ fn test_self_connected_ibc_transfer() -> Result<(), Error> {
 
 pub struct IbcTransferTest;
 
-impl TestOverrides for IbcTransferTest {
-    fn channel_order(&self) -> Order {
-        Order::Ordered
-    }
-}
+impl TestOverrides for IbcTransferTest {}
 
 impl BinaryChannelTest for IbcTransferTest {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(


### PR DESCRIPTION

## Description

Fix the CI changes in  #1887 by disabling ordered channel test and re-enabling integration tests for gaia v4, v5, and v6.

The ordered channel test is now hidden behind the `ordered` feature flag, so that it has to be run manually. We will reconfigure the CI in separate PR to run the ordered channel test using only the `gaia6-ordered` fork.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).