### PR TITLE
Fix for `gm reset` with newer SDK versions

### DIFF
--- a/scripts/gm/CHANGELOG.md
+++ b/scripts/gm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Gaiad Manager Change Log
 
+## v0.1.1
+
+### BUGFIXES
+
+- Added `unsafe-reset-all` support for SDK 0.44.8+ and 0.45.3+ ([#2162])
+
+
+[#2162]: https://github.com/informalsystems/ibc-rs/issues/2162
+
 ## v0.1.0
 
 ### FEATURES

--- a/scripts/gm/bin/lib-gm
+++ b/scripts/gm/bin/lib-gm
@@ -5,7 +5,7 @@ if [ "${DEBUG:-}" = "2" ]; then
 fi
 
 version() {
-  VERSION="v0.1.0"
+  VERSION="v0.1.1"
   if is_json_output; then
     echo '{"status": "success", "message": "'"${VERSION}"'"}'
   else
@@ -1071,10 +1071,12 @@ reset() {
     warn "No configuration at ${HOME_DIR}. Skipping..."
     return 0
   fi
+  # `unsafe-reset-all` was moved to `gaiad tendermint` sub-command
+  TM="$(gaiad | grep -q 'unsafe' || echo "tendermint")"
   if is_json_output; then
-    "$GAIAD_BINARY" unsafe-reset-all --home "$HOME_DIR" 1> /dev/null 2> /dev/null
+    "$GAIAD_BINARY" "$TM" unsafe-reset-all --home "$HOME_DIR" 1> /dev/null 2> /dev/null
   else
-    "$GAIAD_BINARY" unsafe-reset-all --home "$HOME_DIR"
+    "$GAIAD_BINARY" "$TM" unsafe-reset-all --home "$HOME_DIR"
   fi
   if [ -z "$WAS_RUNNING" ]; then
     start "$1"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2162

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

To test:

- `bash gm/bin/gm install`
- `gm reset` with both `gaiad v6.*` and `v7.*` and it should work with both


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).