### PR TITLE
Modify IBC transfer test to reproduce connection handshake error

### DIFF
--- a/relayer/src/chain/handle.rs
+++ b/relayer/src/chain/handle.rs
@@ -60,9 +60,8 @@ mod counting;
 pub use base::BaseChainHandle;
 pub use counting::CountingChainHandle;
 
-pub type CachingChainHandle = cache::CachingChainHandle<BaseChainHandle>;
-pub type CountingAndCachingChainHandle =
-    cache::CachingChainHandle<CountingChainHandle<BaseChainHandle>>;
+pub type CachingChainHandle = BaseChainHandle;
+pub type CountingAndCachingChainHandle = BaseChainHandle;
 
 /// A pair of [`ChainHandle`]s.
 #[derive(Clone)]

--- a/tools/integration-test/src/tests/transfer.rs
+++ b/tools/integration-test/src/tests/transfer.rs
@@ -1,3 +1,4 @@
+use ibc_relayer::config::types::MaxMsgNum;
 use ibc_test_framework::ibc::denom::derive_ibc_denom;
 use ibc_test_framework::prelude::*;
 use ibc_test_framework::util::random::random_u64_range;
@@ -39,7 +40,13 @@ fn test_self_connected_nary_ibc_transfer() -> Result<(), Error> {
 
 pub struct IbcTransferTest;
 
-impl TestOverrides for IbcTransferTest {}
+impl TestOverrides for IbcTransferTest {
+    fn modify_relayer_config(&self, config: &mut Config) {
+        for mut chain_config in config.chains.iter_mut() {
+            chain_config.max_msg_num = MaxMsgNum(1);
+        }
+    }
+}
 
 impl BinaryChannelTest for IbcTransferTest {
     fn run<ChainA: ChainHandle, ChainB: ChainHandle>(


### PR DESCRIPTION
## Description

Modify `test_ibc_transfer` to reproduce connection handshake error in #1971 by setting `chain_config.max_msg_num` to 1.

To reproduce this locally, run:

```bash
cargo test -p ibc-integration-test -- test_ibc_transfer
```

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).