### PR TITLE
Make all handlers emit an `IbcEvent` with height` ctx.host_height()`

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/2035-handler-event-height.md
+++ b/.changelog/unreleased/bug-fixes/ibc/2035-handler-event-height.md
@@ -1,0 +1,2 @@
+- Make all handlers emit an IbcEvent with current host chain height as height parameter value.
+  ([#2035](https://github.com/informalsystems/ibc-rs/issues/2035))

--- a/modules/src/core/ics02_client/events.rs
+++ b/modules/src/core/ics02_client/events.rs
@@ -336,6 +336,9 @@ impl UpgradeClient {
     pub fn set_height(&mut self, height: Height) {
         self.0.height = height;
     }
+    pub fn height(&self) -> Height {
+        self.0.height
+    }
     pub fn client_id(&self) -> &ClientId {
         &self.0.client_id
     }

--- a/modules/src/core/ics02_client/handler/create_client.rs
+++ b/modules/src/core/ics02_client/handler/create_client.rs
@@ -75,10 +75,10 @@ mod tests {
         AllowUpdate, ClientState as TendermintClientState,
     };
     use crate::clients::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
-    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics02_client::client_consensus::AnyConsensusState;
     use crate::core::ics02_client::client_state::ClientState;
     use crate::core::ics02_client::client_type::ClientType;
+    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics02_client::handler::{dispatch, ClientResult};
     use crate::core::ics02_client::msgs::create_client::MsgCreateAnyClient;
     use crate::core::ics02_client::msgs::ClientMsg;

--- a/modules/src/core/ics02_client/handler/create_client.rs
+++ b/modules/src/core/ics02_client/handler/create_client.rs
@@ -56,6 +56,7 @@ pub fn process(
 
     let event_attributes = Attributes {
         client_id,
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::CreateClient(event_attributes.into()));
@@ -74,6 +75,7 @@ mod tests {
         AllowUpdate, ClientState as TendermintClientState,
     };
     use crate::clients::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
+    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics02_client::client_consensus::AnyConsensusState;
     use crate::core::ics02_client::client_state::ClientState;
     use crate::core::ics02_client::client_type::ClientType;
@@ -114,8 +116,9 @@ mod tests {
                 let event = events.pop().unwrap();
                 let expected_client_id = ClientId::new(ClientType::Mock, 0).unwrap();
                 assert!(
-                    matches!(event, IbcEvent::CreateClient(e) if e.client_id() == &expected_client_id)
+                    matches!(event, IbcEvent::CreateClient(ref e) if e.client_id() == &expected_client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 match result {
                     ClientResult::Create(create_result) => {
                         assert_eq!(create_result.client_type, ClientType::Mock);
@@ -204,8 +207,9 @@ mod tests {
                     assert_eq!(events.len(), 1);
                     let event = events.pop().unwrap();
                     assert!(
-                        matches!(event, IbcEvent::CreateClient(e) if e.client_id() == &expected_client_id)
+                        matches!(event, IbcEvent::CreateClient(ref e) if e.client_id() == &expected_client_id)
                     );
+                    assert_eq!(event.height(), ctx.host_height());
                     match result {
                         ClientResult::Create(create_res) => {
                             assert_eq!(create_res.client_type, msg.client_state.client_type());
@@ -267,8 +271,9 @@ mod tests {
                 let event = events.pop().unwrap();
                 let expected_client_id = ClientId::new(ClientType::Tendermint, 0).unwrap();
                 assert!(
-                    matches!(event, IbcEvent::CreateClient(e) if e.client_id() == &expected_client_id)
+                    matches!(event, IbcEvent::CreateClient(ref e) if e.client_id() == &expected_client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 match result {
                     ClientResult::Create(create_res) => {
                         assert_eq!(create_res.client_type, ClientType::Tendermint);

--- a/modules/src/core/ics02_client/handler/update_client.rs
+++ b/modules/src/core/ics02_client/handler/update_client.rs
@@ -93,6 +93,7 @@ pub fn process(
 
     let event_attributes = Attributes {
         client_id,
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::UpdateClient(event_attributes.into()));
@@ -108,6 +109,7 @@ mod tests {
     use crate::core::ics02_client::client_consensus::AnyConsensusState;
     use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
     use crate::core::ics02_client::client_type::ClientType;
+    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics02_client::error::{Error, ErrorDetail};
     use crate::core::ics02_client::handler::dispatch;
     use crate::core::ics02_client::handler::ClientResult::Update;
@@ -153,8 +155,9 @@ mod tests {
                 assert_eq!(events.len(), 1);
                 let event = events.pop().unwrap();
                 assert!(
-                    matches!(event, IbcEvent::UpdateClient(e) if e.client_id() == &msg.client_id)
+                    matches!(event, IbcEvent::UpdateClient(ref e) if e.client_id() == &msg.client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 assert!(log.is_empty());
                 // Check the result
                 match result {
@@ -236,8 +239,9 @@ mod tests {
                     assert_eq!(events.len(), 1);
                     let event = events.pop().unwrap();
                     assert!(
-                        matches!(event, IbcEvent::UpdateClient(e) if e.client_id() == &msg.client_id)
+                        matches!(event, IbcEvent::UpdateClient(ref e) if e.client_id() == &msg.client_id)
                     );
+                    assert_eq!(event.height(), ctx.host_height());
                     assert!(log.is_empty());
                 }
                 Err(err) => {
@@ -303,8 +307,9 @@ mod tests {
                 assert_eq!(events.len(), 1);
                 let event = events.pop().unwrap();
                 assert!(
-                    matches!(event, IbcEvent::UpdateClient(e) if e.client_id() == &msg.client_id)
+                    matches!(event, IbcEvent::UpdateClient(ref e) if e.client_id() == &msg.client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 assert!(log.is_empty());
                 // Check the result
                 match result {
@@ -380,8 +385,9 @@ mod tests {
                 assert_eq!(events.len(), 1);
                 let event = events.pop().unwrap();
                 assert!(
-                    matches!(event, IbcEvent::UpdateClient(e) if e.client_id() == &msg.client_id)
+                    matches!(event, IbcEvent::UpdateClient(ref e) if e.client_id() == &msg.client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 assert!(log.is_empty());
                 // Check the result
                 match result {
@@ -460,8 +466,9 @@ mod tests {
                 assert_eq!(events.len(), 1);
                 let event = events.pop().unwrap();
                 assert!(
-                    matches!(event, IbcEvent::UpdateClient(e) if e.client_id() == &msg.client_id)
+                    matches!(event, IbcEvent::UpdateClient(ref e) if e.client_id() == &msg.client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 assert!(log.is_empty());
                 // Check the result
                 match result {

--- a/modules/src/core/ics02_client/handler/upgrade_client.rs
+++ b/modules/src/core/ics02_client/handler/upgrade_client.rs
@@ -66,6 +66,7 @@ pub fn process(
     });
     let event_attributes = Attributes {
         client_id,
+        height: ctx.host_height(),
         ..Default::default()
     };
 
@@ -84,6 +85,7 @@ mod tests {
     use crate::core::ics02_client::handler::ClientResult::Upgrade;
     use crate::core::ics02_client::msgs::upgrade_client::MsgUpgradeAnyClient;
     use crate::core::ics02_client::msgs::ClientMsg;
+    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics24_host::identifier::ClientId;
     use crate::events::IbcEvent;
     use crate::handler::HandlerOutput;
@@ -120,8 +122,9 @@ mod tests {
                 assert_eq!(events.len(), 1);
                 let event = events.pop().unwrap();
                 assert!(
-                    matches!(event, IbcEvent::UpgradeClient(e) if e.client_id() == &msg.client_id)
+                    matches!(event, IbcEvent::UpgradeClient(ref e) if e.client_id() == &msg.client_id)
                 );
+                assert_eq!(event.height(), ctx.host_height());
                 assert!(log.is_empty());
                 // Check the result
                 match result {

--- a/modules/src/core/ics02_client/handler/upgrade_client.rs
+++ b/modules/src/core/ics02_client/handler/upgrade_client.rs
@@ -80,12 +80,12 @@ mod tests {
 
     use core::str::FromStr;
 
+    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics02_client::error::{Error, ErrorDetail};
     use crate::core::ics02_client::handler::dispatch;
     use crate::core::ics02_client::handler::ClientResult::Upgrade;
     use crate::core::ics02_client::msgs::upgrade_client::MsgUpgradeAnyClient;
     use crate::core::ics02_client::msgs::ClientMsg;
-    use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics24_host::identifier::ClientId;
     use crate::events::IbcEvent;
     use crate::handler::HandlerOutput;

--- a/modules/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -82,6 +82,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         connection_id: Some(result.connection_id.clone()),
+        height: ctx.host_current_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenAckConnection(event_attributes.into()));
@@ -97,6 +98,7 @@ mod tests {
     use test_log::test;
 
     use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
+    use crate::core::ics03_connection::context::ConnectionReader;
     use crate::core::ics03_connection::error;
     use crate::core::ics03_connection::handler::{dispatch, ConnectionResult};
     use crate::core::ics03_connection::msgs::conn_open_ack::test_util::get_dummy_raw_msg_conn_open_ack;
@@ -238,6 +240,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenAckConnection(_)));
+                        assert_eq!(e.height(), test.ctx.host_current_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -62,6 +62,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         connection_id: Some(result.connection_id.clone()),
+        height: ctx.host_current_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenConfirmConnection(event_attributes.into()));
@@ -169,6 +170,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenConfirmConnection(_)));
+                        assert_eq!(e.height(), test.ctx.host_current_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_init.rs
@@ -45,6 +45,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         connection_id: Some(conn_id),
+        height: ctx.host_current_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenInitConnection(event_attributes.into()));
@@ -59,6 +60,7 @@ mod tests {
     use test_log::test;
 
     use crate::core::ics03_connection::connection::State;
+    use crate::core::ics03_connection::context::ConnectionReader;
     use crate::core::ics03_connection::handler::{dispatch, ConnectionResult};
     use crate::core::ics03_connection::msgs::conn_open_init::test_util::get_dummy_raw_msg_conn_open_init;
     use crate::core::ics03_connection::msgs::conn_open_init::MsgConnectionOpenInit;
@@ -118,6 +120,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenInitConnection(_)));
+                        assert_eq!(e.height(), test.ctx.host_current_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_try.rs
@@ -112,6 +112,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         connection_id: Some(conn_id),
+        height: ctx.host_current_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenTryConnection(event_attributes.into()));
@@ -126,6 +127,7 @@ mod tests {
     use test_log::test;
 
     use crate::core::ics03_connection::connection::State;
+    use crate::core::ics03_connection::context::ConnectionReader;
     use crate::core::ics03_connection::handler::{dispatch, ConnectionResult};
     use crate::core::ics03_connection::msgs::conn_open_try::test_util::get_dummy_raw_msg_conn_open_try;
     use crate::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
@@ -248,6 +250,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenTryConnection(_)));
+                        assert_eq!(e.height(), test.ctx.host_current_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/acknowledgement.rs
@@ -1,4 +1,3 @@
-use crate::core::ics02_client::height::Height;
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{Counterparty, Order};
@@ -112,7 +111,7 @@ pub fn process(
     output.log("success: packet ack");
 
     output.emit(IbcEvent::AcknowledgePacket(AcknowledgePacket {
-        height: Height::zero(),
+        height: ctx.host_height(),
         packet: packet.clone(),
     }));
 
@@ -254,6 +253,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::AcknowledgePacket(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -169,7 +169,7 @@ mod tests {
 
         let handler_output = channel_dispatch(
             &context,
-            ChannelMsg::ChannelCloseConfirm(msg_chan_close_confirm.clone()),
+            ChannelMsg::ChannelCloseConfirm(msg_chan_close_confirm),
         )
         .unwrap();
 

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -89,6 +89,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id),
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseConfirmChannel(
@@ -98,4 +99,85 @@ pub(crate) fn process(
     ));
 
     Ok(output.with_result(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::ics04_channel::context::ChannelReader;
+    use crate::core::ics04_channel::msgs::chan_close_confirm::test_util::get_dummy_raw_msg_chan_close_confirm;
+    use crate::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
+    use crate::core::ics04_channel::msgs::ChannelMsg;
+    use crate::events::IbcEvent;
+    use crate::prelude::*;
+
+    use crate::core::ics02_client::client_type::ClientType;
+    use crate::core::ics03_connection::connection::ConnectionEnd;
+    use crate::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
+    use crate::core::ics03_connection::connection::State as ConnectionState;
+    use crate::core::ics03_connection::msgs::test_util::get_dummy_raw_counterparty;
+    use crate::core::ics03_connection::version::get_compatible_versions;
+    use crate::core::ics04_channel::channel::{
+        ChannelEnd, Counterparty, Order, State as ChannelState,
+    };
+    use crate::core::ics04_channel::handler::channel_dispatch;
+    use crate::core::ics04_channel::Version;
+    use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
+
+    use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
+
+    #[test]
+    fn chan_close_confirm_event_height() {
+        let client_id = ClientId::new(ClientType::Mock, 24).unwrap();
+        let conn_id = ConnectionId::new(2);
+        let default_context = MockContext::default();
+        let client_consensus_state_height = default_context.host_height();
+
+        let conn_end = ConnectionEnd::new(
+            ConnectionState::Open,
+            client_id.clone(),
+            ConnectionCounterparty::try_from(get_dummy_raw_counterparty()).unwrap(),
+            get_compatible_versions(),
+            ZERO_DURATION,
+        );
+
+        let msg_chan_close_confirm = MsgChannelCloseConfirm::try_from(
+            get_dummy_raw_msg_chan_close_confirm(client_consensus_state_height.revision_height),
+        )
+        .unwrap();
+
+        let chan_end = ChannelEnd::new(
+            ChannelState::Open,
+            Order::default(),
+            Counterparty::new(
+                msg_chan_close_confirm.port_id.clone(),
+                Some(msg_chan_close_confirm.channel_id.clone()),
+            ),
+            vec![conn_id.clone()],
+            Version::default(),
+        );
+
+        let context = default_context
+            .with_client(&client_id, client_consensus_state_height)
+            .with_connection(conn_id, conn_end)
+            .with_port_capability(msg_chan_close_confirm.port_id.clone())
+            .with_channel(
+                msg_chan_close_confirm.port_id.clone(),
+                msg_chan_close_confirm.channel_id.clone(),
+                chan_end,
+            );
+
+        let handler_output = channel_dispatch(
+            &context,
+            ChannelMsg::ChannelCloseConfirm(msg_chan_close_confirm.clone()),
+        )
+        .unwrap();
+
+        assert!(!handler_output.events.is_empty()); // Some events must exist.
+
+        for event in handler_output.events.iter() {
+            assert!(matches!(event, &IbcEvent::CloseConfirmChannel(_)));
+            assert_eq!(event.height(), context.host_height());
+        }
+    }
 }

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -141,7 +141,7 @@ mod tests {
 
         let handler_output = channel_dispatch(
             &context,
-            ChannelMsg::ChannelCloseInit(msg_chan_close_init.clone()),
+            ChannelMsg::ChannelCloseInit(msg_chan_close_init),
         )
         .unwrap();
 

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -139,11 +139,8 @@ mod tests {
                 )
         };
 
-        let handler_output = channel_dispatch(
-            &context,
-            ChannelMsg::ChannelCloseInit(msg_chan_close_init),
-        )
-        .unwrap();
+        let handler_output =
+            channel_dispatch(&context, ChannelMsg::ChannelCloseInit(msg_chan_close_init)).unwrap();
 
         assert!(!handler_output.events.is_empty()); // Some events must exist.
 

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -60,6 +60,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id),
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseInitChannel(
@@ -69,4 +70,86 @@ pub(crate) fn process(
     ));
 
     Ok(output.with_result(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::ics04_channel::context::ChannelReader;
+    use crate::core::ics04_channel::msgs::chan_close_init::test_util::get_dummy_raw_msg_chan_close_init;
+    use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
+    use crate::core::ics04_channel::msgs::ChannelMsg;
+    use crate::events::IbcEvent;
+    use crate::prelude::*;
+
+    use crate::core::ics02_client::client_type::ClientType;
+    use crate::core::ics03_connection::connection::ConnectionEnd;
+    use crate::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
+    use crate::core::ics03_connection::connection::State as ConnectionState;
+    use crate::core::ics03_connection::msgs::test_util::get_dummy_raw_counterparty;
+    use crate::core::ics03_connection::version::get_compatible_versions;
+    use crate::core::ics04_channel::channel::{
+        ChannelEnd, Counterparty, Order, State as ChannelState,
+    };
+    use crate::core::ics04_channel::handler::channel_dispatch;
+    use crate::core::ics04_channel::Version;
+    use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
+
+    use crate::mock::context::MockContext;
+    use crate::timestamp::ZERO_DURATION;
+
+    #[test]
+    fn chan_close_init_event_height() {
+        let client_id = ClientId::new(ClientType::Mock, 24).unwrap();
+        let conn_id = ConnectionId::new(2);
+
+        let conn_end = ConnectionEnd::new(
+            ConnectionState::Open,
+            client_id.clone(),
+            ConnectionCounterparty::try_from(get_dummy_raw_counterparty()).unwrap(),
+            get_compatible_versions(),
+            ZERO_DURATION,
+        );
+
+        let msg_chan_close_init =
+            MsgChannelCloseInit::try_from(get_dummy_raw_msg_chan_close_init()).unwrap();
+
+        let chan_end = ChannelEnd::new(
+            ChannelState::Open,
+            Order::default(),
+            Counterparty::new(
+                msg_chan_close_init.port_id.clone(),
+                Some(msg_chan_close_init.channel_id.clone()),
+            ),
+            vec![conn_id.clone()],
+            Version::default(),
+        );
+
+        let context = {
+            let default_context = MockContext::default();
+            let client_consensus_state_height = default_context.host_height();
+
+            default_context
+                .with_client(&client_id, client_consensus_state_height)
+                .with_connection(conn_id, conn_end)
+                .with_port_capability(msg_chan_close_init.port_id.clone())
+                .with_channel(
+                    msg_chan_close_init.port_id.clone(),
+                    msg_chan_close_init.channel_id.clone(),
+                    chan_end,
+                )
+        };
+
+        let handler_output = channel_dispatch(
+            &context,
+            ChannelMsg::ChannelCloseInit(msg_chan_close_init.clone()),
+        )
+        .unwrap();
+
+        assert!(!handler_output.events.is_empty()); // Some events must exist.
+
+        for event in handler_output.events.iter() {
+            assert!(matches!(event, &IbcEvent::CloseInitChannel(_)));
+            assert_eq!(event.height(), context.host_height());
+        }
+    }
 }

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -98,6 +98,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id),
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenAckChannel(
@@ -124,6 +125,7 @@ mod tests {
     use crate::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
     use crate::core::ics03_connection::version::get_compatible_versions;
     use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::core::ics04_channel::handler::{channel_dispatch, ChannelResult};
     use crate::core::ics04_channel::msgs::chan_open_ack::test_util::get_dummy_raw_msg_chan_open_ack;
     use crate::core::ics04_channel::msgs::chan_open_ack::MsgChannelOpenAck;
@@ -332,6 +334,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenAckChannel(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -93,6 +93,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id),
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenConfirmChannel(
@@ -118,6 +119,7 @@ mod tests {
     use crate::core::ics03_connection::msgs::test_util::get_dummy_raw_counterparty;
     use crate::core::ics03_connection::version::get_compatible_versions;
     use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order, State};
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::core::ics04_channel::handler::{channel_dispatch, ChannelResult};
     use crate::core::ics04_channel::msgs::chan_open_confirm::test_util::get_dummy_raw_msg_chan_open_confirm;
     use crate::core::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
@@ -207,6 +209,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenConfirmChannel(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -69,6 +69,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(chan_id),
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenInitChannel(
@@ -92,6 +93,7 @@ mod tests {
     use crate::core::ics03_connection::msgs::conn_open_init::MsgConnectionOpenInit;
     use crate::core::ics03_connection::version::get_compatible_versions;
     use crate::core::ics04_channel::channel::State;
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::core::ics04_channel::handler::{channel_dispatch, ChannelResult};
     use crate::core::ics04_channel::msgs::chan_open_init::test_util::get_dummy_raw_msg_chan_open_init;
     use crate::core::ics04_channel::msgs::chan_open_init::MsgChannelOpenInit;
@@ -185,6 +187,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenInitChannel(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -139,6 +139,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(channel_id),
+        height: ctx.host_height(),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenTryChannel(
@@ -165,6 +166,7 @@ mod tests {
     use crate::core::ics03_connection::msgs::test_util::get_dummy_raw_counterparty;
     use crate::core::ics03_connection::version::get_compatible_versions;
     use crate::core::ics04_channel::channel::{ChannelEnd, State};
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::core::ics04_channel::handler::{channel_dispatch, ChannelResult};
     use crate::core::ics04_channel::msgs::chan_open_try::test_util::get_dummy_raw_msg_chan_open_try;
     use crate::core::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
@@ -440,6 +442,7 @@ mod tests {
 
                     for e in handler_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenTryChannel(_)));
+                        assert!(e.height() == test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -442,7 +442,7 @@ mod tests {
 
                     for e in handler_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::OpenTryChannel(_)));
-                        assert!(e.height() == test.ctx.host_height());
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -1,4 +1,3 @@
-use crate::core::ics02_client::height::Height;
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{Counterparty, Order, State};
 use crate::core::ics04_channel::context::ChannelReader;
@@ -127,7 +126,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
     output.log("success: packet receive");
 
     output.emit(IbcEvent::ReceivePacket(ReceivePacket {
-        height: Height::zero(),
+        height: ctx.host_height(),
         packet: msg.packet,
     }));
 
@@ -136,6 +135,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
 
 #[cfg(test)]
 mod tests {
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::prelude::*;
 
     use test_log::test;
@@ -293,6 +293,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::ReceivePacket(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -59,7 +59,6 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
         ));
     }
 
-    // Check if packet height is newer than the height of the local host chain
     let latest_height = ctx.host_height();
     if (!packet.timeout_height.is_zero()) && (packet.timeout_height <= latest_height) {
         return Err(Error::low_packet_height(
@@ -68,7 +67,6 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgRecvPacket) -> HandlerResult<Pac
         ));
     }
 
-    // Check if packet timestamp is newer than the local host chain timestamp
     let latest_timestamp = ctx.host_timestamp();
     if let Expiry::Expired = latest_timestamp.check_expiry(&packet.timeout_timestamp) {
         return Err(Error::low_packet_timestamp());

--- a/modules/src/core/ics04_channel/handler/send_packet.rs
+++ b/modules/src/core/ics04_channel/handler/send_packet.rs
@@ -57,7 +57,6 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
         return Err(Error::frozen_client(connection_end.client_id().clone()));
     }
 
-    // check if packet height is newer than the height of the latest client state on the receiving chain
     let latest_height = client_state.latest_height();
 
     if !packet.timeout_height.is_zero() && packet.timeout_height <= latest_height {
@@ -67,17 +66,13 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
         ));
     }
 
-    //check if packet timestamp is newer than the timestamp of the latest consensus state of the receiving chain
     let consensus_state = ctx.client_consensus_state(&client_id, latest_height)?;
-
     let latest_timestamp = consensus_state.timestamp();
-
     let packet_timestamp = packet.timeout_timestamp;
     if let Expiry::Expired = latest_timestamp.check_expiry(&packet_timestamp) {
         return Err(Error::low_packet_timestamp());
     }
 
-    // check sequence number
     let next_seq_send =
         ctx.get_next_sequence_send(&(packet.source_port.clone(), packet.source_channel.clone()))?;
 

--- a/modules/src/core/ics04_channel/handler/send_packet.rs
+++ b/modules/src/core/ics04_channel/handler/send_packet.rs
@@ -59,9 +59,8 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
 
     // check if packet height is newer than the height of the latest client state on the receiving chain
     let latest_height = client_state.latest_height();
-    let packet_height = packet.timeout_height;
 
-    if !packet.timeout_height.is_zero() && packet_height <= latest_height {
+    if !packet.timeout_height.is_zero() && packet.timeout_height <= latest_height {
         return Err(Error::low_packet_height(
             latest_height,
             packet.timeout_height,
@@ -102,7 +101,7 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
     });
 
     output.emit(IbcEvent::SendPacket(SendPacket {
-        height: packet_height,
+        height: ctx.host_height(),
         packet,
     }));
 
@@ -122,6 +121,7 @@ mod tests {
     use crate::core::ics03_connection::connection::State as ConnectionState;
     use crate::core::ics03_connection::version::get_compatible_versions;
     use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order, State};
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::core::ics04_channel::handler::send_packet::send_packet;
     use crate::core::ics04_channel::packet::test_utils::get_dummy_raw_packet;
     use crate::core::ics04_channel::packet::Packet;
@@ -241,6 +241,7 @@ mod tests {
                     // TODO: The object in the output is a PacketResult what can we check on it?
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::SendPacket(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/timeout.rs
+++ b/modules/src/core/ics04_channel/handler/timeout.rs
@@ -133,7 +133,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: MsgTimeout) -> HandlerResult<Packet
     output.log("success: packet timeout ");
 
     output.emit(IbcEvent::TimeoutPacket(TimeoutPacket {
-        height: Default::default(),
+        height: ctx.host_height(),
         packet: packet.clone(),
     }));
 
@@ -318,6 +318,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::TimeoutPacket(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -128,7 +128,7 @@ pub fn process(
     output.log("success: packet timeout ");
 
     output.emit(IbcEvent::TimeoutOnClosePacket(TimeoutOnClosePacket {
-        height: Default::default(),
+        height: ctx.host_height(),
         packet: packet.clone(),
     }));
 
@@ -271,6 +271,7 @@ mod tests {
                     assert!(!proto_output.events.is_empty()); // Some events must exist.
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::TimeoutOnClosePacket(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -66,7 +66,7 @@ pub fn process(
     output.log("success: packet write acknowledgement");
 
     output.emit(IbcEvent::WriteAcknowledgement(WriteAcknowledgement {
-        height: Default::default(),
+        height: ctx.host_height(),
         packet,
         ack,
     }));
@@ -76,6 +76,7 @@ pub fn process(
 
 #[cfg(test)]
 mod tests {
+    use crate::core::ics04_channel::context::ChannelReader;
     use crate::prelude::*;
 
     use test_log::test;
@@ -206,6 +207,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::WriteAcknowledgement(_)));
+                        assert_eq!(e.height(), test.ctx.host_height());
                     }
                 }
                 Err(e) => {

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -366,6 +366,7 @@ impl IbcEvent {
             IbcEvent::WriteAcknowledgement(ev) => ev.height(),
             IbcEvent::AcknowledgePacket(ev) => ev.height(),
             IbcEvent::TimeoutPacket(ev) => ev.height(),
+            IbcEvent::TimeoutOnClosePacket(ev) => ev.height(),
             _ => unimplemented!(),
         }
     }

--- a/modules/src/events.rs
+++ b/modules/src/events.rs
@@ -349,6 +349,7 @@ impl IbcEvent {
             IbcEvent::NewBlock(bl) => bl.height(),
             IbcEvent::CreateClient(ev) => ev.height(),
             IbcEvent::UpdateClient(ev) => ev.height(),
+            IbcEvent::UpgradeClient(ev) => ev.height(),
             IbcEvent::ClientMisbehaviour(ev) => ev.height(),
             IbcEvent::OpenInitConnection(ev) => ev.height(),
             IbcEvent::OpenTryConnection(ev) => ev.height(),


### PR DESCRIPTION

Closes: #2035 

## Description

Make all handlers emit an `IbcEvent` with height `ctx.host_height()`.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).