### PR TITLE
Improved fee-related error message

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/1400-fee-related-error-message.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/1400-fee-related-error-message.md
@@ -1,0 +1,2 @@
+- Added handler for SDK Err(13) in order to output an understanble error
+  message. ([#1400](https://github.com/informalsystems/ibc-rs/issues/1400))

--- a/relayer/src/sdk_error.rs
+++ b/relayer/src/sdk_error.rs
@@ -18,6 +18,10 @@ define_error! {
 
         OutOfGas
             { code: u32 }
+            |_| { "the gas requirement is higher than the configured maximum gas! please check the Hermes config.toml".to_string() },
+
+        InsufficientFee
+            { code: u32 }
             |_| { "the price configuration for this chain may be too low! please check the `gas_price.price` Hermes config.toml".to_string() },
     }
 }
@@ -181,6 +185,7 @@ pub fn sdk_error_from_tx_sync_error_code(code: u32) -> SdkError {
         // is due to "out of gas" errors. These are unrecoverable at the moment
         // on the Hermes side. We'll inform the user to check for misconfig.
         11 => SdkError::out_of_gas(code),
+        13 => SdkError::insufficient_fee(code),
         _ => SdkError::unknown_sdk(code),
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1400

## Description

This PR adds a match case for the SDK Err(13), which is triggered when the configured gas price is lower than the minimum gas price allowed on the chain.

## Trigger the error

It is possible to trigger the error using gm:

<details>
<summary>gm.toml</summary>

```toml
[global]
gaiad_binary="/opt/bin/gaiad"

[global.hermes]
binary="/home/adizere/bin/hermes"


[a]
  add_to_hermes = true
  ports_start_at = 27000

[b]
  add_to_hermes = true
  ports_start_at = 27030
```

</details>

1. use the above gm config
2. `gm start`, `gm hermes config`, `gm hermes keys`
3. `gm stop a`
4. open the configuration file for the chain a, located in .gm/a/config/app.toml
    - set `minimum-gas-prices = "0.017stake"`
5. `gm start a`
6. replace the gas configuration for chain `a` in the .hermes/config.toml
    - set `gas_price = { price = 0.001, denom = 'stake' }`
7. `hermes create client a b`
    - now we should see the error with the diagnostic for the error


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~ 
- [x] Linked to GitHub issue.
- [ ] ~Updated code comments and documentation (e.g., `docs/`).~

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).