### PR TITLE
Wait for tx hash to succeed regardless of unrecognized IbcEvents

### DIFF
--- a/relayer/src/chain/cosmos/batch.rs
+++ b/relayer/src/chain/cosmos/batch.rs
@@ -1,12 +1,12 @@
 use ibc::events::IbcEvent;
 use ibc_proto::google::protobuf::Any;
 use prost::Message;
+use tendermint::abci::transaction::Hash as TxHash;
 use tendermint_rpc::endpoint::broadcast::tx_sync::Response;
 
 use crate::chain::cosmos::retry::send_tx_with_account_sequence_retry;
 use crate::chain::cosmos::types::account::Account;
 use crate::chain::cosmos::types::config::TxConfig;
-use crate::chain::cosmos::types::tx::TxSyncResult;
 use crate::chain::cosmos::wait::wait_for_block_commits;
 use crate::config::types::{MaxMsgNum, MaxTxSize, Memo};
 use crate::error::Error;
@@ -25,7 +25,7 @@ pub async fn send_batched_messages_and_wait_commit(
         return Ok(Vec::new());
     }
 
-    let mut tx_sync_results = send_messages_as_batches(
+    let tx_hashes = send_messages_as_batches(
         config,
         max_msg_num,
         max_tx_size,
@@ -36,19 +36,14 @@ pub async fn send_batched_messages_and_wait_commit(
     )
     .await?;
 
-    wait_for_block_commits(
+    let events = wait_for_block_commits(
         &config.chain_id,
         &config.rpc_client,
         &config.rpc_address,
         &config.rpc_timeout,
-        &mut tx_sync_results,
+        &tx_hashes,
     )
     .await?;
-
-    let events = tx_sync_results
-        .into_iter()
-        .flat_map(|el| el.events)
-        .collect();
 
     Ok(events)
 }
@@ -89,31 +84,24 @@ async fn send_messages_as_batches(
     account: &mut Account,
     tx_memo: &Memo,
     messages: Vec<Any>,
-) -> Result<Vec<TxSyncResult>, Error> {
+) -> Result<Vec<TxHash>, Error> {
     if messages.is_empty() {
         return Ok(Vec::new());
     }
 
     let batches = batch_messages(max_msg_num, max_tx_size, messages)?;
 
-    let mut tx_sync_results = Vec::new();
+    let mut tx_hashes = Vec::new();
 
     for batch in batches {
-        let events_per_tx = vec![IbcEvent::default(); batch.len()];
-
         let response =
             send_tx_with_account_sequence_retry(config, key_entry, account, tx_memo, batch, 0)
                 .await?;
 
-        let tx_sync_result = TxSyncResult {
-            response,
-            events: events_per_tx,
-        };
-
-        tx_sync_results.push(tx_sync_result);
+        tx_hashes.push(response.hash);
     }
 
-    Ok(tx_sync_results)
+    Ok(tx_hashes)
 }
 
 fn batch_messages(

--- a/relayer/src/chain/cosmos/query/tx.rs
+++ b/relayer/src/chain/cosmos/query/tx.rs
@@ -5,10 +5,12 @@ use ibc::core::ics04_channel::events as ChannelEvents;
 use ibc::core::ics04_channel::packet::{Packet, Sequence};
 use ibc::core::ics24_host::identifier::ChainId;
 use ibc::events::{from_tx_response_event, IbcEvent};
-use ibc::query::QueryTxRequest;
+use ibc::query::{QueryTxHash, QueryTxRequest};
 use ibc::Height as ICSHeight;
+use tendermint::abci::transaction::Hash as TxHash;
 use tendermint::abci::Event;
 use tendermint_rpc::endpoint::tx::Response as ResultTx;
+use tendermint_rpc::endpoint::tx_search::Response as TxSearchResponse;
 use tendermint_rpc::{Client, HttpClient, Order, Url};
 
 use crate::chain::cosmos::query::{header_query, packet_query, tx_hash_query};
@@ -230,7 +232,29 @@ fn filter_matching_event(
     }
 }
 
-fn all_ibc_events_from_tx_search_response(chain_id: &ChainId, response: ResultTx) -> Vec<IbcEvent> {
+pub async fn query_tx_response(
+    rpc_client: &HttpClient,
+    rpc_address: &Url,
+    tx_hash: &TxHash,
+) -> Result<TxSearchResponse, Error> {
+    let response = rpc_client
+        .tx_search(
+            tx_hash_query(&QueryTxHash(*tx_hash)),
+            false,
+            1,
+            1, // get only the first Tx matching the query
+            Order::Ascending,
+        )
+        .await
+        .map_err(|e| Error::rpc(rpc_address.clone(), e))?;
+
+    Ok(response)
+}
+
+pub fn all_ibc_events_from_tx_search_response(
+    chain_id: &ChainId,
+    response: ResultTx,
+) -> Vec<IbcEvent> {
     let height = ICSHeight::new(chain_id.version(), u64::from(response.height));
     let deliver_tx_result = response.tx_result;
     if deliver_tx_result.code.is_err() {

--- a/relayer/src/chain/cosmos/wait.rs
+++ b/relayer/src/chain/cosmos/wait.rs
@@ -1,20 +1,20 @@
 use core::time::Duration;
+use futures::stream::{FuturesOrdered, TryStreamExt};
 use ibc::core::ics24_host::identifier::ChainId;
 use ibc::events::IbcEvent;
-use ibc::query::{QueryTxHash, QueryTxRequest};
-use itertools::Itertools;
-use std::thread;
 use std::time::Instant;
+use tendermint::abci::transaction::Hash as TxHash;
+use tendermint_rpc::endpoint::tx_search::Response as TxSearchResponse;
 use tendermint_rpc::{HttpClient, Url};
-use tracing::{info, trace};
+use tokio::time::sleep;
+use tracing::info;
 
-use crate::chain::cosmos::query::tx::query_txs;
-use crate::chain::cosmos::types::tx::TxSyncResult;
+use crate::chain::cosmos::query::tx::{all_ibc_events_from_tx_search_response, query_tx_response};
 use crate::error::Error;
 
 const WAIT_BACKOFF: Duration = Duration::from_millis(300);
 
-/// Given a vector of `TxSyncResult` elements,
+/// Given a vector of `TxHash` elements,
 /// each including a transaction response hash for one or more messages, periodically queries the chain
 /// with the transaction hashes to get the list of IbcEvents included in those transactions.
 pub async fn wait_for_block_commits(
@@ -22,93 +22,82 @@ pub async fn wait_for_block_commits(
     rpc_client: &HttpClient,
     rpc_address: &Url,
     rpc_timeout: &Duration,
-    tx_sync_results: &mut [TxSyncResult],
-) -> Result<(), Error> {
-    let start_time = Instant::now();
-
-    let hashes = tx_sync_results
-        .iter()
-        .map(|res| res.response.hash.to_string())
-        .join(", ");
-
+    tx_hashes: &[TxHash],
+) -> Result<Vec<IbcEvent>, Error> {
     info!(
         id = %chain_id,
-        "wait_for_block_commits: waiting for commit of tx hashes(s) {}",
-        hashes
+        "wait_for_block_commits: waiting for commit of tx hashes(s) {:?}",
+        tx_hashes
     );
 
-    loop {
-        let elapsed = start_time.elapsed();
+    let responses = wait_tx_hashes(rpc_client, rpc_address, rpc_timeout, tx_hashes).await?;
 
-        if all_tx_results_found(tx_sync_results) {
-            trace!(
-                id = %chain_id,
-                "wait_for_block_commits: retrieved {} tx results after {}ms",
-                tx_sync_results.len(),
-                elapsed.as_millis(),
-            );
+    let all_events = responses
+        .into_iter()
+        .flat_map(|response| {
+            response.txs.into_iter().flat_map(|tx_response| {
+                all_ibc_events_from_tx_search_response(chain_id, tx_response)
+            })
+        })
+        .collect();
 
-            return Ok(());
-        } else if &elapsed > rpc_timeout {
-            return Err(Error::tx_no_confirmation());
-        } else {
-            thread::sleep(WAIT_BACKOFF);
-
-            for tx_sync_result in tx_sync_results.iter_mut() {
-                // ignore error
-                let _ =
-                    update_tx_sync_result(chain_id, rpc_client, rpc_address, tx_sync_result).await;
-            }
-        }
-    }
+    Ok(all_events)
 }
 
-async fn update_tx_sync_result(
-    chain_id: &ChainId,
+pub async fn wait_tx_hashes(
     rpc_client: &HttpClient,
     rpc_address: &Url,
-    tx_sync_result: &mut TxSyncResult,
-) -> Result<(), Error> {
-    let TxSyncResult { response, events } = tx_sync_result;
-
-    // If this transaction was not committed, determine whether it was because it failed
-    // or because it hasn't been committed yet.
-    if empty_event_present(events) {
-        // If the transaction failed, replace the events with an error,
-        // so that we don't attempt to resolve the transaction later on.
-        if response.code.value() != 0 {
-            *events = vec![IbcEvent::ChainError(format!(
-                "deliver_tx on chain {} for Tx hash {} reports error: code={:?}, log={:?}",
-                chain_id, response.hash, response.code, response.log
-            ))];
-        }
-
-        // Otherwise, try to resolve transaction hash to the corresponding events.
-        let events_per_tx = query_txs(
-            chain_id,
-            rpc_client,
-            rpc_address,
-            QueryTxRequest::Transaction(QueryTxHash(response.hash)),
-        )
+    timeout: &Duration,
+    tx_hashes: &[TxHash],
+) -> Result<Vec<TxSearchResponse>, Error> {
+    let responses = tx_hashes
+        .iter()
+        .map(|tx_hash| wait_tx_hash(rpc_client, rpc_address, timeout, tx_hash))
+        .collect::<FuturesOrdered<_>>()
+        .try_collect()
         .await?;
 
-        // If we get events back, progress was made, so we replace the events
-        // with the new ones. in both cases we will check in the next iteration
-        // whether or not the transaction was fully committed.
-        if !events_per_tx.is_empty() {
-            *events = events_per_tx;
+    Ok(responses)
+}
+
+pub async fn wait_tx_succeed(
+    rpc_client: &HttpClient,
+    rpc_address: &Url,
+    timeout: &Duration,
+    tx_hash: &TxHash,
+) -> Result<(), Error> {
+    let response = wait_tx_hash(rpc_client, rpc_address, timeout, tx_hash).await?;
+
+    for response in response.txs {
+        let response_code = response.tx_result.code;
+        if response_code.is_err() {
+            return Err(Error::rpc_response(format!("{}", response_code.value())));
         }
     }
 
     Ok(())
 }
 
-fn empty_event_present(events: &[IbcEvent]) -> bool {
-    events.iter().any(|ev| matches!(ev, IbcEvent::Empty(_)))
-}
+pub async fn wait_tx_hash(
+    rpc_client: &HttpClient,
+    rpc_address: &Url,
+    timeout: &Duration,
+    tx_hash: &TxHash,
+) -> Result<TxSearchResponse, Error> {
+    let start_time = Instant::now();
 
-fn all_tx_results_found(tx_sync_results: &[TxSyncResult]) -> bool {
-    tx_sync_results
-        .iter()
-        .all(|r| !empty_event_present(&r.events))
+    loop {
+        let responses = query_tx_response(rpc_client, rpc_address, tx_hash).await?;
+
+        if responses.txs.is_empty() {
+            let elapsed = start_time.elapsed();
+            if &elapsed > timeout {
+                return Err(Error::tx_no_confirmation());
+            } else {
+                sleep(WAIT_BACKOFF).await;
+            }
+        } else {
+            return Ok(responses);
+        }
+    }
 }

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -2,7 +2,7 @@
 
 use core::time::Duration;
 
-use flex_error::{define_error, DisplayOnly, TraceClone, TraceError};
+use flex_error::{define_error, DisplayOnly, TraceError};
 use http::uri::InvalidUri;
 use humantime::format_duration;
 use prost::{DecodeError, EncodeError};
@@ -46,7 +46,7 @@ define_error! {
 
         Rpc
             { url: tendermint_rpc::Url }
-            [ TraceClone<TendermintRpcError> ]
+            [ TendermintRpcError ]
             |e| { format!("RPC error to endpoint {}", e.url) },
 
         AbciQuery
@@ -91,7 +91,7 @@ define_error! {
             |e| { format!("missing parameter in GRPC response: {}", e.param) },
 
         Decode
-            [ TraceError<TendermintProtoError> ]
+            [ TendermintProtoError ]
             |_| { "error decoding protobuf" },
 
         LightClientVerification
@@ -122,7 +122,7 @@ define_error! {
             |_| { "bad notification" },
 
         ConversionFromAny
-            [ TraceError<TendermintProtoError> ]
+            [ TendermintProtoError ]
             |_| { "conversion from a protobuf `Any` into a domain type failed" },
 
         EmptyUpgradedClientState
@@ -140,6 +140,10 @@ define_error! {
 
         EmptyResponseProof
             |_| { "empty response proof" },
+
+        RpcResponse
+            { detail: String }
+            | e | { format!("RPC client returns error response: {}", e.detail) },
 
         MalformedProof
             [ ProofError ]


### PR DESCRIPTION
Closes: #2314

## Description

Extracted from #2227 to make the waiting of send_tx to succeed if all TxHash are committed successfully. Previously, send_tx would timeout and fail if unsupported transactions are submitted with events unrecognized by `IbcEvent`, even if the transaction were successful.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).