### PR TITLE
Replace use of `SharedConfig` with plain `Config`

### DIFF
--- a/relayer-cli/src/commands/query/channel_ends.rs
+++ b/relayer-cli/src/commands/query/channel_ends.rs
@@ -70,7 +70,7 @@ fn do_run<Chain: ChainHandle>(cmd: &QueryChannelEndsCmd) -> Result<(), Box<dyn s
     let port_id = cmd.port_id.clone();
     let channel_id = cmd.channel_id.clone();
 
-    let mut registry = <Registry<Chain>>::from_owned((*config).clone());
+    let mut registry = <Registry<Chain>>::new((*config).clone());
     let chain = registry.get_or_spawn(&chain_id)?;
 
     let chain_height = match cmd.height {

--- a/relayer-cli/src/commands/query/channels.rs
+++ b/relayer-cli/src/commands/query/channels.rs
@@ -50,7 +50,7 @@ fn run_query_channels<Chain: ChainHandle>(
     let config = app_config();
     let chain_id = cmd.chain_id.clone();
 
-    let mut registry = <Registry<Chain>>::from_owned((*config).clone());
+    let mut registry = <Registry<Chain>>::new((*config).clone());
     let chain = registry.get_or_spawn(&cmd.chain_id)?;
     let chain_height = chain.query_latest_height()?;
 

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -7,7 +7,6 @@ pub mod types;
 
 use alloc::collections::BTreeMap;
 use core::{fmt, time::Duration};
-use std::sync::{Arc, RwLock};
 use std::{fs, fs::File, io::Write, path::Path};
 
 use serde_derive::{Deserialize, Serialize};
@@ -85,8 +84,6 @@ pub struct Config {
     #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
     pub chains: Vec<ChainConfig>,
 }
-
-pub type SharedConfig = Arc<RwLock<Config>>;
 
 impl Config {
     pub fn has_chain(&self, id: &ChainId) -> bool {

--- a/relayer/src/registry.rs
+++ b/relayer/src/registry.rs
@@ -40,7 +40,7 @@ define_error! {
 /// The purpose of this type is to avoid spawning multiple runtimes for a single `ChainId`.
 #[derive(Debug)]
 pub struct Registry<Chain: ChainHandle> {
-    config: RwArc<Config>,
+    config: Config,
     handles: HashMap<ChainId, Chain>,
     rt: Arc<TokioRuntime>,
 }
@@ -51,23 +51,13 @@ pub struct SharedRegistry<Chain: ChainHandle> {
 }
 
 impl<Chain: ChainHandle> Registry<Chain> {
-    /// Construct a new [`Registry`] using the provided shared [`Config`]
-    pub fn new(config: RwArc<Config>) -> Self {
-        Self::from_shared(config)
-    }
-
-    /// Construct a new [`Registry`] using the provided shared [`Config`]
-    pub fn from_shared(config: RwArc<Config>) -> Self {
+    /// Construct a new [`Registry`] using the provided [`Config`]
+    pub fn new(config: Config) -> Self {
         Self {
             config,
             handles: HashMap::new(),
             rt: Arc::new(TokioRuntime::new().unwrap()),
         }
-    }
-
-    /// Construct a new [`Registry`] using the provided owned [`Config`]
-    pub fn from_owned(config: Config) -> Self {
-        Self::new(Arc::new(RwLock::new(config)))
     }
 
     /// Return the size of the registry, i.e., the number of distinct chain runtimes.
@@ -121,8 +111,8 @@ impl<Chain: ChainHandle> Registry<Chain> {
 }
 
 impl<Chain: ChainHandle> SharedRegistry<Chain> {
-    pub fn new(config: RwArc<Config>) -> Self {
-        let registry = Registry::from_shared(config);
+    pub fn new(config: Config) -> Self {
+        let registry = Registry::new(config);
 
         Self {
             registry: Arc::new(RwLock::new(registry)),
@@ -153,13 +143,11 @@ impl<Chain: ChainHandle> SharedRegistry<Chain> {
 /// Spawns a chain runtime from the configuration and given a chain identifier.
 /// Returns the corresponding handle if successful.
 pub fn spawn_chain_runtime<Chain: ChainHandle>(
-    config: &RwArc<Config>,
+    config: &Config,
     chain_id: &ChainId,
     rt: Arc<TokioRuntime>,
 ) -> Result<Chain, SpawnError> {
     let chain_config = config
-        .read()
-        .expect("poisoned lock")
         .find_chain(chain_id)
         .cloned()
         .ok_or_else(|| SpawnError::missing_chain(chain_id.clone()))?;

--- a/tools/test-framework/src/bootstrap/binary/chain.rs
+++ b/tools/test-framework/src/bootstrap/binary/chain.rs
@@ -6,15 +6,13 @@
 use eyre::Report as Error;
 use ibc::core::ics24_host::identifier::ClientId;
 use ibc_relayer::chain::handle::{ChainHandle, CountingAndCachingChainHandle};
-use ibc_relayer::config::{Config, SharedConfig};
+use ibc_relayer::config::Config;
 use ibc_relayer::error::ErrorDetail as RelayerErrorDetail;
 use ibc_relayer::foreign_client::{extract_client_id, ForeignClient};
 use ibc_relayer::keyring::errors::ErrorDetail as KeyringErrorDetail;
 use ibc_relayer::registry::SharedRegistry;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
-use std::sync::RwLock;
 use tracing::{debug, info};
 
 use crate::relayer::driver::RelayerDriver;
@@ -58,7 +56,7 @@ pub fn boostrap_chain_pair_with_nodes(
 
     save_relayer_config(&config, &config_path)?;
 
-    let config = Arc::new(RwLock::new(config));
+    let config = config;
 
     let registry = new_registry(config.clone());
 
@@ -263,7 +261,7 @@ pub fn add_keys_to_chain_handle<Chain: ChainHandle>(
    Create a new [`SharedRegistry`] that uses [`CountingAndCachingChainHandle`]
    as the [`ChainHandle`] implementation.
 */
-pub fn new_registry(config: SharedConfig) -> SharedRegistry<CountingAndCachingChainHandle> {
+pub fn new_registry(config: Config) -> SharedRegistry<CountingAndCachingChainHandle> {
     <SharedRegistry<CountingAndCachingChainHandle>>::new(config)
 }
 
@@ -281,12 +279,6 @@ pub fn add_chain_config(config: &mut Config, running_node: &FullNode) -> Result<
 /**
    Save a relayer's [`Config`] to the filesystem to make it accessible
    through external CLI.
-
-   Note that the saved config file will not be updated if the
-   [`SharedConfig`] is reloaded within the test. So test authors that
-   test on the config reloading functionality of the relayer would have to
-   call this function again to save the updated relayer config to the
-   filesystem.
 */
 pub fn save_relayer_config(config: &Config, config_path: &Path) -> Result<(), Error> {
     let config_str = toml::to_string_pretty(&config)?;

--- a/tools/test-framework/src/bootstrap/nary/chain.rs
+++ b/tools/test-framework/src/bootstrap/nary/chain.rs
@@ -7,8 +7,6 @@ use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::config::Config;
 use ibc_relayer::foreign_client::ForeignClient;
 use ibc_relayer::registry::SharedRegistry;
-use std::sync::Arc;
-use std::sync::RwLock;
 
 use crate::bootstrap::binary::chain::{
     add_chain_config, add_keys_to_chain_handle, bootstrap_foreign_client, new_registry,
@@ -70,8 +68,6 @@ pub fn boostrap_chains_with_any_nodes(
     let config_path = test_config.chain_store_dir.join("relayer-config.toml");
 
     save_relayer_config(&config, &config_path)?;
-
-    let config = Arc::new(RwLock::new(config));
 
     let registry = new_registry(config.clone());
 

--- a/tools/test-framework/src/prelude.rs
+++ b/tools/test-framework/src/prelude.rs
@@ -8,7 +8,6 @@ pub use ibc::core::ics04_channel::channel::Order;
 pub use ibc::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
 pub use ibc_relayer::chain::handle::ChainHandle;
 pub use ibc_relayer::config::Config;
-pub use ibc_relayer::config::SharedConfig;
 pub use ibc_relayer::foreign_client::ForeignClient;
 pub use ibc_relayer::registry::SharedRegistry;
 pub use ibc_relayer::supervisor::SupervisorHandle;

--- a/tools/test-framework/src/relayer/driver.rs
+++ b/tools/test-framework/src/relayer/driver.rs
@@ -3,7 +3,7 @@
 */
 
 use ibc_relayer::chain::handle::CountingAndCachingChainHandle;
-use ibc_relayer::config::SharedConfig;
+use ibc_relayer::config::Config;
 use ibc_relayer::registry::SharedRegistry;
 use ibc_relayer::supervisor::{spawn_supervisor, SupervisorHandle, SupervisorOptions};
 use std::path::PathBuf;
@@ -29,13 +29,10 @@ pub struct RelayerDriver {
     pub config_path: PathBuf,
 
     /**
-       The relayer [`Config`](ibc_relayer::config::Config) that is shared
-       with the [`Registry`](ibc_relayer::registry::Registry).
-
-       Use this shared config when spawning new supervisor using
-       [`spawn_supervisor`](ibc_relayer::supervisor::spawn_supervisor).
+       The relayer [`Config`]. Use this config when spawning new supervisor
+       using [`spawn_supervisor`](ibc_relayer::supervisor::spawn_supervisor).
     */
-    pub config: SharedConfig,
+    pub config: Config,
 
     /**
        The relayer chain [`Registry`](ibc_relayer::registry::Registry)


### PR DESCRIPTION
## Description

With the config reloading feature removed, there is no more need of keeping `Config` behind an `Arc<RwLock<Config>>`.

This PR simplifies the use of `Config` in the relayer supervisor. This also helps ensure that we do not accidentally use the shared mutation feature provided by `RwLock`.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).