### PR TITLE
feat: add flag to skip new_client_connection confirmation

### DIFF
--- a/.changelog/unreleased/improvements/relayer-cli/2317-add-flag-to-skip-new-client-connection.md
+++ b/.changelog/unreleased/improvements/relayer-cli/2317-add-flag-to-skip-new-client-connection.md
@@ -1,0 +1,2 @@
+- Added `--yes` flag to the `create channel` flow to enable skipping the
+  `--new-client-connection` step ([#2317](https://github.com/informalsystems/ibc-rs/issues/2317))

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -30,14 +30,14 @@ static HINT: &str = "Consider using the default invocation\n\nhermes create chan
 ///
 /// There are two possible ways to invoke this command:
 ///
-/// `create channel --a-port <A_PORT_ID> --b-port <B_PORT_ID> --a-chain <A_CHAIN_ID> --a-conn <A_CONNECTION_ID>` 
-/// is the default way in which this command should be used, specifying a `Connection-ID` 
+/// `create channel --a-port <A_PORT_ID> --b-port <B_PORT_ID> --a-chain <A_CHAIN_ID> --a-conn <A_CONNECTION_ID>`
+/// is the default way in which this command should be used, specifying a `Connection-ID`
 /// associated with chain A for this new channel to re-use.
 ///
 /// `create channel --a-port <A_PORT_ID> --b-port <B_PORT_ID> --a-chain <A_CHAIN_ID> --b-chain <B_CHAIN_ID> --new-client-conn`
-/// can alternatively be used to indicate that a new connection/client pair is being 
-/// created as part of this new channel. This brings up an interactive yes/no prompt 
-/// to ensure that the operator at least considers the fact that they're initializing a 
+/// can alternatively be used to indicate that a new connection/client pair is being
+/// created as part of this new channel. This brings up an interactive yes/no prompt
+/// to ensure that the operator at least considers the fact that they're initializing a
 /// new connection with the channel. This prompt can be skipped by appending the `--yes`
 /// flag to the command.
 ///
@@ -97,7 +97,7 @@ pub struct CreateChannelCommand {
         long,
         help = "Indicates that a new client and connection will be created underlying the new channel"
     )]
-    new_client_connection: bool,
+    new_client_conn: bool,
 
     #[clap(long, help = "Skip new_client_conn confirmation")]
     yes: bool,
@@ -109,7 +109,7 @@ impl Runnable for CreateChannelCommand {
             Some(conn) => self.run_reusing_connection(conn),
             None => match &self.chain_b {
                 Some(chain_b) => {
-                    if self.new_client_connection {
+                    if self.new_client_conn {
                         if self.yes {
                             self.run_using_new_connection(chain_b);
                         } else {
@@ -147,7 +147,7 @@ impl Runnable for CreateChannelCommand {
                     }
                 }
                 None => {
-                    Output::error("Missing one of `<b-chain>` or `<a-conn>`".to_string()).exit()
+                    Output::error("Missing one of `--b-chain` or `--a-conn`".to_string()).exit()
                 }
             },
         }

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -96,6 +96,12 @@ pub struct CreateChannelCommand {
         help = "Indicates that a new client and connection will be created underlying the new channel"
     )]
     new_client_connection: bool,
+
+    #[clap(
+        long,
+        help = "Skip new_client_connection confirmation"
+    )]
+    yes: bool,
 }
 
 impl Runnable for CreateChannelCommand {
@@ -105,28 +111,33 @@ impl Runnable for CreateChannelCommand {
             None => match &self.chain_b {
                 Some(chain_b) => {
                     if self.new_client_connection {
-                        match Confirm::new()
-                            .with_prompt(format!(
-                                "{}: {}\n{}: {}",
-                                style("WARN").yellow(),
-                                PROMPT,
-                                style("Hint").cyan(),
-                                HINT
-                            ))
-                            .interact()
-                        {
-                            Ok(confirm) => {
-                                if confirm {
-                                    self.run_using_new_connection(chain_b);
-                                } else {
-                                    Output::error("You elected not to create new clients and connections. Please re-invoke `create channel` with a pre-existing connection ID".to_string()).exit();
+                        if self.yes {
+                            self.run_using_new_connection(chain_b);
+                        }
+                        else {
+                            match Confirm::new()
+                                .with_prompt(format!(
+                                    "{}: {}\n{}: {}",
+                                    style("WARN").yellow(),
+                                    PROMPT,
+                                    style("Hint").cyan(),
+                                    HINT
+                                ))
+                                .interact()
+                            {
+                                Ok(confirm) => {
+                                    if confirm {
+                                        self.run_using_new_connection(chain_b);
+                                    } else {
+                                        Output::error("You elected not to create new clients and connections. Please re-invoke `create channel` with a pre-existing connection ID".to_string()).exit();
+                                    }
                                 }
-                            }
-                            Err(e) => {
-                                Output::error(format!(
-                                    "An error occurred while waiting for user input: {}",
-                                    e
-                                ));
+                                Err(e) => {
+                                    Output::error(format!(
+                                        "An error occurred while waiting for user input: {}",
+                                        e
+                                    ));
+                                }
                             }
                         }
                     } else {

--- a/relayer-cli/src/commands/create/channel.rs
+++ b/relayer-cli/src/commands/create/channel.rs
@@ -30,14 +30,16 @@ static HINT: &str = "Consider using the default invocation\n\nhermes create chan
 ///
 /// There are two possible ways to invoke this command:
 ///
-/// `create channel --port-a <Port-ID> --port-b <Port-ID> <Chain-A-ID> <Connection-ID>` is the default
-/// way in which this command should be used, specifying a `Connection-ID` for this new channel
-/// to re-use. The command expects that `Connection-ID` is associated with chain A.
+/// `create channel --a-port <A_PORT_ID> --b-port <B_PORT_ID> --a-chain <A_CHAIN_ID> --a-conn <A_CONNECTION_ID>` 
+/// is the default way in which this command should be used, specifying a `Connection-ID` 
+/// associated with chain A for this new channel to re-use.
 ///
-/// `create channel --port-a <Port-ID> --port-b <Port-ID> <Chain-A-ID> <Chain-B-ID> --new-client-connection`
-/// to indicate that a new connection/client pair is being created as part of this new channel.
-/// This brings up an interactive yes/no prompt to ensure that the operator at least
-/// considers the fact that they're initializing a new connection with the channel.
+/// `create channel --a-port <A_PORT_ID> --b-port <B_PORT_ID> --a-chain <A_CHAIN_ID> --b-chain <B_CHAIN_ID> --new-client-conn`
+/// can alternatively be used to indicate that a new connection/client pair is being 
+/// created as part of this new channel. This brings up an interactive yes/no prompt 
+/// to ensure that the operator at least considers the fact that they're initializing a 
+/// new connection with the channel. This prompt can be skipped by appending the `--yes`
+/// flag to the command.
 ///
 /// Note that `Connection-ID`s have to be considered based off of the chain's perspective. Although
 /// chain A and chain B might refer to the connection with different names, they are actually referring
@@ -97,10 +99,7 @@ pub struct CreateChannelCommand {
     )]
     new_client_connection: bool,
 
-    #[clap(
-        long,
-        help = "Skip new_client_connection confirmation"
-    )]
+    #[clap(long, help = "Skip new_client_conn confirmation")]
     yes: bool,
 }
 
@@ -113,8 +112,7 @@ impl Runnable for CreateChannelCommand {
                     if self.new_client_connection {
                         if self.yes {
                             self.run_using_new_connection(chain_b);
-                        }
-                        else {
+                        } else {
                             match Confirm::new()
                                 .with_prompt(format!(
                                     "{}: {}\n{}: {}",
@@ -142,13 +140,15 @@ impl Runnable for CreateChannelCommand {
                         }
                     } else {
                         Output::error(
-                                "The `--new-client-connection` flag is required if invoking with `--chain-b`".to_string()
-                            )
-                            .exit();
+                            "The `--new-client-conn` flag is required if invoking with `--b-chain`"
+                                .to_string(),
+                        )
+                        .exit();
                     }
                 }
-                None => Output::error("Missing one of `<chain-b>` or `<connection-a>`".to_string())
-                    .exit(),
+                None => {
+                    Output::error("Missing one of `<b-chain>` or `<a-conn>`".to_string()).exit()
+                }
             },
         }
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2317 

## Description
This PR adds a `--yes` flag to skip the `--new-client-connection` confirmation in the `hermes create channel` command. The motivation behinds this addition is that the `--new-client-connection` flag comes quite handy in testing environments as it allows to create new clients/connection instantly but bypassing the confirmation proved to be quite difficult. I tried to bypass it with different variations from the shell script (i.e. `yes | hermes create` and `echo 'y' | hermes create`) but eventually none of them worked.

I modified the source code/tested and creating this PR to potentially include in a newer release. I think the motivation behind the `--new-client-connection` was to be mainly used in testing environments as the setup of clients/connection in production is always best to be done progressively and it's often evident that relayers are not using existing connections or clients. Thus, this small addition will improve the usage of the command.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).