### PR TITLE
Remove ics07 unwrap() and update ibc protocol spec link

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -208,7 +208,9 @@ impl ClientDef for TendermintClient {
             epoch: consensus_height.revision_number,
             height: consensus_height.revision_height,
         };
-        let value = expected_consensus_state.encode_vec().map_err(Ics02Error::invalid_any_consensus_state)?;
+        let value = expected_consensus_state
+            .encode_vec()
+            .map_err(Ics02Error::invalid_any_consensus_state)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -225,7 +227,9 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ConnectionsPath(connection_id.clone());
-        let value = expected_connection_end.encode_vec().map_err(Ics02Error::invalid_connection_end)?;
+        let value = expected_connection_end
+            .encode_vec()
+            .map_err(Ics02Error::invalid_connection_end)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -243,7 +247,9 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ChannelEndsPath(port_id.clone(), *channel_id);
-        let value = expected_channel_end.encode_vec().map_err(Ics02Error::invalid_channel_end)?;
+        let value = expected_channel_end
+            .encode_vec()
+            .map_err(Ics02Error::invalid_channel_end)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -260,7 +266,9 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ClientStatePath(client_id.clone());
-        let value = expected_client_state.encode_vec().map_err(Ics02Error::invalid_any_client_state)?;
+        let value = expected_client_state
+            .encode_vec()
+            .map_err(Ics02Error::invalid_any_client_state)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -208,7 +208,7 @@ impl ClientDef for TendermintClient {
             epoch: consensus_height.revision_number,
             height: consensus_height.revision_height,
         };
-        let value = expected_consensus_state.encode_vec().unwrap();
+        let value = expected_consensus_state.encode_vec().map_err(Ics02Error::invalid_any_consensus_state)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -225,7 +225,7 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ConnectionsPath(connection_id.clone());
-        let value = expected_connection_end.encode_vec().unwrap();
+        let value = expected_connection_end.encode_vec().map_err(Ics02Error::invalid_connection_end)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -243,7 +243,7 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ChannelEndsPath(port_id.clone(), *channel_id);
-        let value = expected_channel_end.encode_vec().unwrap();
+        let value = expected_channel_end.encode_vec().map_err(Ics02Error::invalid_channel_end)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 
@@ -260,7 +260,7 @@ impl ClientDef for TendermintClient {
         client_state.verify_height(height)?;
 
         let path = ClientStatePath(client_id.clone());
-        let value = expected_client_state.encode_vec().unwrap();
+        let value = expected_client_state.encode_vec().map_err(Ics02Error::invalid_any_client_state)?;
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -46,7 +46,7 @@ pub trait ClientDef: Clone {
     ) -> Result<(Self::ClientState, Self::ConsensusState), Error>;
 
     /// Verification functions as specified in:
-    /// <https://github.com/cosmos/ibc/tree/master/spec/ics-002-client-semantics>
+    /// <https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics>
     ///
     /// Verify a `proof` that the consensus state of a given client (at height `consensus_height`)
     /// matches the input `consensus_state`. The parameter `counterparty_height` represent the

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -252,19 +252,19 @@ define_error! {
         MissingLocalConsensusState
             { height: Height }
             | e | { format_args!("the local consensus state could not be retrieved for height {}", e.height) },
-        
-        InvalidConnectionEnd 
+
+        InvalidConnectionEnd
             [ TraceError<TendermintProtoError>]
             | _ | { "invalid connection end" },
-        
-        InvalidChannelEnd 
+
+        InvalidChannelEnd
             [ TraceError<TendermintProtoError>]
             | _ | { "invalid channel end" },
-        
-        InvalidAnyClientState 
+
+        InvalidAnyClientState
             [ TraceError<TendermintProtoError>]
             | _ | { "invalid any client state" },
-        
+
         InvalidAnyConsensusState
             [ TraceError<TendermintProtoError> ]
             | _ | { "invalid any client consensus state" },

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -252,7 +252,22 @@ define_error! {
         MissingLocalConsensusState
             { height: Height }
             | e | { format_args!("the local consensus state could not be retrieved for height {}", e.height) },
-
+        
+        InvalidConnectionEnd 
+            [ TraceError<TendermintProtoError>]
+            | _ | { "invalid connection end" },
+        
+        InvalidChannelEnd 
+            [ TraceError<TendermintProtoError>]
+            | _ | { "invalid channel end" },
+        
+        InvalidAnyClientState 
+            [ TraceError<TendermintProtoError>]
+            | _ | { "invalid any client state" },
+        
+        InvalidAnyConsensusState
+            [ TraceError<TendermintProtoError> ]
+            | _ | { "invalid any client consensus state" },
     }
 }
 

--- a/modules/src/core/ics02_client/msgs.rs
+++ b/modules/src/core/ics02_client/msgs.rs
@@ -2,7 +2,7 @@
 //! these messages can be found, for instance, in ICS 07 for Tendermint-specific chains. A chain
 //! handles these messages in two layers: first with the general ICS 02 client handler, which
 //! subsequently calls into the chain-specific (e.g., ICS 07) client handler. See:
-//! <https://github.com/cosmos/ibc/tree/master/spec/ics-002-client-semantics#create>.
+//! <https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics#create>.
 
 use crate::core::ics02_client::msgs::create_client::MsgCreateAnyClient;
 use crate::core::ics02_client::msgs::misbehavior::MsgSubmitAnyMisbehaviour;

--- a/modules/src/core/ics03_connection/msgs.rs
+++ b/modules/src/core/ics03_connection/msgs.rs
@@ -2,7 +2,7 @@
 //!
 //! We define each of the four messages in the connection handshake protocol as a `struct`.
 //! Each such message comprises the same fields as the datagrams defined in ICS3 English spec:
-//! <https://github.com/cosmos/ibc/tree/master/spec/ics-003-connection-semantics>.
+//! <https://github.com/cosmos/ibc/tree/master/spec/core/ics-003-connection-semantics>.
 //!
 //! One departure from ICS3 is that we abstract the three counterparty fields (connection id,
 //! prefix, and client id) into a single field of type `Counterparty`; this applies to messages

--- a/modules/src/core/ics24_host/path.rs
+++ b/modules/src/core/ics24_host/path.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// Path-space as listed in ICS-024
-/// https://github.com/cosmos/ibc/tree/master/spec/ics-024-host-requirements#path-space
+/// https://github.com/cosmos/ibc/tree/master/spec/core/ics-024-host-requirements#path-space
 /// Some of these are implemented in other ICSs, but ICS-024 has a nice summary table.
 ///
 use core::str::FromStr;


### PR DESCRIPTION

## Description

- remove ics07-tendemrint client_def.rs unwrap()
- update ibc protocol spec link
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).