### PR TITLE
Refactored configuration file field names

### DIFF
--- a/.changelog/unreleased/breaking-changes/ibc-relayer/2242-replace-config-toml-underscores-with-dashes.md
+++ b/.changelog/unreleased/breaking-changes/ibc-relayer/2242-replace-config-toml-underscores-with-dashes.md
@@ -1,0 +1,3 @@
+- The ibc-relayer configuration file has been refactored to replace
+  all `_` with `-` in the field names. E.g. `log_level` is now `log-level`
+  ([#2242](https://github.com/informalsystems/ibc-rs/issues/2242))

--- a/ci/simple_config.toml
+++ b/ci/simple_config.toml
@@ -1,5 +1,5 @@
 [global]
-log_level = 'trace'
+log-level = 'trace'
 
 [mode]
 
@@ -16,9 +16,9 @@ enabled = false
 
 [mode.packets]
 enabled = true
-clear_interval = 100
-clear_on_start = true
-tx_confirmation = true
+clear-interval = 100
+clear-on-start = true
+tx-confirmation = true
 
 [telemetry]
 enabled = false
@@ -27,34 +27,34 @@ port = 3001
 
 [[chains]]
 id = 'ibc-0'
-rpc_addr = 'http://ibc-0:26657'
-grpc_addr = 'http://ibc-0:9090'
-websocket_addr = 'ws://ibc-0:26657/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-max_gas = 3000000
-max_msg_num = 30
-max_tx_size = 2097152
-gas_price = { price = 0.001, denom = 'stake' }
-clock_drift = '5s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+rpc-addr = 'http://ibc-0:26657'
+grpc-addr = 'http://ibc-0:9090'
+websocket-addr = 'ws://ibc-0:26657/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+max-gas = 3000000
+max-msg-num = 30
+max-tx-size = 2097152
+gas-price = { price = 0.001, denom = 'stake' }
+clock-drift = '5s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }
 
 [[chains]]
 id = 'ibc-1'
-rpc_addr = 'http://ibc-1:26657'
-grpc_addr = 'http://ibc-1:9090'
-websocket_addr = 'ws://ibc-1:26657/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-max_gas = 3000000
-max_msg_num = 30
-max_tx_size = 2097152
-gas_price = { price = 0.001, denom = 'stake' }
-clock_drift = '5s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+rpc-addr = 'http://ibc-1:26657'
+grpc-addr = 'http://ibc-1:9090'
+websocket-addr = 'ws://ibc-1:26657/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+max-gas = 3000000
+max-msg-num = 30
+max-tx-size = 2097152
+gas-price = { price = 0.001, denom = 'stake' }
+clock-drift = '5s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }

--- a/config.toml
+++ b/config.toml
@@ -217,7 +217,7 @@ memo-prefix = ''
 # channel with port ID 'transfer' and channel ID 'channel-0', as well as on
 # all ICA channels.
 #
-# [chains.packet_filter]
+# [chains.packet-filter]
 # policy = 'allow'
 # list = [
 #   ['ica*', '*'],

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@
 
 # Specify the verbosity for the relayer logging output. Default: 'info'
 # Valid options are 'error', 'warn', 'info', 'debug', 'trace'.
-log_level = 'info'
+log-level = 'info'
 
 
 # Specify the mode to be used by the relayer. [Required]
@@ -48,20 +48,20 @@ enabled = true
 # Interval (in number of blocks) at which pending packets
 # should be periodically cleared. A value of '0' will disable
 # periodic packet clearing. [Default: 100]
-clear_interval = 100
+clear-interval = 100
 
 # Whether or not to clear packets on start. [Default: false]
-clear_on_start = true
+clear-on-start = true
 
 # Toggle the transaction confirmation mechanism.
 # The tx confirmation mechanism periodically queries the `/tx_search` RPC
 # endpoint to check that previously-submitted transactions
 # (to any chain in this config file) have been successfully delivered.
-# If they have not been, and `clear_interval = 0`, then those packets are
+# If they have not been, and `clear-interval = 0`, then those packets are
 # queued up for re-submission.
 # Experimental feature. Affects telemetry if set to false.
 # [Default: true]
-tx_confirmation = true
+tx-confirmation = true
 
 # The REST section defines parameters for Hermes' built-in RESTful API.
 # https://hermes.informal.systems/rest.html
@@ -103,28 +103,28 @@ port = 3001
 id = 'ibc-0'
 
 # Specify the RPC address and port where the chain RPC server listens on. Required
-rpc_addr = 'http://127.0.0.1:26657'
+rpc-addr = 'http://127.0.0.1:26657'
 
 # Specify the GRPC address and port where the chain GRPC server listens on. Required
-grpc_addr = 'http://127.0.0.1:9090'
+grpc-addr = 'http://127.0.0.1:9090'
 
 # Specify the WebSocket address and port where the chain WebSocket server
 # listens on. Required
-websocket_addr = 'ws://127.0.0.1:26657/websocket'
+websocket-addr = 'ws://127.0.0.1:26657/websocket'
 
 # Specify the maximum amount of time (duration) that the RPC requests should
 # take before timing out. Default: 10s (10 seconds)
 # Note: Hermes uses this parameter _only_ in `start` mode; for all other CLIs,
 # Hermes uses a large preconfigured timeout (on the order of minutes).
-rpc_timeout = '10s'
+rpc-timeout = '10s'
 
 # Specify the prefix used by the chain. Required
-account_prefix = 'cosmos'
+account-prefix = 'cosmos'
 
 # Specify the name of the private key to use for signing transactions. Required
 # See the Adding Keys chapter for more information about managing signing keys:
 #   https://hermes.informal.systems/commands/keys/index.html#adding-keys
-key_name = 'testkey'
+key-name = 'testkey'
 
 # Specify the address type which determines:
 # 1) address derivation;
@@ -134,71 +134,71 @@ key_name = 'testkey'
 #
 # Example configuration for chains based on Ethermint library:
 #
-# address_type = { derivation = 'ethermint', proto_type = { pk_type = '/ethermint.crypto.v1.ethsecp256k1.PubKey' } }
+# address-type = { derivation = 'ethermint', proto-type = { pk-type = '/ethermint.crypto.v1.ethsecp256k1.PubKey' } }
 #
 # Default: { derivation = 'cosmos' }, i.e. address derivation as in Cosmos SDK.
 # Warning: This is an advanced feature! Modify with caution.
-address_type = { derivation = 'cosmos' }
+address-type = { derivation = 'cosmos' }
 
 # Specify the store prefix used by the on-chain IBC modules. Required
 # Recommended value for Cosmos SDK: 'ibc'
-store_prefix = 'ibc'
+store-prefix = 'ibc'
 
 # Specify the default amount of gas to be used in case the tx simulation fails,
 # and Hermes cannot estimate the amount of gas needed.
 # Default: 100 000
-default_gas = 100000
+default-gas = 100000
 
 # Specify the maximum amount of gas to be used as the gas limit for a transaction.
 # Default: 400 000
-max_gas = 400000
+max-gas = 400000
 
 # Specify the price per gas used of the fee to submit a transaction and
 # the denomination of the fee. Required
-gas_price = { price = 0.001, denom = 'stake' }
+gas-price = { price = 0.001, denom = 'stake' }
 
 # Specify the ratio by which to increase the gas estimate used to compute the fee,
 # to account for potential estimation error. Default: 0.1, ie. 10%.
 # Valid range: 0.0 to 1.0 (inclusive)
-gas_adjustment = 1.0
+gas-adjustment = 1.0
 
 # Specify how many IBC messages at most to include in a single transaction.
 # Default: 30
-max_msg_num = 30
+max-msg-num = 30
 
 # Specify the maximum size, in bytes, of each transaction that Hermes will submit.
 # Default: 2097152 (2 MiB)
-max_tx_size = 2097152
+max-tx-size = 2097152
 
 # Specify the maximum amount of time to tolerate a clock drift.
 # The clock drift parameter defines how much new (untrusted) header's time
 # can drift into the future. Default: 5s
-clock_drift = '5s'
+clock-drift = '5s'
 
 # Specify the maximum time per block for this chain.
 # The block time together with the clock drift are added to the source drift to estimate
 # the maximum clock drift when creating a client on this chain. Default: 30s
 # For cosmos-SDK chains a good approximation is `timeout_propose` + `timeout_commit`
 # Note: This MUST be the same as the `max_expected_time_per_block` genesis parameter for Tendermint chains.
-max_block_time = '30s'
+max-block-time = '30s'
 
 # Specify the amount of time to be used as the light client trusting period.
 # It should be significantly less than the unbonding period
 # (e.g. unbonding period = 3 weeks, trusting period = 2 weeks).
 # Default: 2/3 of the `unbonding period` for Cosmos SDK chains
-trusting_period = '14days'
+trusting-period = '14days'
 
 # Specify the trust threshold for the light client, ie. the maximum fraction of validators
 # which have changed between two blocks.
 # Default: { numerator = '1', denominator = '3' }, ie. 1/3.
 # Warning: This is an advanced feature! Modify with caution.
-trust_threshold = { numerator = '1', denominator = '3' }
+trust-threshold = { numerator = '1', denominator = '3' }
 
 # Specify a string that Hermes will use as a memo for each transaction it submits
 # to this chain. The string is limited to 50 characters. Default: '' (empty).
 # Note: Hermes will append to the string defined here additional
 # operational debugging information, e.g., relayer build version.
-memo_prefix = ''
+memo-prefix = ''
 
 # This section specifies the filters for policy based relaying.
 #
@@ -226,27 +226,27 @@ memo_prefix = ''
 
 # Specify that the transaction fees should be payed from this fee granter's account.
 # Optional. If unspecified (the default behavior), then no fee granter is used, and
-# the account specified in `key_name` will pay the tx fees for all transactions
+# the account specified in `key-name` will pay the tx fees for all transactions
 # submitted to this chain.
-# fee_granter = ''
+# fee-granter = ''
 
 [[chains]]
 id = 'ibc-1'
-rpc_addr = 'http://127.0.0.1:26557'
-grpc_addr = 'http://127.0.0.1:9091'
-websocket_addr = 'ws://127.0.0.1:26557/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-default_gas = 100000
-max_gas = 400000
-gas_price = { price = 0.001, denom = 'stake' }
-gas_adjustment = 0.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
-max_block_time = '30s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+rpc-addr = 'http://127.0.0.1:26557'
+grpc-addr = 'http://127.0.0.1:9091'
+websocket-addr = 'ws://127.0.0.1:26557/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+default-gas = 100000
+max-gas = 400000
+gas-price = { price = 0.001, denom = 'stake' }
+gas-adjustment = 0.1
+max-msg-num = 30
+max-tx-size = 2097152
+clock-drift = '5s'
+max-block-time = '30s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }
+address-type = { derivation = 'cosmos' }

--- a/guide/src/commands/keys/index.md
+++ b/guide/src/commands/keys/index.md
@@ -140,7 +140,7 @@ Success: Added key testkey ([ADDRESS]) on [CHAIN ID] chain
 ```
 
 > **Key name:**
-> By default, the key will be named after the `key_name` property specified in the configuration file.
+> By default, the key will be named after the `key-name` property specified in the configuration file.
 > To use a different key name, specify the `--key-name` option when invoking `keys add`.
 >
 > ```
@@ -196,7 +196,7 @@ Success: Restore key testkey ([ADDRESS]) on [CHAIN ID] chain
 ```
 
 > **Key name:**
-> By default, the key will be named after the `key_name` property specified in the configuration file.
+> By default, the key will be named after the `key-name` property specified in the configuration file.
 > To use a different key name, specify the `--key-name` option when invoking `keys add`.
 >
 > ```

--- a/guide/src/commands/misbehaviour/index.md
+++ b/guide/src/commands/misbehaviour/index.md
@@ -42,9 +42,9 @@ The following types of misbehaviour are handled:
 
     Some header with a height that is higher than the latest
     height on chain `A` has been accepted and a consensus state was created on `B`. Note that this implies
-    that the timestamp of this header must be within the `clock_drift` of the client.
+    that the timestamp of this header must be within the `clock-drift` of the client.
     Assume the client on `B` has been updated with `h2`(not present on/ produced by chain `A`)
-    and it has a timestamp of `t2` that is at most `clock_drift` in the future.
+    and it has a timestamp of `t2` that is at most `clock-drift` in the future.
     Then the latest header from `A` is fetched, let it be `h1`, with a timestamp of `t1`.
     If `t1 >= t2` then evidence of misbehavior is submitted to A.
 

--- a/guide/src/commands/relaying/handshakes.md
+++ b/guide/src/commands/relaying/handshakes.md
@@ -8,7 +8,7 @@ for connections and channels.
 To relay packets and handshake messages configure the `mode` section of the configuration file like so:
 ```toml
 [global]
-log_level = 'info'
+log-level = 'info'
 
 [mode]
 

--- a/guide/src/commands/relaying/packets.md
+++ b/guide/src/commands/relaying/packets.md
@@ -11,7 +11,7 @@ This section describes the configuration and commands that can be used to start 
 To relay packets only configure the `mode` section of the configuration file like so:
 ```toml
 [global]
-log_level = 'info'
+log-level = 'info'
 
 [mode]
 

--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -47,13 +47,13 @@ please refer to the [Keys](./commands/keys/index.md) sections in order to learn 
 
 Hermes supports connection via TLS for use-cases such as connecting from behind
 a proxy or a load balancer. In order to enable this, you'll want to set the
-`rpc_addr`, `grpc_addr`, or `websocket_addr` parameters to specify a TLS
+`rpc-addr`, `grpc-addr`, or `websocket-addr` parameters to specify a TLS
 connection via HTTPS using the following scheme (note that the port number 443
 is just used for example):
 ```
-rpc_addr = 'https://domain.com:443'
-grpc_addr = 'https://domain.com:443'
-websocket_addr = 'wss://domain.com:443/websocket'
+rpc-addr = 'https://domain.com:443'
+grpc-addr = 'https://domain.com:443'
+websocket-addr = 'wss://domain.com:443/websocket'
 ```
 
 ## Support for Interchain Accounts
@@ -133,17 +133,17 @@ in `~/.hermes/config.toml`, ie. with two chains `ibc-0` and `ibc-1`.
     ```toml
     [[chains]]
     id = 'ibc-2'
-    rpc_addr = 'http://127.0.0.1:26457'
-    grpc_addr = 'http://127.0.0.1:9092'
-    websocket_addr = 'ws://127.0.0.1:26457/websocket'
-    rpc_timeout = '10s'
-    account_prefix = 'cosmos'
-    key_name = 'testkey'
-    store_prefix = 'ibc'
-    max_gas = 20000000
-    gas_price = { price = 0.001, denom = 'stake' }
-    clock_drift = '5s'
-    trusting_period = '14days'
+    rpc-addr = 'http://127.0.0.1:26457'
+    grpc-addr = 'http://127.0.0.1:9092'
+    websocket-addr = 'ws://127.0.0.1:26457/websocket'
+    rpc-timeout = '10s'
+    account-prefix = 'cosmos'
+    key-name = 'testkey'
+    store-prefix = 'ibc'
+    max-gas = 20000000
+    gas-price = { price = 0.001, denom = 'stake' }
+    clock-drift = '5s'
+    trusting-period = '14days'
     ```
 
 4. Change the configuration of the chain `ibc-0`, eg. the `max_gas` property.

--- a/guide/src/config.md
+++ b/guide/src/config.md
@@ -60,7 +60,7 @@ websocket-addr = 'wss://domain.com:443/websocket'
 
 As of version 0.13.0, Hermes supports relaying on [Interchain Accounts][ica] channels.
 
-If the `packet_filter` option in the chain configuration is disabled, then
+If the `packet-filter` option in the chain configuration is disabled, then
 Hermes will relay on all existing and future channels, including ICA channels.
 
 There are two kinds of ICA channels:
@@ -76,7 +76,7 @@ but also relay on all ICA channels, you can specify the following packet filter:
 > to match over all the possible ICA ports.
 
 ```toml
-[chains.packet_filter]
+[chains.packet-filter]
 policy = 'allow'
 list = [
   ['ica*', '*'], # allow relaying on all channels whose port starts with `ica`
@@ -90,7 +90,7 @@ If you wish to relay on all channels but not on ICA channels, you can use
 the following packet filter configuration:
 
 ```toml
-[chains.packet_filter]
+[chains.packet-filter]
 policy = 'deny'
 list = [
   ['ica*', '*'], # deny relaying on all channels whose port starts with `ica`
@@ -146,7 +146,7 @@ in `~/.hermes/config.toml`, ie. with two chains `ibc-0` and `ibc-1`.
     trusting-period = '14days'
     ```
 
-4. Change the configuration of the chain `ibc-0`, eg. the `max_gas` property.
+4. Change the configuration of the chain `ibc-0`, eg. the `max-gas` property.
 
 5. Send a `SIGHUP` signal to the `hermes` process:
 

--- a/guide/src/help.md
+++ b/guide/src/help.md
@@ -93,7 +93,7 @@ Relevant snippet:
 log-level = 'error'
 ```
 
-Valid options for `log_level` are: 'error', 'warn', 'info', 'debug', 'trace'.
+Valid options for `log-level` are: 'error', 'warn', 'info', 'debug', 'trace'.
 These levels correspond to the tracing sub-component of the relayer-cli,
 [see here](https://docs.rs/tracing-core/0.1.17/tracing_core/struct.Level.html).
 

--- a/guide/src/help.md
+++ b/guide/src/help.md
@@ -7,7 +7,7 @@ For this purpose, we recommend a few ideas that could be of help:
 - [hermes help][help] command, providing a CLI
   documentation for all `hermes` commands.
 - [profile][profiling] your relayer binary to identify slow methods;
-- [configure][log-level] the `log_level` to help with debugging;
+- [configure][log-level] the `log-level` to help with debugging;
 - [patch][patching] your local gaia chain(s) to enable some corner-case methods
   (e.g., channel close);
 
@@ -82,7 +82,7 @@ all commands.
 
 ## Parametrizing the log output level
 
-The relayer configuration file permits parametrization of output verbosity via the knob called `log_level`.
+The relayer configuration file permits parametrization of output verbosity via the knob called `log-level`.
 This file is loaded by default from `$HOME/.hermes/config.toml`, but can be overridden in all commands
 with the `-c` flag, eg. `hermes -c ./path/to/my/config.toml some command`.
 
@@ -90,7 +90,7 @@ Relevant snippet:
 
 ```toml
 [global]
-log_level = 'error'
+log-level = 'error'
 ```
 
 Valid options for `log_level` are: 'error', 'warn', 'info', 'debug', 'trace'.
@@ -112,7 +112,7 @@ Using the `RUST_LOG` environment variable, we can turn logging on for the
 `tendermint-rpc` library, as follows:
 
 ```
-RUST_LOG=tendermint-rpc=debug,info hermes start
+RUST_LOG=tendermint_rpc=debug,info hermes start
 ```
 
 Setting the `RUST_LOG` environment variable to `tendermint_rpc=debug,info` instructs

--- a/guide/src/tutorials/local-chains/relay-paths/multiple-paths.md
+++ b/guide/src/tutorials/local-chains/relay-paths/multiple-paths.md
@@ -8,7 +8,7 @@ Follow the steps below to connect three chains together and relay packets betwee
 
     ```toml
     [global]
-    log_level = 'info'
+    log-level = 'info'
 
     [mode]
 
@@ -25,57 +25,57 @@ Follow the steps below to connect three chains together and relay packets betwee
 
     [mode.packets]
     enabled = true
-    clear_interval = 100
-    clear_on_start = true
-    tx_confirmation = true
+    clear-interval = 100
+    clear-on-start = true
+    tx-confirmation = true
 
     [[chains]]
     id = 'ibc-0'
-    rpc_addr = 'http://127.0.0.1:26657'
-    grpc_addr = 'http://127.0.0.1:9090'
-    websocket_addr = 'ws://127.0.0.1:26657/websocket'
-    rpc_timeout = '10s'
-    account_prefix = 'cosmos'
-    key_name = 'testkey'
-    store_prefix = 'ibc'
-    max_gas = 2000000
-    gas_price = { price = 0.001, denom = 'stake' }
-    gas_adjustment = 0.1
-    clock_drift = '5s'
-    trusting_period = '14days'
-    trust_threshold = { numerator = '1', denominator = '3' }
+    rpc-addr = 'http://127.0.0.1:26657'
+    grpc-addr = 'http://127.0.0.1:9090'
+    websocket-addr = 'ws://127.0.0.1:26657/websocket'
+    rpc-timeout = '10s'
+    account-prefix = 'cosmos'
+    key-name = 'testkey'
+    store-prefix = 'ibc'
+    max-gas = 2000000
+    gas-price = { price = 0.001, denom = 'stake' }
+    gas-adjustment = 0.1
+    clock-drift = '5s'
+    trusting-period = '14days'
+    trust-threshold = { numerator = '1', denominator = '3' }
 
     [[chains]]
     id = 'ibc-1'
-    rpc_addr = 'http://127.0.0.1:26557'
-    grpc_addr = 'http://127.0.0.1:9091'
-    websocket_addr = 'ws://127.0.0.1:26557/websocket'
-    rpc_timeout = '10s'
-    account_prefix = 'cosmos'
-    key_name = 'testkey'
-    store_prefix = 'ibc'
-    max_gas = 2000000
-    gas_price = { price = 0.001, denom = 'stake' }
-    gas_adjustment = 0.1
-    clock_drift = '5s'
-    trusting_period = '14days'
-    trust_threshold = { numerator = '1', denominator = '3' }
+    rpc-addr = 'http://127.0.0.1:26557'
+    grpc-addr = 'http://127.0.0.1:9091'
+    websocket-addr = 'ws://127.0.0.1:26557/websocket'
+    rpc-timeout = '10s'
+    account-prefix = 'cosmos'
+    key-name = 'testkey'
+    store-prefix = 'ibc'
+    max-gas = 2000000
+    gas-price = { price = 0.001, denom = 'stake' }
+    gas-adjustment = 0.1
+    clock-drift = '5s'
+    trusting-period = '14days'
+    trust-threshold = { numerator = '1', denominator = '3' }
 
     [[chains]]
     id = 'ibc-2'
-    rpc_addr = 'http://127.0.0.1:26457'
-    grpc_addr = 'http://127.0.0.1:9092'
-    websocket_addr = 'ws://127.0.0.1:26457/websocket'
-    rpc_timeout = '10s'
-    account_prefix = 'cosmos'
-    key_name = 'testkey'
-    store_prefix = 'ibc'
-    max_gas = 2000000
-    gas_price = { price = 0.001, denom = 'stake' }
-    gas_adjustment = 0.1
-    clock_drift = '5s'
-    trusting_period = '14days'
-    trust_threshold = { numerator = '1', denominator = '3' }
+    rpc-addr = 'http://127.0.0.1:26457'
+    grpc-addr = 'http://127.0.0.1:9092'
+    websocket-addr = 'ws://127.0.0.1:26457/websocket'
+    rpc-timeout = '10s'
+    account-prefix = 'cosmos'
+    key-name = 'testkey'
+    store-prefix = 'ibc'
+    max-gas = 2000000
+    gas-price = { price = 0.001, denom = 'stake' }
+    gas-adjustment = 0.1
+    clock-drift = '5s'
+    trusting-period = '14days'
+    trust-threshold = { numerator = '1', denominator = '3' }
     ```
 
     This configuration has three chains `ibc-0`, `ibc-1` and `ibc-2`.

--- a/relayer-cli/tests/fixtures/two_chains.toml
+++ b/relayer-cli/tests/fixtures/two_chains.toml
@@ -1,5 +1,5 @@
 [global]
-log_level = 'error' # valid options: 'error', 'warn', 'info', 'debug', 'trace'
+log-level = 'error' # valid options: 'error', 'warn', 'info', 'debug', 'trace'
 
 [mode]
 
@@ -16,40 +16,40 @@ enabled = false
 
 [mode.packets]
 enabled = true
-clear_interval = 100
-clear_on_start = true
-tx_confirmation = true
+clear-interval = 100
+clear-on-start = true
+tx-confirmation = true
 
 [[chains]]
 id = 'ibc-0'
-rpc_addr = 'http://127.0.0.1:26657'
-grpc_addr = 'http://127.0.0.1:9090'
-websocket_addr = 'ws://127.0.0.1:26657/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-client_ids = ['cla1', 'cla2']
-clock_drift = '5s'
-trusting_period = '14days'
+rpc-addr = 'http://127.0.0.1:26657'
+grpc-addr = 'http://127.0.0.1:9090'
+websocket-addr = 'ws://127.0.0.1:26657/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+client-ids = ['cla1', 'cla2']
+clock-drift = '5s'
+trusting-period = '14days'
 
-[chains.trust_threshold]
+[chains.trust-threshold]
 numerator = '1'
 denominator = '3'
 
 [[chains]]
 id = 'ibc-1'
-rpc_addr = 'http://127.0.0.1:26657'
-grpc_addr = 'http://127.0.0.1:9090'
-websocket_addr = 'ws://127.0.0.1:26657/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-client_ids = ['clb1']
-clock_drift = '5s'
-trusting_period = '14days'
+rpc-addr = 'http://127.0.0.1:26657'
+grpc-addr = 'http://127.0.0.1:9090'
+websocket-addr = 'ws://127.0.0.1:26657/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+client-ids = ['clb1']
+clock-drift = '5s'
+trusting-period = '14days'
 
-[chains.trust_threshold]
+[chains.trust-threshold]
 numerator = '1'
 denominator = '3'

--- a/relayer-rest/tests/mock.rs
+++ b/relayer-rest/tests/mock.rs
@@ -93,21 +93,21 @@ fn get_chains() {
 
 const MOCK_CHAIN_CONFIG: &str = r#"
 id = 'mock-0'
-rpc_addr = 'http://127.0.0.1:26557'
-grpc_addr = 'http://127.0.0.1:9091'
-websocket_addr = 'ws://127.0.0.1:26557/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-max_gas = 3000000
-gas_price = { price = 0.001, denom = 'stake' }
-gas_adjustment = 0.1
-max_msg_num = 30
-max_tx_size = 2097152
-clock_drift = '5s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+rpc-addr = 'http://127.0.0.1:26557'
+grpc-addr = 'http://127.0.0.1:9091'
+websocket-addr = 'ws://127.0.0.1:26557/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+max-gas = 3000000
+gas-price = { price = 0.001, denom = 'stake' }
+gas-adjustment = 0.1
+max-msg-num = 30
+max-tx-size = 2097152
+clock-drift = '5s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }
 "#;
 
 #[test]

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -289,7 +289,7 @@ pub enum AddressType {
     Cosmos,
     Ethermint {
         #[serde(rename = "pk-type")]
-        pk_type: String
+        pk_type: String,
     },
 }
 

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -179,7 +179,7 @@ pub struct Channels {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Packets {
     pub enabled: bool,
     #[serde(default = "default::clear_packets_interval")]
@@ -233,7 +233,7 @@ impl fmt::Display for LogLevel {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct GlobalConfig {
     pub log_level: LogLevel,
 }
@@ -306,7 +306,7 @@ impl fmt::Display for AddressType {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ChainConfig {
     pub id: ChainId,
     pub rpc_addr: tendermint_rpc::Url,

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -282,12 +282,15 @@ impl Default for RestConfig {
 #[serde(
     rename_all = "lowercase",
     tag = "derivation",
-    content = "proto_type",
+    content = "proto-type",
     deny_unknown_fields
 )]
 pub enum AddressType {
     Cosmos,
-    Ethermint { pk_type: String },
+    Ethermint {
+        #[serde(rename = "pk-type")]
+        pk_type: String
+    },
 }
 
 impl Default for AddressType {

--- a/relayer/src/sdk_error.rs
+++ b/relayer/src/sdk_error.rs
@@ -18,7 +18,7 @@ define_error! {
 
         OutOfGas
             { code: u32 }
-            |_| { "the price configuration for this chain may be too low! please check the `gas_price.price` Hermes config.toml".to_string() },
+            |_| { "the price configuration for this chain may be too low! please check the `gas-price.price` Hermes config.toml".to_string() },
     }
 }
 

--- a/relayer/tests/config/fixtures/relayer_conf_example.toml
+++ b/relayer/tests/config/fixtures/relayer_conf_example.toml
@@ -1,5 +1,5 @@
 [global]
-log_level = 'error'
+log-level = 'error'
 
 [mode]
 
@@ -16,29 +16,29 @@ enabled = false
 
 [mode.packets]
 enabled = true
-clear_interval = 100
-clear_on_start = true
-tx_confirmation = true
+clear-interval = 100
+clear-on-start = true
+tx-confirmation = true
 
 [[chains]]
 id = 'chain_A'
-rpc_addr = 'http://127.0.0.1:26657'
-grpc_addr = 'http://127.0.0.1:9090'
-websocket_addr = 'ws://localhost:26657/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-max_gas = 200000
-gas_price = { price = 0.001, denom = 'stake' }
-max_msg_num = 4
-max_tx_size = 1048576
-clock_drift = '5s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'cosmos' }
+rpc-addr = 'http://127.0.0.1:26657'
+grpc-addr = 'http://127.0.0.1:9090'
+websocket-addr = 'ws://localhost:26657/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+max-gas = 200000
+gas-price = { price = 0.001, denom = 'stake' }
+max-msg-num = 4
+max-tx-size = 1048576
+clock-drift = '5s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }
+address-type = { derivation = 'cosmos' }
 
-[chains.packet_filter]
+[chains.packet-filter]
 policy = 'allow'
 list = [
   ['ica*', '*'],
@@ -47,15 +47,15 @@ list = [
 
 [[chains]]
 id = 'chain_B'
-rpc_addr = 'http://127.0.0.1:26557'
-grpc_addr = 'http://127.0.0.1:9090'
-websocket_addr = 'ws://localhost:26557/websocket'
-rpc_timeout = '10s'
-account_prefix = 'cosmos'
-key_name = 'testkey'
-store_prefix = 'ibc'
-gas_price = { price = 0.001, denom = 'stake' }
-clock_drift = '5s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
-address_type = { derivation = 'ethermint', proto_type = { pk_type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey' } }
+rpc-addr = 'http://127.0.0.1:26557'
+grpc-addr = 'http://127.0.0.1:9090'
+websocket-addr = 'ws://localhost:26557/websocket'
+rpc-timeout = '10s'
+account-prefix = 'cosmos'
+key-name = 'testkey'
+store-prefix = 'ibc'
+gas-price = { price = 0.001, denom = 'stake' }
+clock-drift = '5s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }
+address-type = { derivation = 'ethermint', proto-type = { pk-type = '/injective.crypto.v1beta1.ethsecp256k1.PubKey' } }

--- a/scripts/gm/bin/lib-gm
+++ b/scripts/gm/bin/lib-gm
@@ -948,7 +948,7 @@ hermes_config() {
   fi
   cat <<EOF > "$GLOBAL_HERMES_CONFIG"
 [global]
-log_level = '${GLOBAL_HERMES_LOG_LEVEL}'
+log-level = '${GLOBAL_HERMES_LOG_LEVEL}'
 
 [mode]
 
@@ -965,9 +965,9 @@ enabled = true
 
 [mode.packets]
 enabled = true
-clear_interval = 100
-clear_on_start = true
-tx_confirmation = true
+clear-interval = 100
+clear-on-start = true
+tx-confirmation = true
 
 [telemetry]
 enabled = ${GLOBAL_HERMES_TELEMETRY_ENABLED}
@@ -988,18 +988,18 @@ EOF
     cat <<EOF >> "$GLOBAL_HERMES_CONFIG"
 [[chains]]
 id = '${ID}'
-rpc_addr = 'http://localhost:${RPC}'
-grpc_addr = 'http://localhost:${GRPC}'
-websocket_addr = 'ws://localhost:${RPC}/websocket'
-rpc_timeout = '15s'
-account_prefix = '${ACCOUNT_PREFIX}'
-key_name = 'wallet'
-store_prefix = 'ibc'
-gas_price = { price = 0.001, denom = '${DENOM}' }
-max_gas = 1000000
-clock_drift = '5s'
-trusting_period = '14days'
-trust_threshold = { numerator = '1', denominator = '3' }
+rpc-addr = 'http://localhost:${RPC}'
+grpc-addr = 'http://localhost:${GRPC}'
+websocket-addr = 'ws://localhost:${RPC}/websocket'
+rpc-timeout = '15s'
+account-prefix = '${ACCOUNT_PREFIX}'
+key-name = 'wallet'
+store-prefix = 'ibc'
+gas-price = { price = 0.001, denom = '${DENOM}' }
+max-gas = 1000000
+clock-drift = '5s'
+trusting-period = '14days'
+trust-threshold = { numerator = '1', denominator = '3' }
 
 EOF
     done


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2242

## Description

This PR refactored the TOML configuration file used by the ibc-relayer in order to have `-` (dash) instead of `_` (underscore) for the field names.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] ~Added tests: integration (for Hermes) or unit/mock tests (for modules).~ 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).