### PR TITLE
Only deploy the guide when a new release is created

### DIFF
--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths:
       - guide/**
+  release:
+    types: [created]
 
 jobs:
   guide:
@@ -50,10 +52,10 @@ jobs:
           cd guide
           mdbook build
 
-      # Only deploy guide when pushing to master
+      # Only deploy guide when releasing a new version of Hermes
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: github.event_name == 'release' && github.event.action == 'created'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./guide/book


### PR DESCRIPTION
## Description

Only deploy the guide to `gh-pages` when a new release is created.

This should alleviate the lack of versioning of the guide by only updating the published version whenever we create a new release of the project, which happens automatically when we push a `vX` tag.

Only downside is that we would have to do the deploy step manually whenever we want to update the guide (eg. because of a typo) in between releases, but that seems manageable.