### PR TITLE
Enable ordered channel test as separate CI task

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -73,8 +73,7 @@ jobs:
         run: |
           nix shell github:informalsystems/cosmos.nix#${{ matrix.gaiad }} -c cargo \
             test -p ibc-integration-test --no-fail-fast -- \
-            --nocapture --test-threads=1
-
+            --nocapture
 
   ordered-channel-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -74,3 +74,34 @@ jobs:
           nix shell github:informalsystems/cosmos.nix#${{ matrix.gaiad }} -c cargo \
             test -p ibc-integration-test --no-fail-fast -- \
             --nocapture --test-threads=1
+
+
+  ordered-channel-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v15
+        with:
+          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
+          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: cachix/cachix-action@v10
+        with:
+          name: cosmos
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p ibc-integration-test --no-fail-fast --no-run
+      - env:
+          RUST_LOG: info
+          RUST_BACKTRACE: 1
+        run: |
+          nix shell github:informalsystems/cosmos.nix/gaia-ordered#gaia6-ordered -c cargo \
+            test -p ibc-integration-test --features ordered --no-fail-fast -- \
+            --nocapture --test-threads=1 test_ordered_channel


### PR DESCRIPTION
## Description

Follow up on #1929 to re-enable ordered channel test on CI as a separate task.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).