### PR TITLE
Increase timeout for assert_eventual_wallet_amount to reduce CI flakiness

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           nix shell github:informalsystems/cosmos.nix#${{ matrix.gaiad }} -c cargo \
             test -p ibc-integration-test --no-fail-fast -- \
-            --nocapture --test-threads=1
+            --nocapture --test-threads=2
 
   ibc-go-integration-test:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
           CHAIN_COMMAND_PATH: simd
         run: |
           nix shell github:informalsystems/cosmos.nix#${{ matrix.simapp }} -c cargo \
-            test -p ibc-integration-test --no-fail-fast -- --nocapture --test-threads=1
+            test -p ibc-integration-test --no-fail-fast -- --nocapture --test-threads=2
 
   ordered-channel-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           nix shell github:informalsystems/cosmos.nix#${{ matrix.gaiad }} -c cargo \
             test -p ibc-integration-test --no-fail-fast -- \
-            --nocapture
+            --nocapture --test-threads=1
 
   ibc-go-integration-test:
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
           CHAIN_COMMAND_PATH: simd
         run: |
           nix shell github:informalsystems/cosmos.nix#${{ matrix.simapp }} -c cargo \
-            test -p ibc-integration-test --no-fail-fast -- --nocapture
+            test -p ibc-integration-test --no-fail-fast -- --nocapture --test-threads=1
 
   ordered-channel-test:
     runs-on: ubuntu-latest

--- a/tools/test-framework/src/chain/driver.rs
+++ b/tools/test-framework/src/chain/driver.rs
@@ -34,6 +34,19 @@ pub mod query_txs;
 pub mod tagged;
 pub mod transfer;
 
+/**
+    Number of times (seconds) to try and query a wallet to reach the
+    target amount, as used by [`assert_eventual_wallet_amount`].
+
+    We set this to around 60 seconds to make sure that the tests still
+    pass in slower environments like the CI.
+
+    If you encounter retry error, try increasing this constant. If the
+    test is taking much longer to reach eventual consistency, it might
+    be indication of some underlying performance issues.
+ */
+const WAIT_WALLET_AMOUNT_ATTEMPTS: u16 = 60;
+
 const COSMOS_HD_PATH: &str = "m/44'/118'/0'/0/0";
 
 /**
@@ -489,7 +502,7 @@ impl ChainDriver {
     ) -> Result<(), Error> {
         assert_eventually_succeed(
             &format!("wallet reach {} amount {} {}", wallet, target_amount, denom),
-            30,
+            WAIT_WALLET_AMOUNT_ATTEMPTS,
             Duration::from_secs(1),
             || {
                 let amount = self.query_balance(wallet, denom)?;

--- a/tools/test-framework/src/chain/driver.rs
+++ b/tools/test-framework/src/chain/driver.rs
@@ -35,16 +35,16 @@ pub mod tagged;
 pub mod transfer;
 
 /**
-    Number of times (seconds) to try and query a wallet to reach the
-    target amount, as used by [`assert_eventual_wallet_amount`].
+   Number of times (seconds) to try and query a wallet to reach the
+   target amount, as used by [`assert_eventual_wallet_amount`].
 
-    We set this to around 60 seconds to make sure that the tests still
-    pass in slower environments like the CI.
+   We set this to around 60 seconds to make sure that the tests still
+   pass in slower environments like the CI.
 
-    If you encounter retry error, try increasing this constant. If the
-    test is taking much longer to reach eventual consistency, it might
-    be indication of some underlying performance issues.
- */
+   If you encounter retry error, try increasing this constant. If the
+   test is taking much longer to reach eventual consistency, it might
+   be indication of some underlying performance issues.
+*/
 const WAIT_WALLET_AMOUNT_ATTEMPTS: u16 = 60;
 
 const COSMOS_HD_PATH: &str = "m/44'/118'/0'/0/0";

--- a/tools/test-framework/src/error.rs
+++ b/tools/test-framework/src/error.rs
@@ -48,6 +48,19 @@ define_error! {
         Packet
             [ PacketError ]
             | _ | { "packet error"},
+
+        Retry
+            {
+                task_name: String,
+                attempts: u16,
+            }
+            | e | {
+                format_args!(
+                    "Expected task to eventually succeeed, but failed after {} attempts: {}",
+                    e.attempts,
+                    e.task_name
+                )
+            }
     }
 }
 

--- a/tools/test-framework/src/util/retry.rs
+++ b/tools/test-framework/src/util/retry.rs
@@ -3,7 +3,6 @@
 */
 
 use core::time::Duration;
-use eyre::eyre;
 use std::thread::sleep;
 use tracing::{debug, info};
 
@@ -35,9 +34,5 @@ pub fn assert_eventually_succeed<R>(
         }
     }
 
-    Err(Error::generic(eyre!(
-        "Expected task to eventually succeeed, but failed after {} attempts: {}",
-        attempts,
-        task_name
-    )))
+    Err(Error::retry(task_name.to_string(), attempts))
 }


### PR DESCRIPTION

## Description

The tests on CI sometimes have flaky failure from `assert_eventual_wallet_amount`, which returns error if the target wallet do not reach the target amount within 30 seconds.

The time limit might be too low in the CI environment, in particular since we allow multiple tests to be running in parallel, and thus increase the load of concurrent full nodes. We will try and increase the timeout to 60 seconds and see if it reduce the flakiness in the integration tests.

If the issue still persist, we may want to consider reducing the concurrent tests being run, so that each full node have sufficient resources to produce the blocks fast enough.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).