### PR TITLE
Fix client upgrade

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/2185-client-upgrade.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/2185-client-upgrade.md
@@ -1,0 +1,2 @@
+- Use appropriate height when querying for client upgrade state
+  ([#2185](https://github.com/informalsystems/ibc-rs/issues/2185))

--- a/relayer-cli/src/commands/tx/client.rs
+++ b/relayer-cli/src/commands/tx/client.rs
@@ -13,6 +13,7 @@ use ibc_relayer::chain::requests::{
 use ibc_relayer::config::Config;
 use ibc_relayer::foreign_client::{CreateOptions, ForeignClient};
 use tendermint_light_client_verifier::types::TrustThreshold;
+use tracing::warn;
 
 use crate::application::app_config;
 use crate::cli_utils::{spawn_chain_runtime, spawn_chain_runtime_generic, ChainHandlePair};
@@ -219,6 +220,12 @@ impl Runnable for TxUpgradeClientCmd {
             // 1 less than the halted height
             src_application_height.increment()
         };
+
+        warn!(
+            "Assuming that chain '{}' is currently halted for upgrade at height {}",
+            client.src_chain().id(),
+            src_upgrade_height
+        );
         let outcome = client.upgrade(src_upgrade_height);
 
         match outcome {

--- a/relayer/src/channel.rs
+++ b/relayer/src/channel.rs
@@ -739,7 +739,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Channel<ChainA, ChainB> {
             self.src_chain().clone(),
         );
 
-        client.build_update_client(height).map_err(|e| {
+        client.wait_and_build_update_client(height).map_err(|e| {
             ChannelError::client_operation(self.dst_client_id().clone(), self.dst_chain().id(), e)
         })
     }

--- a/relayer/src/connection.rs
+++ b/relayer/src/connection.rs
@@ -834,7 +834,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
 
     pub fn build_update_client_on_src(&self, height: Height) -> Result<Vec<Any>, ConnectionError> {
         let client = self.restore_src_client();
-        client.build_update_client(height).map_err(|e| {
+        client.wait_and_build_update_client(height).map_err(|e| {
             ConnectionError::client_operation(
                 self.src_client_id().clone(),
                 self.src_chain().id(),
@@ -845,7 +845,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Connection<ChainA, ChainB> {
 
     pub fn build_update_client_on_dst(&self, height: Height) -> Result<Vec<Any>, ConnectionError> {
         let client = self.restore_dst_client();
-        client.build_update_client(height).map_err(|e| {
+        client.wait_and_build_update_client(height).map_err(|e| {
             ConnectionError::client_operation(
                 self.dst_client_id().clone(),
                 self.dst_chain().id(),

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -149,6 +149,9 @@ define_error! {
             [ TendermintError ]
             |_| { "invalid height" },
 
+        InvalidHeightNoSource
+            |_| { "invalid height" },
+
         InvalidMetadata
             [ TraceError<InvalidMetadataValue> ]
             |_| { "invalid metadata" },

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -441,7 +441,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
         }
     }
 
-    /// Create and send a transaction to perform a chain upgrade.
+    /// Create and send a transaction to perform a client upgrade.
     /// src_upgrade_height: The height on the source chain at which the chain will halt for the upgrade.
     pub fn upgrade(&self, src_upgrade_height: Height) -> Result<Vec<IbcEvent>, ForeignClientError> {
         info!("[{}] upgrade Height: {}", self, src_upgrade_height);

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -435,7 +435,11 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
     pub fn upgrade(&self, src_upgrade_height: Height) -> Result<Vec<IbcEvent>, ForeignClientError> {
         info!("[{}] upgrade Height: {}", self, src_upgrade_height);
 
-        let mut msgs = self.build_update_client(src_upgrade_height)?;
+        let src_application_height = src_upgrade_height
+            .decrement()
+            .map_err(ForeignClientError::client)?;
+
+        let mut msgs = self.build_update_client(src_application_height)?;
 
         // Query the host chain for the upgraded client state, consensus state & their proofs.
         let (client_state, proof_upgrade_client) = self

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -957,14 +957,18 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
         }
     }
 
-    /// Returns a vector with a message for updating the client to height `target_height`.
-    /// If the client already stores a consensus state for this height, returns an empty vector.
+    /// Wait for the source chain application to reach height `target_height`
+    /// before building the update client messages.
+    ///
+    /// Returns a vector with a message for updating the client to height
+    /// `target_height`. If the client already stores a consensus state for this
+    /// height, returns an empty vector.
     pub fn wait_and_build_update_client_with_trusted(
         &self,
         target_height: Height,
         trusted_height: Height,
     ) -> Result<Vec<Any>, ForeignClientError> {
-        let src_network_latest_height = || {
+        let src_application_latest_height = || {
             self.src_chain().query_latest_height().map_err(|e| {
                 ForeignClientError::client_create(
                     self.src_chain.id(),
@@ -975,7 +979,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
         };
 
         // Wait for the source network to produce block(s) & reach `target_height`.
-        while src_network_latest_height()? < target_height {
+        while src_application_latest_height()? < target_height {
             thread::sleep(Duration::from_millis(100))
         }
 

--- a/relayer/src/link/relay_path.rs
+++ b/relayer/src/link/relay_path.rs
@@ -317,14 +317,14 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> RelayPath<ChainA, ChainB> {
     pub fn build_update_client_on_dst(&self, height: Height) -> Result<Vec<Any>, LinkError> {
         let client = self.restore_dst_client();
         client
-            .build_update_client(height)
+            .wait_and_build_update_client(height)
             .map_err(LinkError::client)
     }
 
     pub fn build_update_client_on_src(&self, height: Height) -> Result<Vec<Any>, LinkError> {
         let client = self.restore_src_client();
         client
-            .build_update_client(height)
+            .wait_and_build_update_client(height)
             .map_err(LinkError::client)
     }
 


### PR DESCRIPTION

Closes: #2185

## Description
I did not add a `query_chain_height()` vs `query_latest_application_height()`, as the `query_chain_height()` would only be used in the special case of a client upgrade. Also, I now think it would be best if the cli for client upgrade forced the user to specify the chain upgrade height: it would be better UX IMO, and we wouldn't need to ever query the "chain height" (i.e. tendermint height). To be considered when dealing with #2300.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).