### PR TITLE
Implement `query packet pending` command

### DIFF
--- a/.changelog/unreleased/improvements/2096-query-packet-pending.md
+++ b/.changelog/unreleased/improvements/2096-query-packet-pending.md
@@ -1,0 +1,4 @@
+- Added `query packet pending` command to list outstanding packet
+  commitments that are either unreceived or pending acknowledgement
+  at both ends of a channel.
+  ([#1862](https://github.com/informalsystems/ibc-rs/issues/1862))

--- a/relayer-cli/src/cli_utils.rs
+++ b/relayer-cli/src/cli_utils.rs
@@ -2,9 +2,8 @@ use alloc::sync::Arc;
 use tokio::runtime::Runtime as TokioRuntime;
 
 use ibc::core::ics02_client::client_state::ClientState;
-use ibc::core::ics04_channel::channel::IdentifiedChannelEnd;
 use ibc::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
-use ibc_relayer::chain::counterparty::channel_connection_client;
+use ibc_relayer::chain::counterparty::{channel_connection_client, ChannelConnectionClient};
 use ibc_relayer::{
     chain::{
         handle::{BaseChainHandle, ChainHandle},
@@ -80,7 +79,7 @@ pub fn spawn_chain_counterparty<Chain: ChainHandle>(
     chain_id: &ChainId,
     port_id: &PortId,
     channel_id: &ChannelId,
-) -> Result<(ChainHandlePair<Chain>, IdentifiedChannelEnd), Error> {
+) -> Result<(ChainHandlePair<Chain>, ChannelConnectionClient), Error> {
     let chain = spawn_chain_runtime_generic::<Chain>(config, chain_id)?;
     let channel_connection_client =
         channel_connection_client(&chain, port_id, channel_id).map_err(Error::supervisor)?;
@@ -94,6 +93,6 @@ pub fn spawn_chain_counterparty<Chain: ChainHandle>(
             src: chain,
             dst: counterparty_chain,
         },
-        channel_connection_client.channel,
+        channel_connection_client,
     ))
 }

--- a/relayer-cli/src/commands/query/packet.rs
+++ b/relayer-cli/src/commands/query/packet.rs
@@ -5,6 +5,7 @@ mod ack;
 mod acks;
 mod commitment;
 mod commitments;
+mod pending;
 mod unreceived_acks;
 mod unreceived_packets;
 
@@ -27,4 +28,7 @@ pub enum QueryPacketCmds {
 
     /// Query unreceived acknowledgments
     UnreceivedAcks(unreceived_acks::QueryUnreceivedAcknowledgementCmd),
+
+    /// Output a summary of pending packets in both directions
+    Pending(pending::QueryPendingPacketsCmd),
 }

--- a/relayer-cli/src/commands/query/packet/acks.rs
+++ b/relayer-cli/src/commands/query/packet/acks.rs
@@ -36,15 +36,16 @@ impl QueryPacketAcknowledgementsCmd {
 
         debug!("Options: {:?}", self);
 
-        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
+        let (chains, chan_conn_cli) = spawn_chain_counterparty::<BaseChainHandle>(
             &config,
             &self.chain_id,
             &self.port_id,
             &self.channel_id,
         )?;
 
-        let (seqs, height) = acknowledgements_on_chain(&chains.src, &chains.dst, &ccc.channel)
-            .map_err(Error::supervisor)?;
+        let (seqs, height) =
+            acknowledgements_on_chain(&chains.src, &chains.dst, &chan_conn_cli.channel)
+                .map_err(Error::supervisor)?;
 
         Ok(PacketSeqs { seqs, height })
     }

--- a/relayer-cli/src/commands/query/packet/acks.rs
+++ b/relayer-cli/src/commands/query/packet/acks.rs
@@ -36,14 +36,14 @@ impl QueryPacketAcknowledgementsCmd {
 
         debug!("Options: {:?}", self);
 
-        let (chains, channel) = spawn_chain_counterparty::<BaseChainHandle>(
+        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
             &config,
             &self.chain_id,
             &self.port_id,
             &self.channel_id,
         )?;
 
-        let (seqs, height) = acknowledgements_on_chain(&chains.src, &chains.dst, &channel)
+        let (seqs, height) = acknowledgements_on_chain(&chains.src, &chains.dst, &ccc.channel)
             .map_err(Error::supervisor)?;
 
         Ok(PacketSeqs { seqs, height })

--- a/relayer-cli/src/commands/query/packet/pending.rs
+++ b/relayer-cli/src/commands/query/packet/pending.rs
@@ -1,0 +1,89 @@
+use abscissa_core::clap::Parser;
+use abscissa_core::{Command, Runnable};
+use serde::Serialize;
+
+use ibc::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
+use ibc_relayer::chain::counterparty::{
+    channel_on_destination, pending_packet_summary, PendingPackets,
+};
+use ibc_relayer::chain::handle::BaseChainHandle;
+
+use crate::cli_utils::spawn_chain_counterparty;
+use crate::conclude::Output;
+use crate::error::Error;
+use crate::prelude::*;
+
+/// A structure to display pending packet commitment sequence IDs
+/// at both ends of a channel.
+#[derive(Debug, Serialize)]
+struct Summary {
+    /// The packets sent on the identified chain.
+    forward: PendingPackets,
+    /// The packets sent on the counterparty chain.
+    reverse: PendingPackets,
+}
+
+/// This command does the following:
+///
+/// 1. queries the chain to get its counterparty chain, channel and port identifiers (needed in 2)
+/// 2. queries both chains for all packet commitments/ sequences for the given port and channel
+///    and its counterparty.
+/// 3. queries both chains for the unreceived sequences and acks out of the lists obtained in 2.
+#[derive(Clone, Command, Debug, Parser)]
+pub struct QueryPendingPacketsCmd {
+    #[clap(
+        required = true,
+        help = "identifier of the chain at one end of the channel"
+    )]
+    chain_id: ChainId,
+
+    #[clap(
+        required = true,
+        help = "port identifier on the chain given by <CHAIN_ID>"
+    )]
+    port_id: PortId,
+
+    #[clap(
+        required = true,
+        help = "channel identifier on the chain given by <CHAIN_ID>"
+    )]
+    channel_id: ChannelId,
+}
+
+impl QueryPendingPacketsCmd {
+    fn execute(&self) -> Result<Summary, Error> {
+        let config = app_config();
+
+        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
+            &config,
+            &self.chain_id,
+            &self.port_id,
+            &self.channel_id,
+        )?;
+
+        debug!(
+            chain=%self.chain_id,
+            "fetched channel from source chain: {:?}",
+            ccc.channel
+        );
+
+        let forward = pending_packet_summary(&chains.src, &chains.dst, &ccc.channel)
+            .map_err(Error::supervisor)?;
+        let counterparty_channel =
+            channel_on_destination(&ccc.channel, &ccc.connection, &chains.dst)
+                .map_err(Error::supervisor)?
+                .ok_or_else(|| Error::missing_counterparty_channel_id(ccc.channel))?;
+        let reverse = pending_packet_summary(&chains.dst, &chains.src, &counterparty_channel)
+            .map_err(Error::supervisor)?;
+        Ok(Summary { forward, reverse })
+    }
+}
+
+impl Runnable for QueryPendingPacketsCmd {
+    fn run(&self) {
+        match self.execute() {
+            Ok(pending) => Output::success(pending).exit(),
+            Err(e) => Output::error(format!("{}", e)).exit(),
+        }
+    }
+}

--- a/relayer-cli/src/commands/query/packet/unreceived_acks.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_acks.rs
@@ -34,7 +34,7 @@ impl QueryUnreceivedAcknowledgementCmd {
         let config = app_config();
         debug!("Options: {:?}", self);
 
-        let (chains, channel) = spawn_chain_counterparty::<BaseChainHandle>(
+        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
             &config,
             &self.chain_id,
             &self.port_id,
@@ -43,10 +43,11 @@ impl QueryUnreceivedAcknowledgementCmd {
 
         debug!(
             "fetched from source chain {} the following channel {:?}",
-            self.chain_id, channel
+            self.chain_id, ccc.channel,
         );
 
-        unreceived_acknowledgements(&chains.src, &chains.dst, &channel).map_err(Error::supervisor)
+        unreceived_acknowledgements(&chains.src, &chains.dst, &ccc.channel)
+            .map_err(Error::supervisor)
     }
 }
 

--- a/relayer-cli/src/commands/query/packet/unreceived_acks.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_acks.rs
@@ -34,7 +34,7 @@ impl QueryUnreceivedAcknowledgementCmd {
         let config = app_config();
         debug!("Options: {:?}", self);
 
-        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
+        let (chains, chan_conn_cli) = spawn_chain_counterparty::<BaseChainHandle>(
             &config,
             &self.chain_id,
             &self.port_id,
@@ -43,10 +43,10 @@ impl QueryUnreceivedAcknowledgementCmd {
 
         debug!(
             "fetched from source chain {} the following channel {:?}",
-            self.chain_id, ccc.channel,
+            self.chain_id, chan_conn_cli.channel,
         );
 
-        unreceived_acknowledgements(&chains.src, &chains.dst, &ccc.channel)
+        unreceived_acknowledgements(&chains.src, &chains.dst, &chan_conn_cli.channel)
             .map_err(Error::supervisor)
     }
 }

--- a/relayer-cli/src/commands/query/packet/unreceived_packets.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_packets.rs
@@ -1,9 +1,7 @@
 use abscissa_core::clap::Parser;
 use abscissa_core::{Command, Runnable};
-use serde::Serialize;
 
 use ibc::core::ics24_host::identifier::{ChainId, ChannelId, PortId};
-use ibc::Height;
 use ibc_relayer::chain::counterparty::unreceived_packets;
 use ibc_relayer::chain::handle::BaseChainHandle;
 
@@ -11,12 +9,6 @@ use crate::cli_utils::spawn_chain_counterparty;
 use crate::conclude::Output;
 use crate::error::Error;
 use crate::prelude::*;
-
-#[derive(Serialize, Debug)]
-struct PacketSeqs {
-    height: Height,
-    seqs: Vec<u64>,
-}
 
 /// This command does the following:
 /// 1. queries the chain to get its counterparty chain, channel and port identifiers (needed in 2)

--- a/relayer-cli/src/commands/query/packet/unreceived_packets.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_packets.rs
@@ -34,7 +34,7 @@ impl QueryUnreceivedPacketsCmd {
         let config = app_config();
         debug!("Options: {:?}", self);
 
-        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
+        let (chains, chan_conn_cli) = spawn_chain_counterparty::<BaseChainHandle>(
             &config,
             &self.chain_id,
             &self.port_id,
@@ -43,10 +43,11 @@ impl QueryUnreceivedPacketsCmd {
 
         debug!(
             "fetched from source chain {} the following channel {:?}",
-            self.chain_id, ccc.channel
+            self.chain_id, chan_conn_cli.channel
         );
 
-        unreceived_packets(&chains.src, &chains.dst, &ccc.channel).map_err(Error::supervisor)
+        unreceived_packets(&chains.src, &chains.dst, &chan_conn_cli.channel)
+            .map_err(Error::supervisor)
     }
 }
 

--- a/relayer-cli/src/commands/query/packet/unreceived_packets.rs
+++ b/relayer-cli/src/commands/query/packet/unreceived_packets.rs
@@ -34,7 +34,7 @@ impl QueryUnreceivedPacketsCmd {
         let config = app_config();
         debug!("Options: {:?}", self);
 
-        let (chains, channel) = spawn_chain_counterparty::<BaseChainHandle>(
+        let (chains, ccc) = spawn_chain_counterparty::<BaseChainHandle>(
             &config,
             &self.chain_id,
             &self.port_id,
@@ -43,10 +43,10 @@ impl QueryUnreceivedPacketsCmd {
 
         debug!(
             "fetched from source chain {} the following channel {:?}",
-            self.chain_id, channel
+            self.chain_id, ccc.channel
         );
 
-        unreceived_packets(&chains.src, &chains.dst, &channel).map_err(Error::supervisor)
+        unreceived_packets(&chains.src, &chains.dst, &ccc.channel).map_err(Error::supervisor)
     }
 }
 

--- a/relayer/src/chain/counterparty.rs
+++ b/relayer/src/chain/counterparty.rs
@@ -361,7 +361,7 @@ pub fn unreceived_packets_sequences(
 
 /// Returns the sequences of the written acknowledgments on a given chain and channel (port_id + channel_id), out of
 /// the commitments still present on the counterparty chain.
-pub fn packet_acknowledgedgments(
+fn packet_acknowledgements(
     chain: &impl ChainHandle,
     port_id: &PortId,
     channel_id: &ChannelId,
@@ -408,7 +408,7 @@ pub fn unreceived_acknowledgements_sequences(
     // get the packet commitments on the destination chain
 
     // get the packet acknowledgments on counterparty chain
-    let (acks_on_counterparty, counterparty_height) = packet_acknowledgedgments(
+    let (acks_on_counterparty, counterparty_height) = packet_acknowledgements(
         counterparty_chain,
         counterparty_port_id,
         counterparty_channel_id,
@@ -470,7 +470,7 @@ pub fn acknowledgements_on_chain(
         .as_ref()
         .ok_or_else(Error::missing_counterparty_channel_id)?;
 
-    let (sequences, height) = packet_acknowledgedgments(
+    let (sequences, height) = packet_acknowledgements(
         chain,
         &channel.port_id,
         &channel.channel_id,

--- a/relayer/src/chain/counterparty.rs
+++ b/relayer/src/chain/counterparty.rs
@@ -332,7 +332,6 @@ pub fn unreceived_packets_sequences(
     channel_id: &ChannelId,
     commitments_on_counterparty: Vec<u64>,
 ) -> Result<Vec<u64>, Error> {
-    // get the packet commitments on the counterparty/ source chain
     if commitments_on_counterparty.is_empty() {
         return Ok(vec![]);
     }
@@ -385,6 +384,10 @@ pub fn unreceived_acknowledgements_sequences(
     channel_id: &ChannelId,
     acks_on_counterparty: Vec<u64>,
 ) -> Result<Vec<u64>, Error> {
+    if acks_on_counterparty.is_empty() {
+        return Ok(vec![]);
+    }
+
     let request = QueryUnreceivedAcksRequest {
         port_id: port_id.to_string(),
         channel_id: channel_id.to_string(),

--- a/relayer/src/chain/counterparty.rs
+++ b/relayer/src/chain/counterparty.rs
@@ -485,10 +485,10 @@ pub fn unreceived_acknowledgements(
 #[derive(Debug, Serialize)]
 pub struct PendingPackets {
     /// Not yet received on the counterparty chain.
-    pub unreceived: Vec<u64>,
+    pub unreceived_packets: Vec<u64>,
     /// Received on the counterparty chain,
     /// but the acknowledgement is not yet received on the local chain.
-    pub pending_acks: Vec<u64>,
+    pub unreceived_acks: Vec<u64>,
 }
 
 pub fn pending_packet_summary(
@@ -527,7 +527,7 @@ pub fn pending_packet_summary(
     )?;
 
     Ok(PendingPackets {
-        unreceived,
-        pending_acks,
+        unreceived_packets: unreceived,
+        unreceived_acks: pending_acks,
     })
 }

--- a/tools/integration-test/src/tests/mod.rs
+++ b/tools/integration-test/src/tests/mod.rs
@@ -10,6 +10,7 @@ pub mod client_expiration;
 mod client_settings;
 pub mod connection_delay;
 pub mod memo;
+mod query_packet;
 pub mod supervisor;
 pub mod ternary_transfer;
 pub mod transfer;

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -24,11 +24,6 @@ impl TestOverrides for QueryPacketPendingTest {
     fn should_spawn_supervisor(&self) -> bool {
         false
     }
-
-    // Unordered channel: will permit gaps in the sequence of relayed packets
-    fn channel_order(&self) -> Order {
-        Order::Unordered
-    }
 }
 
 impl BinaryChannelTest for QueryPacketPendingTest {

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -77,8 +77,8 @@ impl BinaryChannelTest for QueryPacketPendingTest {
         let summary =
             pending_packet_summary(chains.handle_a(), chains.handle_b(), channel_end.value())?;
 
-        assert_eq!(summary.unreceived, [1]);
-        assert!(summary.pending_acks.is_empty());
+        assert_eq!(summary.unreceived_packets, [1]);
+        assert!(summary.unreceived_acks.is_empty());
 
         // Receive the packet on the destination chain
         link.build_and_send_recv_packet_messages()?;
@@ -86,8 +86,8 @@ impl BinaryChannelTest for QueryPacketPendingTest {
         let summary =
             pending_packet_summary(chains.handle_a(), chains.handle_b(), channel_end.value())?;
 
-        assert!(summary.unreceived.is_empty());
-        assert_eq!(summary.pending_acks, [1]);
+        assert!(summary.unreceived_packets.is_empty());
+        assert_eq!(summary.unreceived_acks, [1]);
 
         // Acknowledge the packet on the source chain
         let link = link.reverse(false)?;
@@ -96,8 +96,8 @@ impl BinaryChannelTest for QueryPacketPendingTest {
         let summary =
             pending_packet_summary(chains.handle_a(), chains.handle_b(), channel_end.value())?;
 
-        assert!(summary.unreceived.is_empty());
-        assert!(summary.pending_acks.is_empty());
+        assert!(summary.unreceived_packets.is_empty());
+        assert!(summary.unreceived_acks.is_empty());
 
         let denom_b = chains.node_b.denom();
         let amount2 = random_u64_range(1000, 5000);
@@ -136,8 +136,8 @@ impl BinaryChannelTest for QueryPacketPendingTest {
             &counterparty_channel_end,
         )?;
 
-        assert_eq!(summary.unreceived, [1]);
-        assert!(summary.pending_acks.is_empty());
+        assert_eq!(summary.unreceived_packets, [1]);
+        assert!(summary.unreceived_acks.is_empty());
 
         Ok(())
     }

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -59,7 +59,7 @@ impl BinaryChannelTest for QueryPacketPendingTest {
 
         let opts = LinkParameters {
             src_port_id: channel.port_a.clone().into_value(),
-            src_channel_id: channel.channel_id_a.clone().into_value(),
+            src_channel_id: channel.channel_id_a.into_value(),
         };
         let link = Link::new_from_opts(
             chains.handle_a().clone(),

--- a/tools/integration-test/src/tests/query_packet.rs
+++ b/tools/integration-test/src/tests/query_packet.rs
@@ -1,0 +1,87 @@
+use ibc::core::ics04_channel::channel::IdentifiedChannelEnd;
+use ibc::Height;
+use ibc_relayer::chain::counterparty::pending_packet_summary;
+
+use ibc_test_framework::prelude::*;
+use ibc_test_framework::util::random::random_u64_range;
+
+#[test]
+fn test_query_packet_pending() -> Result<(), Error> {
+    run_binary_channel_test(&QueryPacketPendingTest)
+}
+
+pub struct QueryPacketPendingTest;
+
+impl TestOverrides for QueryPacketPendingTest {
+    fn modify_relayer_config(&self, config: &mut Config) {
+        // Disabling clear_on_start should make the relayer not
+        // relay any packet it missed before starting.
+        config.mode.packets.clear_on_start = false;
+        config.mode.packets.clear_interval = 0;
+    }
+
+    fn should_spawn_supervisor(&self) -> bool {
+        false
+    }
+
+    // Unordered channel: will permit gaps in the sequence of relayed packets
+    fn channel_order(&self) -> Order {
+        Order::Unordered
+    }
+}
+
+impl BinaryChannelTest for QueryPacketPendingTest {
+    fn run<ChainA: ChainHandle, ChainB: ChainHandle>(
+        &self,
+        _config: &TestConfig,
+        relayer: RelayerDriver,
+        chains: ConnectedChains<ChainA, ChainB>,
+        channel: ConnectedChannel<ChainA, ChainB>,
+    ) -> Result<(), Error> {
+        let denom_a = chains.node_a.denom();
+
+        let wallet_a = chains.node_a.wallets().user1().cloned();
+        let wallet_b = chains.node_b.wallets().user1().cloned();
+
+        let amount1 = random_u64_range(1000, 5000);
+
+        info!(
+            "Performing IBC transfer with amount {}, which should *not* be relayed",
+            amount1
+        );
+
+        chains.node_a.chain_driver().transfer_token(
+            &channel.port_a.as_ref(),
+            &channel.channel_id_a.as_ref(),
+            &wallet_a.address(),
+            &wallet_b.address(),
+            amount1,
+            &denom_a,
+        )?;
+
+        sleep(Duration::from_secs(1));
+
+        let channel_end = chains.handle_a().query_channel(
+            channel.port_a.as_ref().value(),
+            channel.channel_id_a.as_ref().value(),
+            Height::zero(),
+        )?;
+        let channel_end = IdentifiedChannelEnd::new(
+            channel.port_a.clone().into_value(),
+            channel.channel_id_a.clone().into_value(),
+            channel_end,
+        );
+
+        let summary = pending_packet_summary(chains.handle_a(), chains.handle_b(), &channel_end)?;
+
+        assert_eq!(summary.unreceived, [1]);
+        // TODO: test pending_ack
+
+        // Spawn the supervisor only after the first IBC trasnfer
+        relayer.with_supervisor(|| {
+            sleep(Duration::from_secs(1));
+
+            Ok(())
+        })
+    }
+}

--- a/tools/test-framework/src/error.rs
+++ b/tools/test-framework/src/error.rs
@@ -6,6 +6,7 @@ use flex_error::{define_error, TraceError};
 use ibc_relayer::channel::error::ChannelError;
 use ibc_relayer::connection::ConnectionError;
 use ibc_relayer::error::Error as RelayerError;
+use ibc_relayer::link::error::LinkError;
 use ibc_relayer::supervisor::error::Error as SupervisorError;
 use ibc_relayer::transfer::TransferError;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
@@ -48,6 +49,10 @@ define_error! {
         Transfer
             [ TransferError ]
             | _ | { "transfer error"},
+
+        Link
+            [ LinkError ]
+            | _ | { "link error" },
 
         Retry
             {
@@ -114,5 +119,11 @@ impl From<ConnectionError> for Error {
 impl From<TransferError> for Error {
     fn from(e: TransferError) -> Self {
         Error::transfer(e)
+    }
+}
+
+impl From<LinkError> for Error {
+    fn from(e: LinkError) -> Self {
+        Error::link(e)
     }
 }

--- a/tools/test-framework/src/relayer/channel.rs
+++ b/tools/test-framework/src/relayer/channel.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 use eyre::eyre;
 use ibc::core::ics04_channel::channel::State as ChannelState;
-use ibc::core::ics04_channel::channel::{ChannelEnd, Order};
+use ibc::core::ics04_channel::channel::{ChannelEnd, IdentifiedChannelEnd, Order};
 use ibc::Height;
 use ibc_relayer::chain::handle::ChainHandle;
 use ibc_relayer::channel::{extract_channel_id, Channel, ChannelSide};
@@ -79,6 +79,19 @@ pub fn query_channel_end<ChainA: ChainHandle, ChainB>(
     let channel_end = handle.query_channel(port_id.value(), channel_id.value(), Height::zero())?;
 
     Ok(DualTagged::new(channel_end))
+}
+
+pub fn query_identified_channel_end<ChainA: ChainHandle, ChainB>(
+    handle: &ChainA,
+    channel_id: TaggedChannelIdRef<ChainA, ChainB>,
+    port_id: TaggedPortIdRef<ChainA, ChainB>,
+) -> Result<DualTagged<ChainA, ChainB, IdentifiedChannelEnd>, Error> {
+    let channel_end = handle.query_channel(port_id.value(), channel_id.value(), Height::zero())?;
+    Ok(DualTagged::new(IdentifiedChannelEnd::new(
+        port_id.into_value().clone(),
+        channel_id.into_value().clone(),
+        channel_end,
+    )))
 }
 
 pub fn assert_eventually_channel_established<ChainA: ChainHandle, ChainB: ChainHandle>(

--- a/tools/test-framework/src/relayer/channel.rs
+++ b/tools/test-framework/src/relayer/channel.rs
@@ -89,7 +89,7 @@ pub fn query_identified_channel_end<ChainA: ChainHandle, ChainB>(
     let channel_end = handle.query_channel(port_id.value(), channel_id.value(), Height::zero())?;
     Ok(DualTagged::new(IdentifiedChannelEnd::new(
         port_id.into_value().clone(),
-        channel_id.into_value().clone(),
+        *channel_id.into_value(),
         channel_end,
     )))
 }

--- a/tools/test-framework/src/relayer/connection.rs
+++ b/tools/test-framework/src/relayer/connection.rs
@@ -4,8 +4,8 @@
 
 use core::time::Duration;
 use eyre::eyre;
-use ibc::core::ics03_connection::connection::ConnectionEnd;
 use ibc::core::ics03_connection::connection::State as ConnectionState;
+use ibc::core::ics03_connection::connection::{ConnectionEnd, IdentifiedConnectionEnd};
 use ibc::timestamp::ZERO_DURATION;
 use ibc::Height;
 use ibc_relayer::chain::handle::ChainHandle;
@@ -91,6 +91,17 @@ pub fn query_connection_end<ChainA: ChainHandle, ChainB>(
     let connection_end = handle.query_connection(connection_id.value(), Height::zero())?;
 
     Ok(DualTagged::new(connection_end))
+}
+
+pub fn query_identified_connection_end<ChainA: ChainHandle, ChainB>(
+    handle: &ChainA,
+    connection_id: TaggedConnectionIdRef<ChainA, ChainB>,
+) -> Result<DualTagged<ChainA, ChainB, IdentifiedConnectionEnd>, Error> {
+    let connection_end = handle.query_connection(connection_id.value(), Height::zero())?;
+    Ok(DualTagged::new(IdentifiedConnectionEnd::new(
+        connection_id.into_value().clone(),
+        connection_end,
+    )))
 }
 
 pub fn assert_eventually_connection_established<ChainA: ChainHandle, ChainB: ChainHandle>(

--- a/tools/test-framework/src/types/tagged/dual.rs
+++ b/tools/test-framework/src/types/tagged/dual.rs
@@ -389,6 +389,8 @@ impl<TagA, TagB, Value> AsRef<Value> for Tagged<TagA, TagB, Value> {
     }
 }
 
+impl<TagA, TagB, Value: Copy> Copy for Tagged<TagA, TagB, Value> {}
+
 impl<TagA, TagB, Value: Clone> Clone for Tagged<TagA, TagB, Value> {
     fn clone(&self) -> Self {
         Self::new(self.0.clone())

--- a/tools/test-framework/src/types/tagged/mono.rs
+++ b/tools/test-framework/src/types/tagged/mono.rs
@@ -360,6 +360,8 @@ impl<Tag, Value: IntoIterator> IntoIterator for Tagged<Tag, Value> {
     }
 }
 
+impl<Tag, Value: Copy> Copy for Tagged<Tag, Value> {}
+
 impl<Tag, Value: Clone> Clone for Tagged<Tag, Value> {
     fn clone(&self) -> Self {
         Self::new(self.0.clone())


### PR DESCRIPTION
Closes: #1862

## Description

Add a new subcommand `pending` to `query packet`, displaying a summary of pending packet commitment IDs for the identified channel and its reverse counterpart.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).