### PR TITLE
Deduplicate Docker images for gaiad

### DIFF
--- a/ci/build-ibc-chains.sh
+++ b/ci/build-ibc-chains.sh
@@ -72,9 +72,7 @@ echo "*** Requirements"
 which docker
 
 echo "*** Create Docker image and upload to Docker Hub"
-docker build --build-arg CHAIN=gaia --build-arg RELEASE=$GAIA_BRANCH --build-arg NAME=ibc-0 --no-cache -t informaldev/ibc-0:$GAIA_BRANCH -f "$BASE_DIR/gaia.Dockerfile" .
-docker build --build-arg CHAIN=gaia --build-arg RELEASE=$GAIA_BRANCH --build-arg NAME=ibc-1 --no-cache -t informaldev/ibc-1:$GAIA_BRANCH -f "$BASE_DIR/gaia.Dockerfile" .
+docker build --build-arg RELEASE=$GAIA_BRANCH --no-cache -t informaldev/gaiad:$GAIA_BRANCH -f "$BASE_DIR/gaia.Dockerfile" .
 
 read -p "Press ANY KEY to push image to Docker Hub, or CTRL-C to cancel. " dontcare
-docker push informaldev/ibc-0:$GAIA_BRANCH
-docker push informaldev/ibc-1:$GAIA_BRANCH
+docker push informaldev/gaiad:$GAIA_BRANCH

--- a/ci/docker-compose-gaia-current.yml
+++ b/ci/docker-compose-gaia-current.yml
@@ -9,7 +9,7 @@ services:
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"
     volumes:
-      - type: volume
+      - type: bind
         source: ./chains/gaia/v7.0.1/ibc-0
         target: /chain/gaia
     networks:
@@ -25,7 +25,7 @@ services:
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"
     volumes:
-      - type: volume
+      - type: bind
         source: ./chains/gaia/v7.0.1/ibc-1
         target: /chain/gaia
     networks:

--- a/ci/docker-compose-gaia-current.yml
+++ b/ci/docker-compose-gaia-current.yml
@@ -4,10 +4,14 @@ services:
 
   ibc-0:
     container_name: ibc-0
-    image: "informaldev/ibc-0:v7.0.1"
+    image: "informaldev/gaiad:v7.0.1"
     stdin_open: true
     tty: true
-    entrypoint: "/chain/gaia/run-gaiad.sh"
+    entrypoint: "/usr/bin/run-gaiad.sh"
+    volumes:
+      - type: volume
+        source: ./chains/gaia/v7.0.1/ibc-0
+        target: /chain/gaia
     networks:
       relaynet:
         ipv4_address: 172.25.0.10
@@ -16,10 +20,14 @@ services:
 
   ibc-1:
     container_name: ibc-1
-    image: "informaldev/ibc-1:v7.0.1"
+    image: "informaldev/gaiad:v7.0.1"
     stdin_open: true
     tty: true
-    entrypoint: "/chain/gaia/run-gaiad.sh"
+    entrypoint: "/usr/bin/run-gaiad.sh"
+    volumes:
+      - type: volume
+        source: ./chains/gaia/v7.0.1/ibc-1
+        target: /chain/gaia
     networks:
       relaynet:
         ipv4_address: 172.25.0.11

--- a/ci/docker-compose-gaia-current.yml
+++ b/ci/docker-compose-gaia-current.yml
@@ -4,7 +4,7 @@ services:
 
   ibc-0:
     container_name: ibc-0
-    image: "informaldev/gaiad:v7.0.1"
+    image: "ghcr.io/mzabaluev/gaiad:v7.0.1"
     stdin_open: true
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"
@@ -20,7 +20,7 @@ services:
 
   ibc-1:
     container_name: ibc-1
-    image: "informaldev/gaiad:v7.0.1"
+    image: "ghcr.io/mzabaluev/gaiad:v7.0.1"
     stdin_open: true
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"

--- a/ci/docker-compose-gaia-legacy.yml
+++ b/ci/docker-compose-gaia-legacy.yml
@@ -4,10 +4,14 @@ services:
 
   ibc-0:
     container_name: ibc-0
-    image: "informaldev/ibc-0:v6.0.0"
+    image: "informaldev/gaiad:v6.0.0"
     stdin_open: true
     tty: true
-    entrypoint: "/chain/gaia/run-gaiad.sh"
+    entrypoint: "/usr/bin/run-gaiad.sh"
+    volumes:
+      - type: volume
+        source: ./chains/gaia/v6.0.0/ibc-0
+        target: /chain/gaia
     networks:
       relaynet:
         ipv4_address: 172.25.0.10
@@ -16,10 +20,14 @@ services:
 
   ibc-1:
     container_name: ibc-1
-    image: "informaldev/ibc-1:v6.0.0"
+    image: "informaldev/gaiad:v6.0.0"
     stdin_open: true
     tty: true
-    entrypoint: "/chain/gaia/run-gaiad.sh"
+    entrypoint: "/usr/bin/run-gaiad.sh"
+    volumes:
+      - type: volume
+        source: ./chains/gaia/v6.0.0/ibc-1
+        target: /chain/gaia
     networks:
       relaynet:
         ipv4_address: 172.25.0.11

--- a/ci/docker-compose-gaia-legacy.yml
+++ b/ci/docker-compose-gaia-legacy.yml
@@ -9,7 +9,7 @@ services:
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"
     volumes:
-      - type: volume
+      - type: bind
         source: ./chains/gaia/v6.0.0/ibc-0
         target: /chain/gaia
     networks:
@@ -25,7 +25,7 @@ services:
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"
     volumes:
-      - type: volume
+      - type: bind
         source: ./chains/gaia/v6.0.0/ibc-1
         target: /chain/gaia
     networks:

--- a/ci/docker-compose-gaia-legacy.yml
+++ b/ci/docker-compose-gaia-legacy.yml
@@ -4,7 +4,7 @@ services:
 
   ibc-0:
     container_name: ibc-0
-    image: "informaldev/gaiad:v6.0.0"
+    image: "ghcr.io/mzabaluev/gaiad:v6.0.0"
     stdin_open: true
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"
@@ -20,7 +20,7 @@ services:
 
   ibc-1:
     container_name: ibc-1
-    image: "informaldev/gaiad:v6.0.0"
+    image: "ghcr.io/mzabaluev/gaiad:v6.0.0"
     stdin_open: true
     tty: true
     entrypoint: "/usr/bin/run-gaiad.sh"

--- a/ci/gaia.Dockerfile
+++ b/ci/gaia.Dockerfile
@@ -32,7 +32,7 @@ FROM alpine:edge
 LABEL maintainer="hello@informal.systems"
 
 # Add jq for debugging
-RUN apk add --no-cache jq curl tree
+RUN apk add --no-cache jq curl
 
 # Copy over binaries from the build-env
 COPY --from=build-env /go/bin/gaiad /usr/bin/gaiad
@@ -40,7 +40,5 @@ COPY --from=build-env /go/bin/gaiad /usr/bin/gaiad
 # Copy entrypoint script
 COPY ./run-gaiad.sh /usr/bin
 RUN chmod 755 /usr/bin/run-gaiad.sh
-
-RUN tree -pug /chain
 
 ENTRYPOINT "/bin/sh"

--- a/ci/gaia.Dockerfile
+++ b/ci/gaia.Dockerfile
@@ -31,23 +31,15 @@ RUN gaiad version --long
 FROM alpine:edge
 LABEL maintainer="hello@informal.systems"
 
-ARG RELEASE
-ARG CHAIN
-ARG NAME
-
 # Add jq for debugging
 RUN apk add --no-cache jq curl tree
-
-WORKDIR /$NAME
 
 # Copy over binaries from the build-env
 COPY --from=build-env /go/bin/gaiad /usr/bin/gaiad
 
-COPY --chown=root:root ./chains/$CHAIN/$RELEASE/$NAME /chain/$CHAIN
-
 # Copy entrypoint script
-COPY ./run-gaiad.sh /chain/$CHAIN
-RUN chmod 755 /chain/$CHAIN/run-gaiad.sh
+COPY ./run-gaiad.sh /usr/bin
+RUN chmod 755 /usr/bin/run-gaiad.sh
 
 RUN tree -pug /chain
 

--- a/ci/gaia.Dockerfile
+++ b/ci/gaia.Dockerfile
@@ -18,9 +18,8 @@ WORKDIR /go/src/github.com/cosmos/gaia
 # Checkout branch
 RUN git checkout $RELEASE
 
-# Install minimum necessary dependencies, build Cosmos SDK, remove packages
-RUN apk add --no-cache $PACKAGES && \
-    make install
+# Build and install Gaia
+RUN make install
 
 # Show version
 RUN gaiad version --long


### PR DESCRIPTION
The `ibc-0` and `ibc-1` images were only really different in the content of the chain data directory, which is copied from the repository checkout.

To save building Gaia twice and occupying twice the space on the Docker repo, build and push the gaiad image once and reuse it for the two node container instances in CI, specifying volume mounts of the respective chain data directories from the repository checkout.