### PR TITLE
Update Rust toolchain to 1.61

### DIFF
--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -143,7 +143,8 @@ impl Runnable for KeysAddCmd {
             // This case should never trigger.
             // The 'required' parameter for the flags will trigger an error if both flags have not been given.
             // And the 'group' parameter for the flags will trigger an error if both flags are given.
-            _ => Output::error("--mnemonic-file and --key-file can't both be None".to_string()).exit(),
+            _ => Output::error("--mnemonic-file and --key-file can't both be None".to_string())
+                .exit(),
         }
     }
 }

--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -143,7 +143,7 @@ impl Runnable for KeysAddCmd {
             // This case should never trigger.
             // The 'required' parameter for the flags will trigger an error if both flags have not been given.
             // And the 'group' parameter for the flags will trigger an error if both flags are given.
-            _ => Output::error(format!("--mnemonic-file and --key-file can't both be None")).exit(),
+            _ => Output::error("--mnemonic-file and --key-file can't both be None".to_string()).exit(),
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel    = "1.60.0"
+channel    = "1.61"
 components = ["rustfmt", "clippy", "cargo"]


### PR DESCRIPTION
Update the version to 1.61 in `rust-toolchain.toml` and fix the clippy lints new for 1.61.
No MSRV bump is done here. 