### PR TITLE
Use manual `Debug` impl for `ChannelId` to show it as a string instead of a number

### DIFF
--- a/modules/src/core/ics24_host/identifier.rs
+++ b/modules/src/core/ics24_host/identifier.rs
@@ -1,5 +1,5 @@
 use core::convert::{From, Infallible};
-use core::fmt::{self, Display, Formatter};
+use core::fmt::{self, Debug, Display, Formatter};
 use core::str::FromStr;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -335,7 +335,7 @@ impl Default for PortId {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChannelId(u64);
 
 impl ChannelId {
@@ -367,6 +367,12 @@ impl ChannelId {
 impl Display for ChannelId {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(f, "{}{}", Self::prefix(), self.0)
+    }
+}
+
+impl Debug for ChannelId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_tuple("ChannelId").field(&self.to_string()).finish()
     }
 }
 


### PR DESCRIPTION
This reverts the formatting change introduced in [b44ade9f8](https://github.com/informalsystems/ibc-rs/pull/2071).

## Before

```rust
channel_id: Some(
    ChannelId(
        2,
     ),
),
```

## After

```rust
channel_id: Some(
    ChannelId(
        "channel-2",
    ),
),
```

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).