### PR TITLE
Fix bug in wildcard filter where pattern would match in the middle of a string

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/2075-wildcard-filter-middle.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/2075-wildcard-filter-middle.md
@@ -1,0 +1,2 @@
+- Fix a bug in the wildcard filter where pattern would match in the middle of a
+  string ([#2075](https://github.com/informalsystems/ibc-rs/issues/2075))

--- a/relayer/src/config/filter.rs
+++ b/relayer/src/config/filter.rs
@@ -137,29 +137,35 @@ impl Serialize for ChannelFilters {
 
 /// Newtype wrapper for expressing wildcard patterns compiled to a [`regex::Regex`].
 #[derive(Clone, Debug)]
-pub struct Wildcard(regex::Regex);
+pub struct Wildcard {
+    pattern: String,
+    regex: regex::Regex,
+}
 
 impl Wildcard {
+    pub fn new(pattern: String) -> Result<Self, regex::Error> {
+        let escaped = regex::escape(&pattern).replace("\\*", "(?:.*)");
+        let regex = format!("^{escaped}$").parse()?;
+        Ok(Self { pattern, regex })
+    }
+
     #[inline]
     pub fn is_match(&self, text: &str) -> bool {
-        self.0.is_match(text)
+        self.regex.is_match(text)
     }
 }
 
 impl FromStr for Wildcard {
     type Err = regex::Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let escaped = regex::escape(s).replace("\\*", "(?:.*)");
-        format!("^{escaped}$").parse().map(Self)
+    fn from_str(pattern: &str) -> Result<Self, Self::Err> {
+        Self::new(pattern.to_string())
     }
 }
 
 impl fmt::Display for Wildcard {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = self.0.to_string().replace("(?:.*)", "*");
-        let s = s.trim_start_matches('^').trim_end_matches('$');
-        write!(f, "{}", s)
+        write!(f, "{}", self.pattern)
     }
 }
 
@@ -168,13 +174,13 @@ impl Serialize for Wildcard {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(&self.pattern)
     }
 }
 
 impl PartialEq for Wildcard {
     fn eq(&self, other: &Self) -> bool {
-        self.to_string() == other.to_string()
+        self.pattern == other.pattern
     }
 }
 


### PR DESCRIPTION
Closes: #2075 

## Description

The fix anchors the regex by delimiting it with `^` and `$` so that it only matches the full string and not anywhere in the middle.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).