### PR TITLE
Check `version` field of message in `ConnOpenInit` handler

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/2062-conn-open-init-version.md
+++ b/.changelog/unreleased/bug-fixes/ibc/2062-conn-open-init-version.md
@@ -1,0 +1,2 @@
+- Use the version in the message when handling a MsgConnOpenInit
+  ([#2062](https://github.com/informalsystems/ibc-rs/issues/2062))

--- a/modules/src/core/ics03_connection/error.rs
+++ b/modules/src/core/ics03_connection/error.rs
@@ -1,4 +1,5 @@
 use crate::core::ics02_client::error as client_error;
+use crate::core::ics03_connection::version::Version;
 use crate::core::ics24_host::error::ValidationError;
 use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
 use crate::proofs::ProofError;
@@ -65,6 +66,12 @@ define_error! {
 
         NoCommonVersion
             | _ | { "no common version" },
+
+        VersionNotSupported
+            {
+                version: Version,
+            }
+            | e | { format_args!("version \"{}\" not supported", e.version) },
 
         InvalidAddress
             | _ | { "invalid address" },

--- a/modules/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_init.rs
@@ -104,7 +104,7 @@ mod tests {
         let tests: Vec<Test> = vec![
             Test {
                 name: "Processing fails because no client exists in the context".to_string(),
-                ctx: default_context.clone(),
+                ctx: default_context,
                 msg: ConnectionMsg::ConnectionOpenInit(msg_conn_init_default.clone()),
                 expected_versions: vec![msg_conn_init_default.version.clone().unwrap()],
                 want_pass: false,
@@ -118,9 +118,9 @@ mod tests {
             },
             Test {
                 name: "Good parameters".to_string(),
-                ctx: good_context.clone(),
+                ctx: good_context,
                 msg: ConnectionMsg::ConnectionOpenInit(msg_conn_init_default.clone()),
-                expected_versions: vec![msg_conn_init_default.version.clone().unwrap()],
+                expected_versions: vec![msg_conn_init_default.version.unwrap()],
                 want_pass: true,
             },
         ]

--- a/modules/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_init.rs
@@ -20,11 +20,22 @@ pub(crate) fn process(
     // An IBC client running on the local (host) chain should exist.
     ctx.client_state(&msg.client_id)?;
 
+    let versions = match msg.version {
+        Some(version) => {
+            if ctx.get_compatible_versions().contains(&version) {
+                Ok(vec![version])
+            } else {
+                Err(Error::version_not_supported(version))
+            }
+        }
+        None => Ok(ctx.get_compatible_versions()),
+    }?;
+
     let new_connection_end = ConnectionEnd::new(
         State::Init,
         msg.client_id.clone(),
         msg.counterparty.clone(),
-        ctx.get_compatible_versions(),
+        versions,
         msg.delay_period,
     );
 

--- a/modules/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_init.rs
@@ -102,7 +102,9 @@ mod tests {
             version: Version::try_from(RawVersion {
                 identifier: "random identifier 424242".to_string(),
                 features: vec![],
-            }).unwrap().into(),
+            })
+            .unwrap()
+            .into(),
             ..msg_conn_init_default.clone()
         };
         let default_context = MockContext::default();

--- a/modules/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_init.rs
@@ -80,6 +80,8 @@ mod tests {
     use crate::mock::context::MockContext;
     use crate::Height;
 
+    use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
+
     #[test]
     fn conn_open_init_msg_processing() {
         struct Test {
@@ -96,6 +98,13 @@ mod tests {
             version: None,
             ..msg_conn_init_default.clone()
         };
+        let msg_conn_init_bad_version = MsgConnectionOpenInit {
+            version: Version::try_from(RawVersion {
+                identifier: "random identifier 424242".to_string(),
+                features: vec![],
+            }).unwrap().into(),
+            ..msg_conn_init_default.clone()
+        };
         let default_context = MockContext::default();
         let good_context = default_context
             .clone()
@@ -107,6 +116,13 @@ mod tests {
                 ctx: default_context,
                 msg: ConnectionMsg::ConnectionOpenInit(msg_conn_init_default.clone()),
                 expected_versions: vec![msg_conn_init_default.version.clone().unwrap()],
+                want_pass: false,
+            },
+            Test {
+                name: "Incompatible version in MsgConnectionOpenInit msg".to_string(),
+                ctx: good_context.clone(),
+                msg: ConnectionMsg::ConnectionOpenInit(msg_conn_init_bad_version),
+                expected_versions: vec![],
                 want_pass: false,
             },
             Test {

--- a/modules/src/core/ics03_connection/msgs/conn_open_init.rs
+++ b/modules/src/core/ics03_connection/msgs/conn_open_init.rs
@@ -21,7 +21,7 @@ pub const TYPE_URL: &str = "/ibc.core.connection.v1.MsgConnectionOpenInit";
 pub struct MsgConnectionOpenInit {
     pub client_id: ClientId,
     pub counterparty: Counterparty,
-    pub version: Version,
+    pub version: Option<Version>,
     pub delay_period: Duration,
     pub signer: Signer,
 }
@@ -51,7 +51,7 @@ impl TryFrom<RawMsgConnectionOpenInit> for MsgConnectionOpenInit {
                 .counterparty
                 .ok_or_else(Error::missing_counterparty)?
                 .try_into()?,
-            version: msg.version.ok_or_else(Error::empty_versions)?.try_into()?,
+            version: msg.version.map(|version| version.try_into()).transpose()?,
             delay_period: Duration::from_nanos(msg.delay_period),
             signer: msg.signer.into(),
         })
@@ -63,7 +63,7 @@ impl From<MsgConnectionOpenInit> for RawMsgConnectionOpenInit {
         RawMsgConnectionOpenInit {
             client_id: ics_msg.client_id.as_str().to_string(),
             counterparty: Some(ics_msg.counterparty.into()),
-            version: Some(ics_msg.version.into()),
+            version: ics_msg.version.map(|version| version.into()),
             delay_period: ics_msg.delay_period.as_nanos() as u64,
             signer: ics_msg.signer.to_string(),
         }

--- a/modules/src/core/ics03_connection/version.rs
+++ b/modules/src/core/ics03_connection/version.rs
@@ -1,3 +1,5 @@
+use core::fmt::Display;
+
 use crate::prelude::*;
 
 use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
@@ -61,6 +63,12 @@ impl Default for Version {
                 Order::Unordered.as_str().to_owned(),
             ],
         }
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.identifier)
     }
 }
 

--- a/modules/tests/runner/mod.rs
+++ b/modules/tests/runner/mod.rs
@@ -363,7 +363,7 @@ impl IbcTestRunner {
                     MsgConnectionOpenInit {
                         client_id: Self::client_id(client_id),
                         counterparty: Self::counterparty(counterparty_client_id, None),
-                        version: Self::version(),
+                        version: Some(Self::version()),
                         delay_period: Self::delay_period(),
                         signer: Self::signer(),
                     },

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -793,7 +793,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
         let new_msg = MsgConnectionOpenInit {
             client_id: self.dst_client_id().clone(),
             counterparty,
-            version,
+            version: Some(version),
             delay_period: self.delay_period,
             signer,
         };


### PR DESCRIPTION
Closes: #2062

## Description
We previously ignored the version in the message when handling a `MsgConnOpenInit`. This PR fixes this in a manner compliant with ICS 003.

Relevant part of the spec is [here](https://github.com/cosmos/ibc/blob/master/spec/core/ics-003-connection-semantics/README.md) (search for `A specific version can optionally be passed`).

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).