### PR TITLE
extract ics07 verify_* function to ics02-client/client_def.rs as default impl function

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -1,10 +1,9 @@
 use core::convert::TryInto;
 
 use ibc_proto::ibc::core::commitment::v1::MerkleProof as RawMerkleProof;
-use prost::Message;
+// use prost::Message;
 use tendermint_light_client_verifier::types::{TrustedBlockState, UntrustedBlockState};
 use tendermint_light_client_verifier::{ProdVerifier, Verdict, Verifier};
-use tendermint_proto::Protobuf;
 
 use crate::clients::ics07_tendermint::client_state::ClientState;
 use crate::clients::ics07_tendermint::consensus_state::ConsensusState;
@@ -12,26 +11,12 @@ use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header;
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
-use crate::core::ics02_client::client_state::AnyClientState;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
-use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::context::ChannelReader;
-use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
-use crate::core::ics04_channel::packet::Sequence;
-use crate::core::ics23_commitment::commitment::{
-    CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
-};
-use crate::core::ics23_commitment::merkle::{apply_prefix, MerkleProof};
-use crate::core::ics24_host::identifier::ConnectionId;
-use crate::core::ics24_host::identifier::{ChannelId, ClientId, PortId};
-use crate::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, CommitmentsPath,
-    ConnectionsPath, ReceiptsPath, SeqRecvsPath,
-};
-use crate::core::ics24_host::Path;
+use crate::core::ics24_host::identifier::ClientId;
 use crate::downcast;
 use crate::prelude::*;
 use crate::Height;
@@ -190,216 +175,6 @@ impl ClientDef for TendermintClient {
         ))
     }
 
-    fn verify_client_consensus_state(
-        &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        client_id: &ClientId,
-        consensus_height: Height,
-        expected_consensus_state: &AnyConsensusState,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-
-        let path = ClientConsensusStatePath {
-            client_id: client_id.clone(),
-            epoch: consensus_height.revision_number,
-            height: consensus_height.revision_height,
-        };
-        let value = expected_consensus_state
-            .encode_vec()
-            .map_err(Ics02Error::invalid_any_consensus_state)?;
-        verify_membership(client_state, prefix, proof, root, path, value)
-    }
-
-    fn verify_connection_state(
-        &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        connection_id: &ConnectionId,
-        expected_connection_end: &ConnectionEnd,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-
-        let path = ConnectionsPath(connection_id.clone());
-        let value = expected_connection_end
-            .encode_vec()
-            .map_err(Ics02Error::invalid_connection_end)?;
-        verify_membership(client_state, prefix, proof, root, path, value)
-    }
-
-    fn verify_channel_state(
-        &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        expected_channel_end: &ChannelEnd,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-
-        let path = ChannelEndsPath(port_id.clone(), *channel_id);
-        let value = expected_channel_end
-            .encode_vec()
-            .map_err(Ics02Error::invalid_channel_end)?;
-        verify_membership(client_state, prefix, proof, root, path, value)
-    }
-
-    fn verify_client_full_state(
-        &self,
-        client_state: &Self::ClientState,
-        height: Height,
-        prefix: &CommitmentPrefix,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        client_id: &ClientId,
-        expected_client_state: &AnyClientState,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-
-        let path = ClientStatePath(client_id.clone());
-        let value = expected_client_state
-            .encode_vec()
-            .map_err(Ics02Error::invalid_any_client_state)?;
-        verify_membership(client_state, prefix, proof, root, path, value)
-    }
-
-    fn verify_packet_data(
-        &self,
-        ctx: &dyn ChannelReader,
-        client_state: &Self::ClientState,
-        height: Height,
-        connection_end: &ConnectionEnd,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
-        commitment: String,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-        verify_delay_passed(ctx, height, connection_end)?;
-
-        let commitment_path = CommitmentsPath {
-            port_id: port_id.clone(),
-            channel_id: *channel_id,
-            sequence,
-        };
-
-        let mut commitment_bytes = Vec::new();
-        commitment
-            .encode(&mut commitment_bytes)
-            .expect("buffer size too small");
-
-        verify_membership(
-            client_state,
-            connection_end.counterparty().prefix(),
-            proof,
-            root,
-            commitment_path,
-            commitment_bytes,
-        )
-    }
-
-    fn verify_packet_acknowledgement(
-        &self,
-        ctx: &dyn ChannelReader,
-        client_state: &Self::ClientState,
-        height: Height,
-        connection_end: &ConnectionEnd,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
-        ack: Acknowledgement,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-        verify_delay_passed(ctx, height, connection_end)?;
-
-        let ack_path = AcksPath {
-            port_id: port_id.clone(),
-            channel_id: *channel_id,
-            sequence,
-        };
-        verify_membership(
-            client_state,
-            connection_end.counterparty().prefix(),
-            proof,
-            root,
-            ack_path,
-            ack.into_bytes(),
-        )
-    }
-
-    fn verify_next_sequence_recv(
-        &self,
-        ctx: &dyn ChannelReader,
-        client_state: &Self::ClientState,
-        height: Height,
-        connection_end: &ConnectionEnd,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-        verify_delay_passed(ctx, height, connection_end)?;
-
-        let mut seq_bytes = Vec::new();
-        u64::from(sequence)
-            .encode(&mut seq_bytes)
-            .expect("buffer size too small");
-
-        let seq_path = SeqRecvsPath(port_id.clone(), *channel_id);
-        verify_membership(
-            client_state,
-            connection_end.counterparty().prefix(),
-            proof,
-            root,
-            seq_path,
-            seq_bytes,
-        )
-    }
-
-    fn verify_packet_receipt_absence(
-        &self,
-        ctx: &dyn ChannelReader,
-        client_state: &Self::ClientState,
-        height: Height,
-        connection_end: &ConnectionEnd,
-        proof: &CommitmentProofBytes,
-        root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
-    ) -> Result<(), Ics02Error> {
-        client_state.verify_height(height)?;
-        verify_delay_passed(ctx, height, connection_end)?;
-
-        let receipt_path = ReceiptsPath {
-            port_id: port_id.clone(),
-            channel_id: *channel_id,
-            sequence,
-        };
-        verify_non_membership(
-            client_state,
-            connection_end.counterparty().prefix(),
-            proof,
-            root,
-            receipt_path,
-        )
-    }
-
     fn verify_upgrade_and_update_state(
         &self,
         _client_state: &Self::ClientState,
@@ -409,77 +184,37 @@ impl ClientDef for TendermintClient {
     ) -> Result<(Self::ClientState, Self::ConsensusState), Ics02Error> {
         todo!()
     }
-}
 
-fn verify_membership(
-    client_state: &ClientState,
-    prefix: &CommitmentPrefix,
-    proof: &CommitmentProofBytes,
-    root: &CommitmentRoot,
-    path: impl Into<Path>,
-    value: Vec<u8>,
-) -> Result<(), Ics02Error> {
-    let merkle_path = apply_prefix(prefix, vec![path.into().to_string()]);
-    let merkle_proof: MerkleProof = RawMerkleProof::try_from(proof.clone())
-        .map_err(Ics02Error::invalid_commitment_proof)?
-        .into();
+    fn verify_delay_passed(
+        &self,
+        ctx: &dyn ChannelReader,
+        height: Height,
+        connection_end: &ConnectionEnd,
+    ) -> Result<(), Ics02Error> {
+        let current_timestamp = ctx.host_timestamp();
+        let current_height = ctx.host_height();
 
-    merkle_proof
-        .verify_membership(
-            &client_state.proof_specs,
-            root.clone().into(),
-            merkle_path,
-            value,
-            0,
+        let client_id = connection_end.client_id();
+        let processed_time = ctx
+            .client_update_time(client_id, height)
+            .map_err(|_| Error::processed_time_not_found(client_id.clone(), height))?;
+        let processed_height = ctx
+            .client_update_height(client_id, height)
+            .map_err(|_| Error::processed_height_not_found(client_id.clone(), height))?;
+
+        let delay_period_time = connection_end.delay_period();
+        let delay_period_height = ctx.block_delay(delay_period_time);
+
+        ClientState::verify_delay_passed(
+            current_timestamp,
+            current_height,
+            processed_time,
+            processed_height,
+            delay_period_time,
+            delay_period_height,
         )
-        .map_err(|e| Ics02Error::tendermint(Error::ics23_error(e)))
-}
-
-fn verify_non_membership(
-    client_state: &ClientState,
-    prefix: &CommitmentPrefix,
-    proof: &CommitmentProofBytes,
-    root: &CommitmentRoot,
-    path: impl Into<Path>,
-) -> Result<(), Ics02Error> {
-    let merkle_path = apply_prefix(prefix, vec![path.into().to_string()]);
-    let merkle_proof: MerkleProof = RawMerkleProof::try_from(proof.clone())
-        .map_err(Ics02Error::invalid_commitment_proof)?
-        .into();
-
-    merkle_proof
-        .verify_non_membership(&client_state.proof_specs, root.clone().into(), merkle_path)
-        .map_err(|e| Ics02Error::tendermint(Error::ics23_error(e)))
-}
-
-fn verify_delay_passed(
-    ctx: &dyn ChannelReader,
-    height: Height,
-    connection_end: &ConnectionEnd,
-) -> Result<(), Ics02Error> {
-    let current_timestamp = ctx.host_timestamp();
-    let current_height = ctx.host_height();
-
-    let client_id = connection_end.client_id();
-    let processed_time = ctx
-        .client_update_time(client_id, height)
-        .map_err(|_| Error::processed_time_not_found(client_id.clone(), height))?;
-    let processed_height = ctx
-        .client_update_height(client_id, height)
-        .map_err(|_| Error::processed_height_not_found(client_id.clone(), height))?;
-
-    let delay_period_time = connection_end.delay_period();
-    let delay_period_height = ctx.block_delay(delay_period_time);
-
-    ClientState::verify_delay_passed(
-        current_timestamp,
-        current_height,
-        processed_time,
-        processed_height,
-        delay_period_time,
-        delay_period_height,
-    )
-    .map_err(|e| e.into())
+        .map_err(|e| e.into())
+    }
 }
 
 fn downcast_consensus_state(cs: AnyConsensusState) -> Result<ConsensusState, Ics02Error> {

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -188,20 +188,6 @@ impl ClientState {
 
         Ok(())
     }
-
-    /// Verify that the client is at a sufficient height and unfrozen at the given height
-    pub fn verify_height(&self, height: Height) -> Result<(), Error> {
-        if self.latest_height < height {
-            return Err(Error::insufficient_height(self.latest_height(), height));
-        }
-
-        match self.frozen_height {
-            Some(frozen_height) if frozen_height <= height => {
-                Err(Error::client_frozen(frozen_height, height))
-            }
-            _ => Ok(()),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -218,6 +204,10 @@ impl crate::core::ics02_client::client_state::ClientState for ClientState {
 
     fn client_type(&self) -> ClientType {
         ClientType::Tendermint
+    }
+
+    fn proof_specs(&self) -> &ProofSpecs {
+        &self.proof_specs
     }
 
     fn latest_height(&self) -> Height {

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -41,6 +41,15 @@ define_error! {
             { client_id: ClientId }
             | e | { format_args!("client is frozen: {0}", e.client_id) },
 
+        ClientFrozenAt
+            {
+                frozen_height: Height,
+                target_height: Height,
+            }
+            | e | {
+                format_args!("the client is frozen: frozen_height={0} target_height={1}", e.frozen_height, e.target_height)
+            },
+
         ConsensusStateNotFound
             { client_id: ClientId, height: Height }
             | e | {
@@ -268,6 +277,20 @@ define_error! {
         InvalidAnyConsensusState
             [ TraceError<TendermintProtoError> ]
             | _ | { "invalid any client consensus state" },
+
+
+        InsufficientHeight
+            {
+                latest_height: Height,
+                target_height: Height,
+            }
+            | e | {
+                format_args!("the height is insufficient: latest_height={0} target_height={1}", e.latest_height, e.target_height)
+            },
+
+        Ics23Error
+            [ Ics23Error ]
+            | _ | { "ics23 commitment error" },
     }
 }
 


### PR DESCRIPTION
## Description

Since the overall validation of the data is dependent on ics23, I think it is possible to have these validation functions as the default implementation in ics02.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).