### PR TITLE
Disable color log on integration test CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -70,6 +70,7 @@ jobs:
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
+          NO_COLOR_LOG: 1
         run: |
           nix shell github:informalsystems/cosmos.nix#${{ matrix.gaiad }} -c cargo \
             test -p ibc-integration-test --no-fail-fast -- \
@@ -100,6 +101,7 @@ jobs:
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
+          NO_COLOR_LOG: 1
         run: |
           nix shell github:informalsystems/cosmos.nix/gaia-ordered#gaia6-ordered -c cargo \
             test -p ibc-integration-test --features ordered --no-fail-fast -- \
@@ -130,6 +132,7 @@ jobs:
       - env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
+          NO_COLOR_LOG: 1
           CHAIN_COMMAND_PATH: icad
         run: |
           nix shell github:informalsystems/cosmos.nix#ica -c cargo \


### PR DESCRIPTION
## Description

Adds a `NO_COLOR_LOG` variable that if is set to `1`, will disable `eyre_color` when running the integration tests. This will help inspecting the log output from CI.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).