### PR TITLE
Add `std` to `ibc-proto` and `ibc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,9 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"
@@ -471,9 +474,9 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "contracts"
-version = "0.4.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9424f2ca1e42776615720e5746eed6efa19866fdbaac2923ab51c294ac4d1f2"
+checksum = "f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,9 +605,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "6a9df9647255ed398be26379810e02ed1d58263570b3bcd243ee2481f79c88b1"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -633,16 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,15 +645,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
+name = "curve25519-dalek-ng"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
+ "rand_core 0.6.3",
+ "subtle-ng",
  "zeroize",
 ]
 
@@ -721,6 +714,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -772,9 +766,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
+version = "0.14.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "28c2de318745e96b4c6679669a4283c345977dc6b5683e4e713661bbb5b33637"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -792,14 +786,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.1"
+name = "ed25519-consensus"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "542217a53411d471743362251a5a1770a667cb0cc0384c9be2c0952bd70a7275"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.3",
  "sha2 0.9.9",
+ "thiserror",
  "zeroize",
 ]
 
@@ -811,13 +807,14 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "0b8d8eb14e60f3254bd24d2f4b5675b79c1dc79318e37fb8274e607c4d82ebd9"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
+ "digest 0.10.3",
  "ff",
  "generic-array",
  "group",
@@ -1205,18 +1202,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac 0.11.1",
- "digest 0.9.0",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1366,6 +1362,7 @@ dependencies = [
  "tendermint-light-client-verifier",
  "tendermint-proto",
  "tendermint-rpc",
+ "tendermint-rpc-abci",
  "tendermint-testgen",
  "test-log",
  "time",
@@ -1448,6 +1445,7 @@ dependencies = [
  "tendermint-light-client-verifier",
  "tendermint-proto",
  "tendermint-rpc",
+ "tendermint-rpc-abci",
  "tendermint-testgen",
  "test-log",
  "thiserror",
@@ -1657,15 +1655,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "d56cf9685907682fb1a2cc016db2b67633b484943f1c43672de64fb101131f52"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "sec1",
- "sha2 0.9.9",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -2129,7 +2127,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "crypto-mac 0.8.0",
+ "crypto-mac",
 ]
 
 [[package]]
@@ -2510,12 +2508,12 @@ checksum = "ac95c60a949a63fd2822f4964939662d8f2c16c4fa0624fd954bc6e703b9a3f6"
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "6b5fc62eda367f95399820ccb69ffa1695519e053001ae0b7517d16438d26ef2"
 dependencies = [
  "crypto-bigint",
- "hmac 0.11.0",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -2898,17 +2896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,11 +3036,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 dependencies = [
- "digest 0.9.0",
+ "digest 0.10.3",
  "rand_core 0.6.3",
 ]
 
@@ -3156,6 +3143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,14 +3193,13 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8150cb636f400ead6de6f4893824d40ecf71214c5d9f8a1d445b5f38fff7b3"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
  "async-trait",
  "bytes",
  "ed25519",
- "ed25519-dalek",
+ "ed25519-consensus",
  "flex-error",
  "futures",
  "k256",
@@ -3219,7 +3211,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "serde_repr",
  "sha2 0.9.9",
  "signature",
  "subtle",
@@ -3231,9 +3222,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a5c41141b56f1e0463182d910b8ccb84fd4abe61a4290a89794d44ad3e15a9"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
  "flex-error",
  "serde",
@@ -3245,9 +3235,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f937884254ac9888dd42fad6c2423f3db85989d3910995867a2064d0b47a2de"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -3267,23 +3256,20 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7679dbd1cc1ad6d723a799b7cd3c55e592de230bc96e23c1ccb8b309bfa61700"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
  "tendermint",
- "tendermint-rpc",
  "time",
 ]
 
 [[package]]
 name = "tendermint-proto"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ba5f19afd52d69aa139cbf2a2ad129673a87aebeb66742b852a4d91b482e7b"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
  "bytes",
  "flex-error",
@@ -3299,9 +3285,8 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4a92790ed1f844984ce78436c9bdd0931034b387ee6158f0f0731956285d6f"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -3318,10 +3303,12 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "subtle",
  "subtle-encoding",
  "tendermint",
  "tendermint-config",
  "tendermint-proto",
+ "tendermint-rpc-abci",
  "thiserror",
  "time",
  "tokio",
@@ -3332,12 +3319,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-testgen"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aade187d7b5bb7c6df215d20661411283d32873f7657dd5633590d89cf928b"
+name = "tendermint-rpc-abci"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
 dependencies = [
- "ed25519-dalek",
+ "serde",
+ "subtle",
+ "subtle-encoding",
+ "tendermint",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "tendermint-testgen"
+version = "0.24.0-pre.1"
+source = "git+https://github.com/Wizdave97/tendermint-rs.git?branch=david/no_std-and-std-targets#8c6e01558344f3b50ef34fb14529e9978b5bdf7d"
+dependencies = [
+ "ed25519-consensus",
  "gumdrop",
  "serde",
  "serde_json",

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -7,9 +7,9 @@ resolver = "2"
 [dependencies]
 ibc = { path = "../../modules", default-features = false }
 ibc-proto = { path = "../../proto", default-features = false }
-tendermint = { version = "0.23.5", default-features = false }
-tendermint-proto = { version = "0.23.5", default-features = false }
-tendermint-light-client-verifier = { version = "0.23.5", default-features = false }
+tendermint = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
+tendermint-proto = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
+tendermint-light-client-verifier = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
 
 sp-core = { version = "5.0.0", default-features = false, optional = true }
 sp-io = { version = "5.0.0", default-features = false, optional = true }
@@ -29,6 +29,11 @@ substrate-std = [
   "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
+  "ibc-proto/std",
+  "ibc/std",
+  "tendermint/std",
+  "tendermint-proto/std",
+  "tendermint-light-client-verifier/std"
 ]
 
 [patch.crates-io]

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -18,12 +18,29 @@ all-features = true
 
 [features]
 default = ["std"]
-std = ["flex-error/std", "flex-error/eyre_tracer", "ibc-proto/std", "clock"]
-clock = ["tendermint/clock", "time/std"]
-
+std = [
+    "flex-error/std",
+    "flex-error/eyre_tracer",
+    "ibc-proto/std",
+    "ics23/std",
+    "time/std",
+    "serde/std",
+    "serde_json/std",
+    "tracing/std",
+    "prost/std",
+    "prost-types/std",
+    "bytes/std",
+    "subtle-encoding/std",
+    "sha2/std",
+    "num-traits/std",
+    "tendermint/std",
+    "tendermint-proto/std",
+    "tendermint-light-client-verifier/std",
+    "tendermint-rpc-abci/std"
+]
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
-mocks = ["tendermint-testgen", "clock", "std"]
+mocks = ["tendermint-testgen"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
@@ -43,23 +60,11 @@ sha2 = { version = "0.10.2", default-features = false }
 flex-error = { version = "0.4.4", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
-
-[dependencies.tendermint]
-version = "=0.23.5"
-default-features = false
-
-[dependencies.tendermint-proto]
-version = "=0.23.5"
-default-features = false
-
-[dependencies.tendermint-light-client-verifier]
-version = "=0.23.5"
-default-features = false
-
-[dependencies.tendermint-testgen]
-version = "=0.23.5"
-optional = true
-default-features = false
+tendermint = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
+tendermint-proto = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
+tendermint-light-client-verifier = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false}
+tendermint-testgen = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", optional = true }
+tendermint-rpc-abci = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false  }
 
 [dev-dependencies]
 env_logger = "0.9.0"
@@ -67,10 +72,11 @@ tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter", "json
 test-log = { version = "0.2.8", features = ["trace"] }
 modelator = "0.4.2"
 sha2 = { version = "0.10.2" }
-tendermint-rpc = { version = "=0.23.5", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "=0.23.5" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets"} # Needed for generating (synthetic) light blocks.
 
 [[test]]
 name = "mbt"
 path = "tests/mbt.rs"
 required-features = ["mocks"]
+

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -209,7 +209,7 @@ impl ClientDef for TendermintClient {
             epoch: consensus_height.revision_number,
             height: consensus_height.revision_height,
         };
-        let value = expected_consensus_state.encode_vec().unwrap();
+        let value = expected_consensus_state.encode_vec();
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -226,7 +226,7 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ConnectionsPath(connection_id.clone());
-        let value = expected_connection_end.encode_vec().unwrap();
+        let value = expected_connection_end.encode_vec();
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -244,7 +244,7 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ChannelEndsPath(port_id.clone(), channel_id.clone());
-        let value = expected_channel_end.encode_vec().unwrap();
+        let value = expected_channel_end.encode_vec();
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -261,7 +261,7 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ClientStatePath(client_id.clone());
-        let value = expected_client_state.encode_vec().unwrap();
+        let value = expected_client_state.encode_vec();
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 

--- a/modules/src/core/ics02_client/client_consensus.rs
+++ b/modules/src/core/ics02_client/client_consensus.rs
@@ -97,16 +97,12 @@ impl From<AnyConsensusState> for Any {
         match value {
             AnyConsensusState::Tendermint(value) => Any {
                 type_url: TENDERMINT_CONSENSUS_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyConsensusState::Tendermint`"),
+                value: value.encode_vec(),
             },
             #[cfg(any(test, feature = "mocks"))]
             AnyConsensusState::Mock(value) => Any {
                 type_url: MOCK_CONSENSUS_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyConsensusState::Mock`"),
+                value: value.encode_vec(),
             },
         }
     }

--- a/modules/src/core/ics02_client/client_state.rs
+++ b/modules/src/core/ics02_client/client_state.rs
@@ -182,16 +182,12 @@ impl From<AnyClientState> for Any {
         match value {
             AnyClientState::Tendermint(value) => Any {
                 type_url: TENDERMINT_CLIENT_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyClientState::Tendermint`"),
+                value: value.encode_vec(),
             },
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(value) => Any {
                 type_url: MOCK_CLIENT_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyClientState::Mock`"),
+                value: value.encode_vec(),
             },
         }
     }

--- a/modules/src/core/ics02_client/events.rs
+++ b/modules/src/core/ics02_client/events.rs
@@ -1,8 +1,8 @@
 //! Types for the IBC events emitted from Tendermint Websocket by the client module.
 
 use serde_derive::{Deserialize, Serialize};
-use tendermint::abci::tag::Tag;
-use tendermint::abci::Event as AbciEvent;
+use tendermint_rpc_abci::tag::Tag;
+use tendermint_rpc_abci::Event as AbciEvent;
 
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error;

--- a/modules/src/core/ics02_client/header.rs
+++ b/modules/src/core/ics02_client/header.rs
@@ -75,7 +75,7 @@ impl Header for AnyHeader {
 
 impl AnyHeader {
     pub fn encode_to_string(&self) -> String {
-        let buf = Protobuf::encode_vec(self).expect("encoding shouldn't fail");
+        let buf = Protobuf::encode_vec(self);
         let encoded = hex::encode(buf);
         String::from_utf8(encoded).expect("hex-encoded string should always be valid UTF-8")
     }
@@ -114,16 +114,12 @@ impl From<AnyHeader> for Any {
         match value {
             AnyHeader::Tendermint(header) => Any {
                 type_url: TENDERMINT_HEADER_TYPE_URL.to_string(),
-                value: header
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyHeader::Tendermint`"),
+                value: header.encode_vec(),
             },
             #[cfg(any(test, feature = "mocks"))]
             AnyHeader::Mock(header) => Any {
                 type_url: MOCK_HEADER_TYPE_URL.to_string(),
-                value: header
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyHeader::Mock`"),
+                value: header.encode_vec(),
             },
         }
     }

--- a/modules/src/core/ics02_client/misbehaviour.rs
+++ b/modules/src/core/ics02_client/misbehaviour.rs
@@ -87,17 +87,13 @@ impl From<AnyMisbehaviour> for Any {
         match value {
             AnyMisbehaviour::Tendermint(misbehaviour) => Any {
                 type_url: TENDERMINT_MISBEHAVIOR_TYPE_URL.to_string(),
-                value: misbehaviour
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyMisbehavior::Tendermint`"),
+                value: misbehaviour.encode_vec(),
             },
 
             #[cfg(any(test, feature = "mocks"))]
             AnyMisbehaviour::Mock(misbehaviour) => Any {
                 type_url: MOCK_MISBEHAVIOUR_TYPE_URL.to_string(),
-                value: misbehaviour
-                    .encode_vec()
-                    .expect("encoding to `Any` from `AnyMisbehavior::Mock`"),
+                value: misbehaviour.encode_vec(),
             },
         }
     }

--- a/modules/src/core/ics03_connection/events.rs
+++ b/modules/src/core/ics03_connection/events.rs
@@ -1,8 +1,8 @@
 //! Types for the IBC events emitted from Tendermint Websocket by the connection module.
 
 use serde_derive::{Deserialize, Serialize};
-use tendermint::abci::tag::Tag;
-use tendermint::abci::Event as AbciEvent;
+use tendermint_rpc_abci::tag::Tag;
+use tendermint_rpc_abci::Event as AbciEvent;
 
 use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics02_client::height::Height;
@@ -18,7 +18,7 @@ const CLIENT_ID_ATTRIBUTE_KEY: &str = "client_id";
 const COUNTERPARTY_CONN_ID_ATTRIBUTE_KEY: &str = "counterparty_connection_id";
 const COUNTERPARTY_CLIENT_ID_ATTRIBUTE_KEY: &str = "counterparty_client_id";
 
-pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IbcEvent> {
+pub fn try_from_tx(event: &tendermint_rpc_abci::Event) -> Option<IbcEvent> {
     match event.type_str.parse() {
         Ok(IbcEventType::OpenInitConnection) => extract_attributes_from_tx(event)
             .map(OpenInit::from)
@@ -40,7 +40,7 @@ pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IbcEvent> {
     }
 }
 
-fn extract_attributes_from_tx(event: &tendermint::abci::Event) -> Result<Attributes, Error> {
+fn extract_attributes_from_tx(event: &tendermint_rpc_abci::Event) -> Result<Attributes, Error> {
     let mut attr = Attributes::default();
 
     for tag in &event.attributes {

--- a/modules/src/core/ics04_channel/events.rs
+++ b/modules/src/core/ics04_channel/events.rs
@@ -1,8 +1,8 @@
 //! Types for the IBC events emitted from Tendermint Websocket by the channels module.
 
 use serde_derive::{Deserialize, Serialize};
-use tendermint::abci::tag::Tag;
-use tendermint::abci::Event as AbciEvent;
+use tendermint_rpc_abci::tag::Tag;
+use tendermint_rpc_abci::Event as AbciEvent;
 
 use crate::core::ics02_client::height::Height;
 use crate::core::ics04_channel::error::Error;
@@ -33,7 +33,7 @@ const PKT_TIMEOUT_HEIGHT_ATTRIBUTE_KEY: &str = "packet_timeout_height";
 const PKT_TIMEOUT_TIMESTAMP_ATTRIBUTE_KEY: &str = "packet_timeout_timestamp";
 const PKT_ACK_ATTRIBUTE_KEY: &str = "packet_ack";
 
-pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IbcEvent> {
+pub fn try_from_tx(event: &tendermint_rpc_abci::Event) -> Option<IbcEvent> {
     match event.type_str.parse() {
         Ok(IbcEventType::OpenInitChannel) => extract_attributes_from_tx(event)
             .map(OpenInit::try_from)
@@ -114,7 +114,7 @@ pub fn try_from_tx(event: &tendermint::abci::Event) -> Option<IbcEvent> {
     }
 }
 
-fn extract_attributes_from_tx(event: &tendermint::abci::Event) -> Result<Attributes, Error> {
+fn extract_attributes_from_tx(event: &tendermint_rpc_abci::Event) -> Result<Attributes, Error> {
     let mut attr = Attributes::default();
 
     for tag in &event.attributes {
@@ -142,7 +142,7 @@ fn extract_attributes_from_tx(event: &tendermint::abci::Event) -> Result<Attribu
 }
 
 fn extract_packet_and_write_ack_from_tx(
-    event: &tendermint::abci::Event,
+    event: &tendermint_rpc_abci::Event,
 ) -> Result<(Packet, Vec<u8>), Error> {
     let mut packet = Packet::default();
     let mut write_ack: Vec<u8> = Vec::new();

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -6,7 +6,7 @@ use core::str::FromStr;
 use flex_error::{define_error, TraceError};
 use prost::alloc::fmt::Formatter;
 use serde_derive::{Deserialize, Serialize};
-use tendermint::abci::Event as AbciEvent;
+use tendermint_rpc_abci::Event as AbciEvent;
 
 use crate::core::ics02_client::error as client_error;
 use crate::core::ics02_client::events as ClientEvents;
@@ -320,7 +320,10 @@ impl TryFrom<IbcEvent> for AbciEvent {
 }
 
 // This is tendermint specific
-pub fn from_tx_response_event(height: Height, event: &tendermint::abci::Event) -> Option<IbcEvent> {
+pub fn from_tx_response_event(
+    height: Height,
+    event: &tendermint_rpc_abci::Event,
+) -> Option<IbcEvent> {
     // Return the first hit we find
     if let Some(mut client_res) = ClientEvents::try_from_tx(event) {
         client_res.set_height(height);

--- a/modules/src/mock/header.rs
+++ b/modules/src/mock/header.rs
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn encode_any() {
         let header = MockHeader::new(Height::new(1, 10)).with_timestamp(Timestamp::none());
-        let bytes = header.wrap_any().encode_vec().unwrap();
+        let bytes = header.wrap_any().encode_vec();
 
         assert_eq!(
             &bytes,

--- a/modules/src/query.rs
+++ b/modules/src/query.rs
@@ -1,4 +1,4 @@
-use tendermint::abci::transaction::Hash;
+use tendermint_rpc_abci::transaction::Hash;
 
 use crate::core::ics02_client::client_consensus::QueryClientEventRequest;
 use crate::core::ics04_channel::channel::QueryPacketEventDataRequest;

--- a/modules/src/timestamp.rs
+++ b/modules/src/timestamp.rs
@@ -74,7 +74,7 @@ impl Timestamp {
     }
 
     /// Returns a `Timestamp` representation of the current time.
-    #[cfg(feature = "clock")]
+    #[cfg(feature = "std")]
     pub fn now() -> Timestamp {
         Time::now().into()
     }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -30,13 +30,10 @@ tonic       = { version = "0.6", optional = true, default-features = false }
 serde       = { version = "1.0", default-features = false }
 schemars    = { version = "0.8", optional = true }
 base64      = { version = "0.13", default-features = false, features = ["alloc"] }
-
-[dependencies.tendermint-proto]
-version          = "=0.23.5"
-default-features = false
+tendermint-proto = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
 
 [features]
-default     = ["std", "client"]
-std         = []
+default     = ["std"]
+std         = ["prost/std", "prost-types/std", "bytes/std", "serde/std", "base64/std", "tendermint-proto/std"]
 client      = ["std", "tonic", "tonic/codegen", "tonic/transport", "tonic/prost"]
 json-schema = ["std", "schemars"]

--- a/proto/src/prost/cosmos.base.tendermint.v1beta1.rs
+++ b/proto/src/prost/cosmos.base.tendermint.v1beta1.rs
@@ -89,7 +89,7 @@ pub struct GetNodeInfoRequest {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoResponse {
     #[prost(message, optional, tag = "1")]
-    pub default_node_info: ::core::option::Option<::tendermint_proto::p2p::DefaultNodeInfo>,
+    pub default_node_info: ::core::option::Option<::tendermint_proto::p2p::NodeInfo>,
     #[prost(message, optional, tag = "2")]
     pub application_version: ::core::option::Option<VersionInfo>,
 }

--- a/proto/src/prost/ibc.applications.transfer.v1.rs
+++ b/proto/src/prost/ibc.applications.transfer.v1.rs
@@ -187,7 +187,7 @@ pub struct QueryParamsResponse {
 /// method
 #[derive(::serde::Serialize, ::serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct QueryDenomHashRequest {
-    /// The denomination trace `(\[port_id]/[channel_id])+/[denom\]`
+    /// The denomination trace (\[port_id]/[channel_id\])+/[denom\]
     #[prost(string, tag = "1")]
     pub trace: ::prost::alloc::string::String,
 }

--- a/relayer-cli/Cargo.toml
+++ b/relayer-cli/Cargo.toml
@@ -26,7 +26,7 @@ telemetry   = ["ibc-relayer/telemetry", "ibc-telemetry"]
 rest-server = ["ibc-relayer-rest"]
 
 [dependencies]
-ibc              = { version = "0.13.0-rc.0", path = "../modules", features = ["std", "clock"] }
+ibc              = { version = "0.13.0-rc.0", path = "../modules" }
 ibc-relayer      = { version = "0.13.0-rc.0", path = "../relayer" }
 ibc-proto        = { version = "0.16.0", path = "../proto" }
 ibc-telemetry    = { version = "0.13.0-rc.0", path = "../telemetry", optional = true }
@@ -57,27 +57,12 @@ atty = "0.2.14"
 flex-error = { version = "0.4.4", default-features = false, features = ["std", "eyre_tracer"] }
 signal-hook = "0.3.13"
 
-[dependencies.tendermint-proto]
-version = "=0.23.5"
-
-[dependencies.tendermint]
-version = "=0.23.5"
-features = ["secp256k1"]
-
-[dependencies.tendermint-rpc]
-version = "=0.23.5"
-features = ["http-client", "websocket-client"]
-
-[dependencies.tendermint-light-client]
-version = "=0.23.5"
-features = ["unstable"]
-
-[dependencies.tendermint-light-client-verifier]
-version = "=0.23.5"
-
-[dependencies.abscissa_core]
-version = "=0.6.0"
-features = ["options"]
+tendermint-proto = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets" }
+tendermint = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["secp256k1"] }
+tendermint-rpc = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["http-client", "websocket-client"] }
+tendermint-light-client = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets" }
+abscissa_core = { version = "=0.6.0", features = ["options"] }
 
 [dev-dependencies]
 abscissa_core = { version = "=0.6.0", features = ["testing"] }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -21,8 +21,8 @@ profiling = []
 telemetry = ["ibc-telemetry"]
 
 [dependencies]
-ibc           = { version = "0.13.0-rc.0", path = "../modules", features = ["std", "clock"] }
-ibc-proto     = { version = "0.16.0", path = "../proto", default-features = false, features = ["std", "tonic"] }
+ibc           = { version = "0.13.0-rc.0", path = "../modules" }
+ibc-proto     = { version = "0.16.0", path = "../proto", default-features = false, features = ["tonic", "client"] }
 ibc-telemetry = { version = "0.13.0-rc.0", path = "../telemetry", optional = true }
 
 subtle-encoding = "0.5"
@@ -39,7 +39,7 @@ prost = { version = "0.9" }
 prost-types = { version = "0.9" }
 futures = "0.3.21"
 crossbeam-channel = "0.5.4"
-k256 = { version = "0.10.4", features = ["ecdsa-core", "ecdsa", "sha256"]}
+k256 = { version = "0.11.0-pre.0", features = ["ecdsa-core", "ecdsa", "sha256"]}
 hex = "0.4"
 bitcoin = { version = "=0.27", features = ["use-serde"] }
 tiny-bip39 = "0.8.0"
@@ -64,33 +64,14 @@ nanoid = "0.4.0"
 regex = "1.5.5"
 moka = "0.7.2"
 
-[dependencies.num-bigint]
-version = "0.4"
-features = ["serde"]
-
-[dependencies.num-rational]
-version = "0.4.0"
-features = ["num-bigint", "serde"]
-
-[dependencies.tendermint]
-version = "=0.23.5"
-features = ["secp256k1"]
-
-[dependencies.tendermint-rpc]
-version = "=0.23.5"
-features = ["http-client", "websocket-client"]
-
-[dependencies.tendermint-light-client]
-version = "=0.23.5"
-default-features = false
-features = ["rpc-client", "secp256k1", "unstable"]
-
-[dependencies.tendermint-light-client-verifier]
-version = "=0.23.5"
-default-features = false
-
-[dependencies.tendermint-proto]
-version = "=0.23.5"
+tendermint-proto = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets" }
+tendermint = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["secp256k1"] }
+tendermint-rpc = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["http-client", "websocket-client"] }
+tendermint-light-client = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["unstable"] }
+tendermint-light-client-verifier = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets" }
+num-bigint = { version = "0.4", features = ["serde"] }
+num-rational = { version = "0.4.0", features = ["num-bigint", "serde"] }
+tendermint-rpc-abci = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets" }
 
 [dev-dependencies]
 ibc = { version = "0.13.0-rc.0", path = "../modules", features = ["mocks"] }
@@ -100,4 +81,4 @@ tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter", "json
 test-log = { version = "0.2.8", features = ["trace"] }
 
 # Needed for generating (synthetic) light blocks.
-tendermint-testgen = { version = "=0.23.5" }
+tendermint-testgen = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets" }

--- a/relayer/src/event/monitor/error.rs
+++ b/relayer/src/event/monitor/error.rs
@@ -53,7 +53,9 @@ impl Error {
         use tendermint_rpc::error::ErrorDetail;
 
         match e.detail() {
-            ErrorDetail::Server(detail) if detail.reason.contains("subscription was cancelled") => {
+            ErrorDetail::WebSocket(detail)
+                if detail.reason.contains("subscription was cancelled") =>
+            {
                 Self::subscription_cancelled(e)
             }
             _ => Self::rpc(e),

--- a/relayer/src/link/tx_hashes.rs
+++ b/relayer/src/link/tx_hashes.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use tendermint::abci::transaction;
+use tendermint_rpc_abci::transaction;
 
 use crate::link::relay_sender::AsyncReply;
 

--- a/relayer/src/sdk_error.rs
+++ b/relayer/src/sdk_error.rs
@@ -1,5 +1,5 @@
 use flex_error::define_error;
-use tendermint::abci::Code;
+use tendermint_rpc::abci::Code;
 use tendermint_rpc::endpoint::broadcast::tx_commit::TxResult;
 
 // Provides mapping for errors returned from ibc-go and cosmos-sdk
@@ -162,10 +162,10 @@ pub fn sdk_error_from_tx_result(result: &TxResult) -> SdkError {
         Code::Err(code) => {
             let codespace = result.codespace.to_string();
             if codespace == "client" {
-                SdkError::client(client_error_from_code(code))
+                SdkError::client(client_error_from_code(code.into()))
             } else {
                 // TODO: Implement mapping for other codespaces in ibc-go
-                SdkError::unknown_sdk(code)
+                SdkError::unknown_sdk(code.into())
             }
         }
     }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -19,8 +19,8 @@ ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
 ibc-test-framework = { path = "../test-framework" }
-tendermint      = { version = "=0.23.5" }
-tendermint-rpc  = { version = "=0.23.5", features = ["http-client", "websocket-client"] }
+tendermint = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", default-features = false }
+tendermint-rpc  = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["http-client", "websocket-client"] }
 
 serde_json = "1"
 serde = "1.0.136"

--- a/tools/test-framework/Cargo.toml
+++ b/tools/test-framework/Cargo.toml
@@ -18,8 +18,8 @@ ibc             = { path = "../../modules" }
 ibc-relayer     = { path = "../../relayer" }
 ibc-relayer-cli = { path = "../../relayer-cli" }
 ibc-proto       = { path = "../../proto" }
-tendermint      = { version = "=0.23.5" }
-tendermint-rpc  = { version = "=0.23.5", features = ["http-client", "websocket-client"] }
+tendermint      = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets"}
+tendermint-rpc  = { git = "https://github.com/Wizdave97/tendermint-rs.git", branch = "david/no_std-and-std-targets", features = ["http-client", "websocket-client"] }
 
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1.32"


### PR DESCRIPTION
Closes: #2015

## Description
This is a draft that points tendermint-rs dependencies to the updates made here  https://github.com/informalsystems/tendermint-rs/pull/1109
This PR attempts to implement std features in `ibc` and `ibc-proto` based on this

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).