### PR TITLE
Avoid using local time in client update

### DIFF
--- a/.changelog/unreleased/bug-fixes/relayer/2180-client-expiry-time.md
+++ b/.changelog/unreleased/bug-fixes/relayer/2180-client-expiry-time.md
@@ -1,0 +1,2 @@
+- Fixed client expiry computation to avoid using local time.
+  ([#2180](https://github.com/informalsystems/ibc-rs/issues/2180))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2180 

## Description

Simple fix: use source network status instead of local time when computing client expiry status.


______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~~Added tests: integration (for Hermes) or unit/mock tests (for modules).~~
- [X] Linked to GitHub issue.
- [] ~~Updated code comments and documentation (e.g., `docs/`).~~

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).