### PR TITLE
Add code space information in unknown SDK error

### DIFF
--- a/relayer/src/sdk_error.rs
+++ b/relayer/src/sdk_error.rs
@@ -13,8 +13,17 @@ define_error! {
             |_| { "Expected error code, instead got Ok" },
 
         UnknownSdk
+            {
+                codespace: String,
+                code: u32,
+            }
+            | e | {
+                format_args!("unknown SDK error with code space: {}, code: {}", e.codespace, e.code)
+            },
+
+        UnknownTxSync
             { code: u32 }
-            |e| { format!("unknown SDK error: {}", e.code) },
+            | e | { format_args!("unknown TX sync response error: {}", e.code) },
 
         OutOfGas
             { code: u32 }
@@ -169,7 +178,7 @@ pub fn sdk_error_from_tx_result(result: &TxResult) -> SdkError {
                 SdkError::client(client_error_from_code(code))
             } else {
                 // TODO: Implement mapping for other codespaces in ibc-go
-                SdkError::unknown_sdk(code)
+                SdkError::unknown_sdk(codespace, code)
             }
         }
     }
@@ -186,6 +195,6 @@ pub fn sdk_error_from_tx_sync_error_code(code: u32) -> SdkError {
         // on the Hermes side. We'll inform the user to check for misconfig.
         11 => SdkError::out_of_gas(code),
         13 => SdkError::insufficient_fee(code),
-        _ => SdkError::unknown_sdk(code),
+        _ => SdkError::unknown_tx_sync(code),
     }
 }


### PR DESCRIPTION

## Description

Follow up on #2266 to improve the error diagnostic for unknown errors coming from Cosmos SDK by including the code space for the error. This should help us identify the source of error in Cosmos SDK or ibc-go, and better format the error message in Hermes.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).