### PR TITLE
Ignore acc seq mismath when expected < got

### DIFF
--- a/.changelog/unreleased/improvements/relayer/2249-ignore-nonce-mismatch.md
+++ b/.changelog/unreleased/improvements/relayer/2249-ignore-nonce-mismatch.md
@@ -1,0 +1,2 @@
+- Reduce relaying delay when some account mismatch errors occur during Tx
+  simulation ([#2249](https://github.com/informalsystems/ibc-rs/issues/2249))

--- a/relayer-cli/src/lib.rs
+++ b/relayer-cli/src/lib.rs
@@ -19,6 +19,7 @@
     unused_lifetimes,
     unused_qualifications
 )]
+#![allow(deprecated)]
 
 extern crate alloc;
 

--- a/relayer/src/chain/cosmos/estimate.rs
+++ b/relayer/src/chain/cosmos/estimate.rs
@@ -149,7 +149,10 @@ fn can_recover_from_simulation_failure(e: &Error) -> bool {
     use crate::error::ErrorDetail::*;
 
     match e.detail() {
-        GrpcStatus(detail) => detail.is_client_state_height_too_low(),
+        GrpcStatus(detail) => {
+            detail.is_client_state_height_too_low()
+                || detail.is_account_sequence_mismatch_that_can_be_ignored()
+        }
         _ => false,
     }
 }

--- a/relayer/src/chain/cosmos/retry.rs
+++ b/relayer/src/chain/cosmos/retry.rs
@@ -94,12 +94,9 @@ fn do_send_tx_with_account_sequence_retry<'a>(
 
         match tx_result {
             // Gas estimation failed with acct. s.n. mismatch at estimate gas step.
-            // This indicates that the full node did not yet push the previous tx out of its
-            // mempool. Possible explanations: fees too low, network congested, or full node
-            // congested. Whichever the case, it is more expedient in production to drop the tx
-            // and refresh the s.n., to allow proceeding to the other transactions. A separate
-            // retry at the worker-level will handle retrying.
-            Err(e) if mismatching_account_sequence_number(&e) => {
+            // It indicates that the account sequence cached by hermes is stale.
+            // This can happen when the same account is used by another agent.
+            Err(e) if mismatch_account_sequence_number_error_requires_refresh(&e) => {
                 warn!("failed at estimate_gas step mismatching account sequence: dropping the tx & refreshing account sequence number");
                 refresh_account(&config.grpc_address, &key_entry.account, account).await?;
                 // Note: propagating error here can lead to bug & dropped packets:
@@ -143,18 +140,19 @@ fn do_send_tx_with_account_sequence_retry<'a>(
             // Catch-all arm for the Ok variant.
             // This is the case when gas estimation succeeded.
             Ok(response) => {
-                // Complete success.
                 match response.code {
+                    // Gas estimation succeeded and broadcasting was successfully.
                     Code::Ok => {
                         debug!("broadcast_tx_sync: {:?}", response);
 
                         account.sequence.increment_mut();
                         Ok(response)
                     }
+
                     // Gas estimation succeeded, but broadcasting failed with unrecoverable error.
                     Code::Err(code) => {
-                        // Avoid increasing the account s.n. if CheckTx failed
-                        // Log the error
+                        // Do not increase the account s.n. if CheckTx failed.
+                        // Log the error.
                         error!(
                             "broadcast_tx_sync: {:?}: diagnostic: {:?}",
                             response,
@@ -174,12 +172,13 @@ fn do_send_tx_with_account_sequence_retry<'a>(
 
 /// Determine whether the given error yielded by `tx_simulate`
 /// indicates hat the current sequence number cached in Hermes
-/// may be out-of-sync with the full node's version of the s.n.
-fn mismatching_account_sequence_number(e: &Error) -> bool {
+/// is smaller than the full node's version of the s.n. and therefore
+/// account needs to be refreshed.
+fn mismatch_account_sequence_number_error_requires_refresh(e: &Error) -> bool {
     use crate::error::ErrorDetail::*;
 
     match e.detail() {
-        GrpcStatus(detail) => detail.is_account_sequence_mismatch(),
+        GrpcStatus(detail) => detail.is_account_sequence_mismatch_that_requires_refresh(),
         _ => false,
     }
 }

--- a/relayer/src/chain/cosmos/retry.rs
+++ b/relayer/src/chain/cosmos/retry.rs
@@ -141,7 +141,7 @@ fn do_send_tx_with_account_sequence_retry<'a>(
             // This is the case when gas estimation succeeded.
             Ok(response) => {
                 match response.code {
-                    // Gas estimation succeeded and broadcasting was successfully.
+                    // Gas estimation succeeded and broadcasting was successful.
                     Code::Ok => {
                         debug!("broadcast_tx_sync: {:?}", response);
 

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -573,7 +573,7 @@ impl GrpcStatusSubdetail {
     /// If it evaluates to true then the error is ignored and the transaction that caused this
     /// simulation error is still sent to mempool with `broadcast_tx_sync` allowing for potential
     /// recovery after mempool's `recheckTxs` step.
-    /// More details in https://github.com/informalsystems/ibc-rs/issues/2249
+    /// More details in <https://github.com/informalsystems/ibc-rs/issues/2249>
     pub fn is_account_sequence_mismatch_that_can_be_ignored(&self) -> bool {
         match parse_sequences_in_mismatch_error_message(self.status.message()) {
             None => false,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2249

Changes:
- extracts the "expected" and "got" s.n. from error message
- uses default gas if mismatch s.n. occurs during simulation and expected < got

Testing:
- start two chains
- create a channel
- send 5000 transfers (this should already show the mismatch issue and CLI will finish early), repeat if error
- start hermes
  - before the fix: tx not sent, account is recached with wrong sequence, at next attempt the error is seen again, recaching again etc. (more details on what happens in #2249)
  - after the fix: tx is sent with default gas. For 5k sent packets, meaning 10k packet relays (recv and ack), I see the mismatch error with expected < got around 10 times
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).