### PR TITLE
Create channel cli

### DIFF
--- a/.changelog/unreleased/improvements/relayer-cli/1421-create-channel-cli.md
+++ b/.changelog/unreleased/improvements/relayer-cli/1421-create-channel-cli.md
@@ -1,0 +1,2 @@
+- Change `create channel` CLI command such that it is more difficult to create
+  clients / connections using it ([#1421](https://github.com/informalsystems/ibc-rs/issues/1421))

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -57,6 +57,7 @@ atty = "0.2.14"
 flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 signal-hook = "0.3.13"
 dialoguer = "0.10.0"
+console = "0.15.0"
 
 [dependencies.tendermint-proto]
 version = "=0.23.5"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -56,7 +56,7 @@ itertools = "0.10.3"
 atty = "0.2.14"
 flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 signal-hook = "0.3.13"
-dialoguer = 0.10.0
+dialoguer = "0.10.0"
 
 [dependencies.tendermint-proto]
 version = "=0.23.5"

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -56,6 +56,7 @@ itertools = "0.10.3"
 atty = "0.2.14"
 flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 signal-hook = "0.3.13"
+dialoguer = 0.10.0
 
 [dependencies.tendermint-proto]
 version = "=0.23.5"

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -17,7 +17,7 @@ use crate::conclude::{exit_with_unrecoverable_error, Output};
 use crate::prelude::*;
 use ibc_relayer::config::default::connection_delay;
 
-static PROMPT: &str = "WARN: Are you sure you want new clients & connections to be created? Hermes will use default security parameters.\nHint: consider using the default invocation `hermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CONNECTION-A-ID>` to re-use a pre-existing connection.";
+static PROMPT: &str = "Are you sure you want new clients & connections to be created? Hermes will use default security parameters.\nHint: consider using the default invocation\n`hermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CONNECTION-A-ID>`\nto re-use a pre-existing connection.";
 
 /// The data structure that represents all the possible options when invoking
 /// the `create channel` CLI command.
@@ -99,10 +99,7 @@ impl Runnable for CreateChannelCommand {
             None => match &self.chain_b_id {
                 Some(chain_b) => {
                     if self.new_client_connection {
-                        match Confirm::new()
-                            .with_prompt(PROMPT)
-                            .interact_on(&Term::stdout())
-                        {
+                        match Confirm::new().with_prompt(PROMPT).interact() {
                             Ok(confirm) => {
                                 if confirm {
                                     self.run_using_new_connection(chain_b);

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -16,6 +16,23 @@ use crate::conclude::{exit_with_unrecoverable_error, Output};
 use crate::prelude::*;
 use ibc_relayer::config::default::connection_delay;
 
+/// The data structure that represents all the possible options when invoking
+/// the `create channel` CLI command.
+///
+/// There are two possible ways to invoke this command:
+///
+/// `create channel --port-a --port-b <Chain-A-ID> <Chain-B-ID> --new-client-connection` to indicate
+/// that a new connection/client pair is being created as part of this new channel.
+/// This will bring up an interactive yes/no prompt so that the operator at least has to
+/// consider the fact that they're initializing a new connection with the channel.
+///
+/// `create channel --port-a --port-b <Chain-A-ID> <Connection-ID>` is the default
+/// way in which this command should be used, specifying a `connection-id` for this new channel
+/// to re-use. The command expects that `connection-ID` is associated with Chain-A.
+///
+/// `connection-ID`s have to be considered based off of the chain's perspective. Although chain A
+/// and chain B might refer to the connection with different names, they are referring to the same
+/// connection.
 #[derive(Clone, Command, Debug, Parser)]
 #[clap(disable_version_flag = true)]
 pub struct CreateChannelCommand {

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -27,17 +27,17 @@ static HINT: &str = "Consider using the default invocation\n\nhermes create chan
 ///
 /// There are two possible ways to invoke this command:
 ///
-/// `create channel --port-a --port-b <Chain-A-ID> <Chain-B-ID> --new-client-connection` to indicate
+/// `create channel --port-a <Port-ID> --port-b <Port-ID> <Chain-A-ID> <Chain-B-ID> --new-client-connection` to indicate
 /// that a new connection/client pair is being created as part of this new channel.
-/// This will bring up an interactive yes/no prompt so that the operator at least has to
-/// consider the fact that they're initializing a new connection with the channel.
+/// This brings up an interactive yes/no prompt to ensure that the operator at least
+/// considers the fact that they're initializing a new connection with the channel.
 ///
-/// `create channel --port-a --port-b <Chain-A-ID> <Connection-ID>` is the default
-/// way in which this command should be used, specifying a `connection-id` for this new channel
-/// to re-use. The command expects that `connection-ID` is associated with Chain-A.
+/// `create channel --port-a <Port-ID> --port-b <Port-ID> <Chain-A-ID> <Connection-ID>` is the default
+/// way in which this command should be used, specifying a `Connection-ID` for this new channel
+/// to re-use. The command expects that `Connection-ID` is associated with chain A.
 ///
-/// Note that `connection-ID`s have to be considered based off of the chain's perspective. Although
-/// chain A and chain B might refer to the connection with different names, they are referring
+/// Note that `Connection-ID`s have to be considered based off of the chain's perspective. Although
+/// chain A and chain B might refer to the connection with different names, they are actually referring
 /// to the same connection.
 #[derive(Clone, Command, Debug, Parser)]
 #[clap(disable_version_flag = true)]

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -27,8 +27,8 @@ static HINT: &str = "Consider using the default invocation\n\nhermes create chan
 ///
 /// There are two possible ways to invoke this command:
 ///
-/// `create channel --port-a <Port-ID> --port-b <Port-ID> <Chain-A-ID> <Chain-B-ID> --new-client-connection` to indicate
-/// that a new connection/client pair is being created as part of this new channel.
+/// `create channel --port-a <Port-ID> --port-b <Port-ID> <Chain-A-ID> <Chain-B-ID> --new-client-connection`
+/// to indicate that a new connection/client pair is being created as part of this new channel.
 /// This brings up an interactive yes/no prompt to ensure that the operator at least
 /// considers the fact that they're initializing a new connection with the channel.
 ///

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -81,6 +81,12 @@ pub struct CreateChannelCommand {
         help = "the version for the new channel"
     )]
     version: Option<String>,
+
+    #[clap(
+        long,
+        help = "indicates that a new client and connection will be created alongside the new channel"
+    )]
+    new_client_connection: bool,
 }
 
 impl Runnable for CreateChannelCommand {

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -91,25 +91,32 @@ pub struct CreateChannelCommand {
 
 impl Runnable for CreateChannelCommand {
     fn run(&self) {
-        match &self.chain_b_id {
-            None => self.run_reusing_connection(),
-            Some(chain_b) => self.run_using_new_connection(chain_b),
+        match &self.connection_a {
+            Some(conn) => self.run_reusing_connection(conn),
+            None => match &self.chain_b_id {
+                Some(chain_b) => {
+                    if self.new_client_connection {
+                        self.run_using_new_connection(chain_b)
+                    } else {
+                        Output::error(
+                                "The `--new-client-connection` flag is required if invoking with `<chain-b-id>`".to_string()
+                            )
+                            .exit();
+                    }
+                }
+                None => {
+                    Output::error("Missing one of `<chain-b-id>` or `<connection-a>`".to_string())
+                        .exit()
+                }
+            },
         }
     }
 }
 
 impl CreateChannelCommand {
-    // Creates a new channel, as well as a new underlying connection and clients.
+    /// Creates a new channel, as well as a new underlying connection and clients.
     fn run_using_new_connection(&self, chain_b_id: &ChainId) {
         let config = app_config();
-
-        // Bail with an explicit error. The user might be expecting to use this connection.
-        if self.connection_a.is_some() {
-            Output::error(
-                "Option `<connection-a>` is incompatible with `<chain-b-id>`".to_string(),
-            )
-            .exit();
-        }
 
         let chains = ChainHandlePair::spawn(&config, &self.chain_a_id, chain_b_id)
             .unwrap_or_else(exit_with_unrecoverable_error);
@@ -141,23 +148,13 @@ impl CreateChannelCommand {
         Output::success(channel).exit();
     }
 
-    // Creates a new channel, reusing an already existing connection and its clients.
-    fn run_reusing_connection(&self) {
+    /// Creates a new channel, reusing an already existing connection and its clients.
+    fn run_reusing_connection(&self, connection_a_id: &ConnectionId) {
         let config = app_config();
 
         // Validate & spawn runtime for side a.
         let chain_a = spawn_chain_runtime(&config, &self.chain_a_id)
             .unwrap_or_else(exit_with_unrecoverable_error);
-
-        // Unwrap the identifier of the connection on side a.
-        let connection_a_id = match &self.connection_a {
-            Some(c) => c,
-            None => Output::error(
-                "Option `--connection-a` is necessary when <chain-b-id> argument is missing"
-                    .to_string(),
-            )
-            .exit(),
-        };
 
         // Query the connection end.
         let height = Height::new(chain_a.id().version(), 0);

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -1,5 +1,7 @@
 use abscissa_core::clap::Parser;
 use abscissa_core::{Command, Runnable};
+
+use console::style;
 use dialoguer::Confirm;
 
 use ibc::core::ics02_client::client_state::ClientState;
@@ -17,7 +19,8 @@ use crate::conclude::{exit_with_unrecoverable_error, Output};
 use crate::prelude::*;
 use ibc_relayer::config::default::connection_delay;
 
-static PROMPT: &str = "Are you sure you want new clients & connections to be created? Hermes will use default security parameters.\nHint: consider using the default invocation\n`hermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CONNECTION-A-ID>`\nto re-use a pre-existing connection.";
+static PROMPT: &str = "Are you sure you want new clients & connections to be created? Hermes will use default security parameters.";
+static HINT: &str = "Consider using the default invocation\n\nhermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CONNECTION-A-ID>\n\nto re-use a pre-existing connection.";
 
 /// The data structure that represents all the possible options when invoking
 /// the `create channel` CLI command.
@@ -99,7 +102,16 @@ impl Runnable for CreateChannelCommand {
             None => match &self.chain_b_id {
                 Some(chain_b) => {
                     if self.new_client_connection {
-                        match Confirm::new().with_prompt(PROMPT).interact() {
+                        match Confirm::new()
+                            .with_prompt(format!(
+                                "{}: {}\n{}: {}",
+                                style("WARN").yellow(),
+                                PROMPT,
+                                style("Hint").cyan(),
+                                HINT
+                            ))
+                            .interact()
+                        {
                             Ok(confirm) => {
                                 if confirm {
                                     self.run_using_new_connection(chain_b);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1421 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Changes the flow of the `create channel` CLI command. The default invocation has been changed from
```
hermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CHAIN-B-ID>
```
to 
```
hermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CONNECTION-A-ID>
```

If users _want_ to create new clients and connections using this invocation, it is now required that `--new-client-connections` flag be passed along:
```
hermes create channel --port-a <PORT-ID> --port-b <PORT-ID> <CHAIN-A-ID> <CHAIN-B-ID> --new-client-connections
```
This brings up an interactive prompt that the user must agree to, letting them know that they are creating new clients / connections as part of the invocation. 
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).