### PR TITLE
Fixed typo in section 6.1.4.2 of Hermes guide

### DIFF
--- a/guide/src/tutorials/local-chains/relay-paths/multiple-paths.md
+++ b/guide/src/tutorials/local-chains/relay-paths/multiple-paths.md
@@ -100,7 +100,7 @@ Follow the steps below to connect three chains together and relay packets betwee
    making an exception. Execute the following command:
 
     ```shell
-    hermes create channel ibc-0 --chain-b-id ibc-1 --port-a transfer --port-b transfer --new-client-connection
+    hermes create channel ibc-0 --chain-b ibc-1 --port-a transfer --port-b transfer --new-client-connection
     ```
 
     Then respond 'yes' to the prompt that pops up. Once the command has run to
@@ -166,7 +166,7 @@ Follow the steps below to connect three chains together and relay packets betwee
    previous invocation we used to create a channel between `ibc-0` and `ibc-1`:
 
     ```shell
-    hermes create channel ibc-1 --chain-b-id ibc-2 --port-a transfer --port-b transfer --new-client-connection
+    hermes create channel ibc-1 --chain-b ibc-2 --port-a transfer --port-b transfer --new-client-connection
     ```
 
     ```json


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In section 6.1.4.2 of the Hermes guide, there is a typo in the commands to create the channels between ibc-0 and ibc-1. The commands use the argument  --chain-b-id which changed to  --chain-b after PR #2014 


______

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).