### PR TITLE
Disable MBT tests on CI due to flakiness

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -199,15 +199,16 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -p ibc-integration-test --no-fail-fast --no-run
-      - env:
-          RUST_LOG: debug
-          RUST_BACKTRACE: 1
-          NO_COLOR_LOG: 1
-        run: |
-          nix shell \
-            .#${{ matrix.gaiad }} \
-            .#apalache \
-            -c cargo \
-            test -p ibc-integration-test --features mbt --no-fail-fast -- \
-            --nocapture --test-threads=1 mbt
+          args: -p ibc-integration-test --features mbt --no-fail-fast --no-run
+      # Disable running MBT tests until flakiness is addressed
+      # - env:
+      #     RUST_LOG: debug
+      #     RUST_BACKTRACE: 1
+      #     NO_COLOR_LOG: 1
+      #   run: |
+      #     nix shell \
+      #       .#${{ matrix.gaiad }} \
+      #       .#apalache \
+      #       -c cargo \
+      #       test -p ibc-integration-test --features mbt --no-fail-fast -- \
+      #       --nocapture --test-threads=1 mbt

--- a/relayer-cli/src/commands/query/channel_client.rs
+++ b/relayer-cli/src/commands/query/channel_client.rs
@@ -35,7 +35,7 @@ impl Runnable for QueryChannelClientCmd {
 
         match chain.query_channel_client_state(QueryChannelClientStateRequest {
             port_id: self.port_id.clone(),
-            channel_id: self.channel_id.clone(),
+            channel_id: self.channel_id,
         }) {
             Ok(cs) => Output::success(cs).exit(),
             Err(e) => Output::error(format!("{}", e)).exit(),


### PR DESCRIPTION
## Description

The MBT test introduced in #2070 appears to be flaky, and often fail on CI. We will disable running the test and only re-enable it after the flakiness is addressed.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).