### PR TITLE
Fix sign doc for simulation

### DIFF
--- a/relayer/src/chain/cosmos.rs
+++ b/relayer/src/chain/cosmos.rs
@@ -331,9 +331,10 @@ impl CosmosSdkChain {
         debug!("max fee, for use in tx simulation: {}", PrettyFee(&max_fee));
 
         let (body, body_buf) = tx_body_and_bytes(proto_msgs, self.tx_memo())?;
+        let account_number = self.account_number()?;
 
         let (auth_info, auth_buf) = auth_info_and_bytes(signer_info.clone(), max_fee)?;
-        let signed_doc = self.signed_doc(body_buf.clone(), auth_buf, account_seq)?;
+        let signed_doc = self.signed_doc(body_buf.clone(), auth_buf, account_number)?;
 
         let simulate_tx = Tx {
             body: Some(body),
@@ -367,7 +368,6 @@ impl CosmosSdkChain {
         );
 
         let (_auth_adjusted, auth_buf_adjusted) = auth_info_and_bytes(signer_info, adjusted_fee)?;
-        let account_number = self.account_number()?;
         let signed_doc =
             self.signed_doc(body_buf.clone(), auth_buf_adjusted.clone(), account_number)?;
 

--- a/relayer/src/chain/cosmos/account.rs
+++ b/relayer/src/chain/cosmos/account.rs
@@ -1,0 +1,109 @@
+use core::fmt;
+
+use ibc_proto::cosmos::auth::v1beta1::BaseAccount;
+use prost::Message;
+
+use crate::error::Error;
+
+use super::CosmosSdkChain;
+
+/// Wrapper for account number and sequence number.
+///
+/// More fields may be added later.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Account {
+    // pub address: String,
+    // pub pub_key: Option<prost_types::Any>,
+    pub number: AccountNumber,
+    pub sequence: AccountSequence,
+}
+
+impl From<BaseAccount> for Account {
+    fn from(value: BaseAccount) -> Self {
+        Self {
+            number: AccountNumber::new(value.account_number),
+            sequence: AccountSequence::new(value.sequence),
+        }
+    }
+}
+
+/// Newtype for account numbers
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountNumber(u64);
+
+impl AccountNumber {
+    pub fn new(number: u64) -> Self {
+        Self(number)
+    }
+
+    pub fn to_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for AccountNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Newtype for account sequence numbers
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountSequence(u64);
+
+impl AccountSequence {
+    pub fn new(sequence: u64) -> Self {
+        Self(sequence)
+    }
+
+    pub fn to_u64(self) -> u64 {
+        self.0
+    }
+
+    pub fn increment(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+impl fmt::Display for AccountSequence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Uses the GRPC client to retrieve the account sequence
+pub async fn query_account(chain: &CosmosSdkChain, address: String) -> Result<BaseAccount, Error> {
+    use crate::chain::ChainEndpoint;
+    use ibc_proto::cosmos::auth::v1beta1::query_client::QueryClient;
+    use ibc_proto::cosmos::auth::v1beta1::{EthAccount, QueryAccountRequest};
+
+    crate::telemetry!(query, chain.id(), "query_account");
+
+    let mut client = QueryClient::connect(chain.grpc_addr.clone())
+        .await
+        .map_err(Error::grpc_transport)?;
+
+    let request = tonic::Request::new(QueryAccountRequest {
+        address: address.clone(),
+    });
+
+    let response = client.account(request).await;
+
+    // Querying for an account might fail, i.e. if the account doesn't actually exist
+    let resp_account = match response.map_err(Error::grpc_status)?.into_inner().account {
+        Some(account) => account,
+        None => return Err(Error::empty_query_account(address)),
+    };
+
+    if resp_account.type_url == "/cosmos.auth.v1beta1.BaseAccount" {
+        Ok(BaseAccount::decode(resp_account.value.as_slice())
+            .map_err(|e| Error::protobuf_decode("BaseAccount".to_string(), e))?)
+    } else if resp_account.type_url.ends_with(".EthAccount") {
+        Ok(EthAccount::decode(resp_account.value.as_slice())
+            .map_err(|e| Error::protobuf_decode("EthAccount".to_string(), e))?
+            .base_account
+            .ok_or_else(Error::empty_base_account)?)
+    } else {
+        Err(Error::unknown_account_type(resp_account.type_url))
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description
There is a small inconsequential bug in the `signed_doc()` call when we simulate a transaction. We pass `account_seq` instead of `account_number`. It currently doesn't cause issues because sdk does not perform full signature 
 [verification](https://github.com/cosmos/cosmos-sdk/blob/5e9656f363a0b8e1e00a58aaeee3c0a8c1e1561b/x/auth/middleware/sigverify.go#L493-L495) during simulation. 
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).