### PR TITLE
Remove all occurences of Any* enums from light-clients

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -19,7 +19,7 @@ use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -274,7 +274,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -306,7 +306,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -337,7 +337,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -368,7 +368,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -427,7 +427,7 @@ fn verify_membership(
             value,
             0,
         )
-        .map_err(|e| Ics02Error::ics23_verification(e))
+        .map_err(Ics02Error::ics23_verification)
 }
 
 fn verify_non_membership(
@@ -444,11 +444,11 @@ fn verify_non_membership(
 
     merkle_proof
         .verify_non_membership(&client_state.proof_specs, root.clone().into(), merkle_path)
-        .map_err(|e| Ics02Error::ics23_verification(e))
+        .map_err(Ics02Error::ics23_verification)
 }
 
 fn verify_delay_passed(
-    ctx: &dyn ChannelReader,
+    ctx: &dyn ChannelMetaReader,
     height: Height,
     connection_end: &ConnectionEnd,
 ) -> Result<(), Ics02Error> {

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -14,12 +14,12 @@ use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::context::LightClientReader;
+use crate::core::ics02_client::context::ClientReaderLightClient;
 use crate::core::ics02_client::error::{Error as Ics02Error, ErrorDetail as Ics02ErrorDetail};
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -47,13 +47,13 @@ impl ClientDef for TendermintClient {
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReaderLightClient,
         client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,
     ) -> Result<(Self::ClientState, Self::ConsensusState), Ics02Error> {
         fn maybe_consensus_state(
-            ctx: &dyn LightClientReader,
+            ctx: &dyn ClientReaderLightClient,
             client_id: &ClientId,
             height: Height,
         ) -> Result<Option<Box<dyn ConsensusState>>, Ics02Error> {
@@ -288,7 +288,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -320,7 +320,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -351,7 +351,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -382,7 +382,7 @@ impl ClientDef for TendermintClient {
 
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -462,7 +462,7 @@ fn verify_non_membership(
 }
 
 fn verify_delay_passed(
-    ctx: &dyn ChannelMetaReader,
+    ctx: &dyn ChannelReaderLightClient,
     height: Height,
     connection_end: &ConnectionEnd,
 ) -> Result<(), Ics02Error> {

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -67,7 +67,7 @@ impl ClientDef for TendermintClient {
         let existing_consensus_state =
             match ctx.maybe_consensus_state(&client_id, header.height())? {
                 Some(cs) => {
-                    let cs = downcast_consensus_state(cs.as_ref())?.clone();
+                    let cs = downcast_consensus_state(cs.as_ref())?;
                     // If this consensus state matches, skip verification
                     // (optimization)
                     if cs == header_consensus_state {

--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -14,7 +14,7 @@ use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::context::ConsensusReader;
+use crate::core::ics02_client::context::LightClientReader;
 use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
@@ -47,7 +47,7 @@ impl ClientDef for TendermintClient {
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ConsensusReader,
+        ctx: &dyn LightClientReader,
         client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -12,7 +12,6 @@ use ibc_proto::ibc::lightclients::tendermint::v1::ClientState as RawClientState;
 
 use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header;
-use crate::core::ics02_client::client_state::AnyClientState;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics02_client::trust_threshold::TrustThreshold;
@@ -236,10 +235,6 @@ impl crate::core::ics02_client::client_state::ClientState for ClientState {
         self.latest_height = upgrade_height;
         self.unbonding_period = upgrade_options.unbonding_period;
         self.chain_id = chain_id;
-    }
-
-    fn wrap_any(self) -> AnyClientState {
-        AnyClientState::Tendermint(self)
     }
 
     fn encode_vec(&self) -> Result<Vec<u8>, Ics02Error> {
@@ -637,31 +632,28 @@ pub mod test_util {
     use tendermint::block::Header;
 
     use crate::clients::ics07_tendermint::client_state::{AllowUpdate, ClientState};
-    use crate::core::ics02_client::client_state::AnyClientState;
     use crate::core::ics02_client::height::Height;
     use crate::core::ics24_host::identifier::ChainId;
 
-    pub fn get_dummy_tendermint_client_state(tm_header: Header) -> AnyClientState {
-        AnyClientState::Tendermint(
-            ClientState::new(
-                ChainId::from(tm_header.chain_id.clone()),
-                Default::default(),
-                Duration::from_secs(64000),
-                Duration::from_secs(128000),
-                Duration::from_millis(3000),
-                Height::new(
-                    ChainId::chain_version(tm_header.chain_id.as_str()),
-                    u64::from(tm_header.height),
-                )
-                .unwrap(),
-                Default::default(),
-                vec!["".to_string()],
-                AllowUpdate {
-                    after_expiry: false,
-                    after_misbehaviour: false,
-                },
+    pub fn get_dummy_tendermint_client_state(tm_header: Header) -> ClientState {
+        ClientState::new(
+            ChainId::from(tm_header.chain_id.clone()),
+            Default::default(),
+            Duration::from_secs(64000),
+            Duration::from_secs(128000),
+            Duration::from_millis(3000),
+            Height::new(
+                ChainId::chain_version(tm_header.chain_id.as_str()),
+                u64::from(tm_header.height),
             )
             .unwrap(),
+            Default::default(),
+            vec!["".to_string()],
+            AllowUpdate {
+                after_expiry: false,
+                after_misbehaviour: false,
+            },
         )
+        .unwrap()
     }
 }

--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -219,11 +219,11 @@ impl crate::core::ics02_client::client_state::ClientState for ClientState {
     }
 
     fn upgrade(
-        mut self,
+        &mut self,
         upgrade_height: Height,
         upgrade_options: UpgradeOptions,
         chain_id: ChainId,
-    ) -> Self {
+    ) {
         // Reset custom fields to zero values
         self.trusting_period = ZERO_DURATION;
         self.trust_level = TrustThreshold::ZERO;
@@ -236,12 +236,14 @@ impl crate::core::ics02_client::client_state::ClientState for ClientState {
         self.latest_height = upgrade_height;
         self.unbonding_period = upgrade_options.unbonding_period;
         self.chain_id = chain_id;
-
-        self
     }
 
     fn wrap_any(self) -> AnyClientState {
         AnyClientState::Tendermint(self)
+    }
+
+    fn encode_vec(&self) -> Result<Vec<u8>, Ics02Error> {
+        Protobuf::encode_vec(self).map_err(Ics02Error::invalid_any_client_state)
     }
 }
 

--- a/modules/src/clients/ics07_tendermint/consensus_state.rs
+++ b/modules/src/clients/ics07_tendermint/consensus_state.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
 
-use core::convert::Infallible;
-
 use serde::Serialize;
 use tendermint::{hash::Algorithm, time::Time, Hash};
 use tendermint_proto::google::protobuf as tpb;
@@ -13,6 +11,7 @@ use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header;
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_type::ClientType;
+use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -33,8 +32,6 @@ impl ConsensusState {
 }
 
 impl crate::core::ics02_client::client_consensus::ConsensusState for ConsensusState {
-    type Error = Infallible;
-
     fn client_type(&self) -> ClientType {
         ClientType::Tendermint
     }
@@ -45,6 +42,10 @@ impl crate::core::ics02_client::client_consensus::ConsensusState for ConsensusSt
 
     fn wrap_any(self) -> AnyConsensusState {
         AnyConsensusState::Tendermint(self)
+    }
+
+    fn encode_vec(&self) -> Result<Vec<u8>, Ics02Error> {
+        Protobuf::encode_vec(self).map_err(Ics02Error::invalid_any_consensus_state)
     }
 }
 

--- a/modules/src/clients/ics07_tendermint/consensus_state.rs
+++ b/modules/src/clients/ics07_tendermint/consensus_state.rs
@@ -9,7 +9,6 @@ use ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState as RawConsensus
 
 use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header;
-use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
@@ -38,10 +37,6 @@ impl crate::core::ics02_client::client_consensus::ConsensusState for ConsensusSt
 
     fn root(&self) -> &CommitmentRoot {
         &self.root
-    }
-
-    fn wrap_any(self) -> AnyConsensusState {
-        AnyConsensusState::Tendermint(self)
     }
 
     fn encode_vec(&self) -> Result<Vec<u8>, Ics02Error> {

--- a/modules/src/clients/ics07_tendermint/error.rs
+++ b/modules/src/clients/ics07_tendermint/error.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 use flex_error::{define_error, TraceError};
 
-use crate::core::ics23_commitment::error::Error as Ics23Error;
+use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics24_host::error::ValidationError;
 use crate::core::ics24_host::identifier::ClientId;
 use crate::timestamp::{Timestamp, TimestampOverflowError};
@@ -249,10 +249,6 @@ define_error! {
                     e.client_id, e.height)
             },
 
-        Ics23Error
-            [ Ics23Error ]
-            | _ | { "ics23 commitment error" },
-
         InsufficientHeight
             {
                 latest_height: Height,
@@ -290,5 +286,11 @@ define_error! {
             | e | {
                 format_args!("insufficient signers overlap between {0} and {1}", e.q1, e.q2)
             },
+    }
+}
+
+impl From<Error> for Ics02Error {
+    fn from(e: Error) -> Self {
+        Self::client_specific(e.to_string())
     }
 }

--- a/modules/src/clients/ics07_tendermint/header.rs
+++ b/modules/src/clients/ics07_tendermint/header.rs
@@ -13,7 +13,6 @@ use ibc_proto::ibc::lightclients::tendermint::v1::Header as RawHeader;
 
 use crate::clients::ics07_tendermint::error::Error;
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::header::AnyHeader;
 use crate::core::ics24_host::identifier::ChainId;
 use crate::timestamp::Timestamp;
 use crate::Height;
@@ -79,10 +78,6 @@ impl crate::core::ics02_client::header::Header for Header {
 
     fn timestamp(&self) -> Timestamp {
         self.signed_header.header.time.into()
-    }
-
-    fn wrap_any(self) -> AnyHeader {
-        AnyHeader::Tendermint(self)
     }
 }
 

--- a/modules/src/clients/ics07_tendermint/misbehaviour.rs
+++ b/modules/src/clients/ics07_tendermint/misbehaviour.rs
@@ -6,7 +6,6 @@ use ibc_proto::ibc::lightclients::tendermint::v1::Misbehaviour as RawMisbehaviou
 
 use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header;
-use crate::core::ics02_client::misbehaviour::AnyMisbehaviour;
 use crate::core::ics24_host::identifier::ClientId;
 use crate::Height;
 
@@ -24,10 +23,6 @@ impl crate::core::ics02_client::misbehaviour::Misbehaviour for Misbehaviour {
 
     fn height(&self) -> Height {
         self.header1.height()
-    }
-
-    fn wrap_any(self) -> AnyMisbehaviour {
-        AnyMisbehaviour::Tendermint(self)
     }
 }
 

--- a/modules/src/core/ics02_client/client_consensus.rs
+++ b/modules/src/core/ics02_client/client_consensus.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-use core::any::Any as AnyTrait;
+use core::any::Any as CoreAny;
 use core::marker::{Send, Sync};
 
 use ibc_proto::google::protobuf::Any as ProtoAny;
@@ -33,12 +33,12 @@ pub trait ConsensusState: core::fmt::Debug + Send + Sync + AsAny {
     fn encode_vec(&self) -> Result<Vec<u8>, Error>;
 }
 
-pub trait AsAny: AnyTrait {
-    fn as_any(&self) -> &dyn AnyTrait;
+pub trait AsAny: CoreAny {
+    fn as_any(&self) -> &dyn CoreAny;
 }
 
-impl<M: AnyTrait + ConsensusState> AsAny for M {
-    fn as_any(&self) -> &dyn AnyTrait {
+impl<M: CoreAny + ConsensusState> AsAny for M {
+    fn as_any(&self) -> &dyn CoreAny {
         self
     }
 }

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -4,7 +4,7 @@ use crate::clients::ics07_tendermint::client_def::TendermintClient;
 use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::context::ConsensusReader;
+use crate::core::ics02_client::context::LightClientReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::header::{AnyHeader, Header};
 use crate::core::ics03_connection::connection::ConnectionEnd;
@@ -30,7 +30,7 @@ pub trait ClientDef {
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ConsensusReader,
+        ctx: &dyn LightClientReader,
         client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,
@@ -195,7 +195,7 @@ impl ClientDef for AnyClient {
     /// Validates an incoming `header` against the latest consensus state of this client.
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ConsensusReader,
+        ctx: &dyn LightClientReader,
         client_id: ClientId,
         client_state: AnyClientState,
         header: AnyHeader,

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -4,13 +4,13 @@ use crate::clients::ics07_tendermint::client_def::TendermintClient;
 use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::context::LightClientReader;
+use crate::core::ics02_client::context::ClientReaderLightClient;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::header::{AnyHeader, Header};
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -30,7 +30,7 @@ pub trait ClientDef {
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReaderLightClient,
         client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,
@@ -108,7 +108,7 @@ pub trait ClientDef {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -124,7 +124,7 @@ pub trait ClientDef {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -140,7 +140,7 @@ pub trait ClientDef {
     #[allow(clippy::too_many_arguments)]
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -155,7 +155,7 @@ pub trait ClientDef {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -195,7 +195,7 @@ impl ClientDef for AnyClient {
     /// Validates an incoming `header` against the latest consensus state of this client.
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn LightClientReader,
+        ctx: &dyn ClientReaderLightClient,
         client_id: ClientId,
         client_state: AnyClientState,
         header: AnyHeader,
@@ -427,7 +427,7 @@ impl ClientDef for AnyClient {
     }
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -484,7 +484,7 @@ impl ClientDef for AnyClient {
 
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -541,7 +541,7 @@ impl ClientDef for AnyClient {
 
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -594,7 +594,7 @@ impl ClientDef for AnyClient {
     }
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelMetaReader,
+        ctx: &dyn ChannelReaderLightClient,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -4,7 +4,7 @@ use crate::clients::ics07_tendermint::client_def::TendermintClient;
 use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::context::ClientReader;
+use crate::core::ics02_client::context::ConsensusReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::header::{AnyHeader, Header};
 use crate::core::ics03_connection::connection::ConnectionEnd;
@@ -30,7 +30,7 @@ pub trait ClientDef: Clone {
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ClientReader,
+        ctx: &dyn ConsensusReader,
         client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,
@@ -196,7 +196,7 @@ impl ClientDef for AnyClient {
     /// Validates an incoming `header` against the latest consensus state of this client.
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ClientReader,
+        ctx: &dyn ConsensusReader,
         client_id: ClientId,
         client_state: AnyClientState,
         header: AnyHeader,

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -62,7 +62,7 @@ pub trait ClientDef: Clone {
         root: &CommitmentRoot,
         client_id: &ClientId,
         consensus_height: Height,
-        expected_consensus_state: &AnyConsensusState,
+        expected_consensus_state: &dyn ConsensusState,
     ) -> Result<(), Error>;
 
     /// Verify a `proof` that a connection state matches that of the input `connection_end`.
@@ -246,7 +246,7 @@ impl ClientDef for AnyClient {
         root: &CommitmentRoot,
         client_id: &ClientId,
         consensus_height: Height,
-        expected_consensus_state: &AnyConsensusState,
+        expected_consensus_state: &dyn ConsensusState,
     ) -> Result<(), Error> {
         match self {
             Self::Tendermint(client) => {

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -94,7 +94,7 @@ pub trait ClientDef: Clone {
 
     /// Verify the client state for this chain that it is stored on the counterparty chain.
     #[allow(clippy::too_many_arguments)]
-    fn verify_client_full_state(
+    fn verify_client_full_state<U>(
         &self,
         client_state: &Self::ClientState,
         height: Height,
@@ -102,7 +102,7 @@ pub trait ClientDef: Clone {
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
         client_id: &ClientId,
-        expected_client_state: &AnyClientState,
+        expected_client_state: &dyn ClientState<UpgradeOptions = U>,
     ) -> Result<(), Error>;
 
     /// Verify a `proof` that a packet has been commited.
@@ -379,7 +379,7 @@ impl ClientDef for AnyClient {
         }
     }
 
-    fn verify_client_full_state(
+    fn verify_client_full_state<U>(
         &self,
         client_state: &Self::ClientState,
         height: Height,
@@ -387,7 +387,7 @@ impl ClientDef for AnyClient {
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
         client_id: &ClientId,
-        client_state_on_counterparty: &AnyClientState,
+        client_state_on_counterparty: &dyn ClientState<UpgradeOptions = U>,
     ) -> Result<(), Error> {
         match self {
             Self::Tendermint(client) => {

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -10,7 +10,7 @@ use crate::core::ics02_client::header::{AnyHeader, Header};
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -36,7 +36,6 @@ pub trait ClientDef: Clone {
         header: Self::Header,
     ) -> Result<(Self::ClientState, Self::ConsensusState), Error>;
 
-    /// TODO
     fn verify_upgrade_and_update_state(
         &self,
         client_state: &Self::ClientState,
@@ -109,7 +108,7 @@ pub trait ClientDef: Clone {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -125,7 +124,7 @@ pub trait ClientDef: Clone {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -141,7 +140,7 @@ pub trait ClientDef: Clone {
     #[allow(clippy::too_many_arguments)]
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -156,7 +155,7 @@ pub trait ClientDef: Clone {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -428,7 +427,7 @@ impl ClientDef for AnyClient {
     }
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -485,7 +484,7 @@ impl ClientDef for AnyClient {
 
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -542,7 +541,7 @@ impl ClientDef for AnyClient {
 
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,
@@ -595,7 +594,7 @@ impl ClientDef for AnyClient {
     }
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelReader,
+        ctx: &dyn ChannelMetaReader,
         client_state: &Self::ClientState,
         height: Height,
         connection_end: &ConnectionEnd,

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -23,7 +23,7 @@ use crate::Height;
 #[cfg(any(test, feature = "mocks"))]
 use crate::mock::client_def::MockClient;
 
-pub trait ClientDef: Clone {
+pub trait ClientDef {
     type Header: Header;
     type ClientState: ClientState;
     type ConsensusState: ConsensusState;

--- a/modules/src/core/ics02_client/client_state.rs
+++ b/modules/src/core/ics02_client/client_state.rs
@@ -21,7 +21,7 @@ use crate::Height;
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 
-pub trait ClientState: Clone + core::fmt::Debug + Send + Sync {
+pub trait ClientState: core::fmt::Debug + Send + Sync {
     /// Client-specific options for upgrading the client
     type UpgradeOptions;
 

--- a/modules/src/core/ics02_client/client_state.rs
+++ b/modules/src/core/ics02_client/client_state.rs
@@ -47,14 +47,16 @@ pub trait ClientState: core::fmt::Debug + Send + Sync {
     /// Resets all fields except the blockchain-specific ones,
     /// and updates the given fields.
     fn upgrade(
-        self,
+        &mut self,
         upgrade_height: Height,
         upgrade_options: Self::UpgradeOptions,
         chain_id: ChainId,
-    ) -> Self;
+    );
 
     /// Wrap into an `AnyClientState`
     fn wrap_any(self) -> AnyClientState;
+
+    fn encode_vec(&self) -> Result<Vec<u8>, Error>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -182,15 +184,13 @@ impl From<AnyClientState> for Any {
         match value {
             AnyClientState::Tendermint(value) => Any {
                 type_url: TENDERMINT_CLIENT_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
+                value: ClientState::encode_vec(&value)
                     .expect("encoding to `Any` from `AnyClientState::Tendermint`"),
             },
             #[cfg(any(test, feature = "mocks"))]
             AnyClientState::Mock(value) => Any {
                 type_url: MOCK_CLIENT_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
+                value: ClientState::encode_vec(&value)
                     .expect("encoding to `Any` from `AnyClientState::Mock`"),
             },
         }
@@ -222,25 +222,27 @@ impl ClientState for AnyClientState {
     }
 
     fn upgrade(
-        self,
+        &mut self,
         upgrade_height: Height,
         upgrade_options: Self::UpgradeOptions,
         chain_id: ChainId,
-    ) -> Self {
+    ) {
         match self {
-            AnyClientState::Tendermint(tm_state) => tm_state
-                .upgrade(upgrade_height, upgrade_options.into_tendermint(), chain_id)
-                .wrap_any(),
+            AnyClientState::Tendermint(tm_state) => {
+                tm_state.upgrade(upgrade_height, upgrade_options.into_tendermint(), chain_id)
+            }
 
             #[cfg(any(test, feature = "mocks"))]
-            AnyClientState::Mock(mock_state) => {
-                mock_state.upgrade(upgrade_height, (), chain_id).wrap_any()
-            }
+            AnyClientState::Mock(mock_state) => mock_state.upgrade(upgrade_height, (), chain_id),
         }
     }
 
     fn wrap_any(self) -> AnyClientState {
         self
+    }
+
+    fn encode_vec(&self) -> Result<Vec<u8>, Error> {
+        Protobuf::encode_vec(self).map_err(Error::invalid_any_client_state)
     }
 }
 

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -2,7 +2,7 @@
 //! that any host chain must implement to be able to process any `ClientMsg`. See
 //! "ADR 003: IBC protocol implementation" for more details.
 
-use crate::core::ics02_client::client_consensus::AnyConsensusState;
+use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::AnyClientState;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::{Error, ErrorDetail};
@@ -10,6 +10,7 @@ use crate::core::ics02_client::handler::ClientResult::{self, Create, Update, Upg
 use crate::core::ics24_host::identifier::ClientId;
 use crate::timestamp::Timestamp;
 use crate::Height;
+use std::prelude::v1::Box;
 
 /// Defines the read-only part of ICS2 (client functions) context.
 pub trait ClientReader {
@@ -76,6 +77,79 @@ pub trait ClientReader {
     /// Returns a natural number, counting how many clients have been created thus far.
     /// The value of this counter should increase only via method `ClientKeeper::increase_client_counter`.
     fn client_counter(&self) -> Result<u64, Error>;
+}
+
+pub trait ConsensusReader {
+    fn consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Box<dyn ConsensusState>, Error>;
+
+    /// Similar to `consensus_state`, attempt to retrieve the consensus state,
+    /// but return `None` if no state exists at the given height.
+    fn maybe_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Option<Box<dyn ConsensusState>>, Error> {
+        match self.consensus_state(client_id, height) {
+            Ok(cs) => Ok(Some(cs)),
+            Err(e) => match e.detail() {
+                ErrorDetail::ConsensusStateNotFound(_) => Ok(None),
+                _ => Err(e),
+            },
+        }
+    }
+
+    /// Search for the lowest consensus state higher than `height`.
+    fn next_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Option<Box<dyn ConsensusState>>, Error>;
+
+    /// Search for the highest consensus state lower than `height`.
+    fn prev_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Option<Box<dyn ConsensusState>>, Error>;
+
+    /// Returns the current timestamp of the local chain.
+    fn host_timestamp(&self) -> Timestamp;
+}
+
+impl<T: ClientReader> ConsensusReader for T {
+    fn consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Box<dyn ConsensusState>, Error> {
+        ClientReader::consensus_state(self, client_id, height).map(|cs| cs.boxed_dyn())
+    }
+
+    fn next_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Option<Box<dyn ConsensusState>>, Error> {
+        ClientReader::next_consensus_state(self, client_id, height)
+            .map(|cs| cs.map(AnyConsensusState::boxed_dyn))
+    }
+
+    fn prev_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Option<Box<dyn ConsensusState>>, Error> {
+        ClientReader::prev_consensus_state(self, client_id, height)
+            .map(|cs| cs.map(AnyConsensusState::boxed_dyn))
+    }
+
+    fn host_timestamp(&self) -> Timestamp {
+        ClientReader::host_timestamp(self)
+    }
 }
 
 /// Defines the write-only part of ICS2 (client functions) context.

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -7,7 +7,7 @@ use alloc::boxed::Box;
 use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::AnyClientState;
 use crate::core::ics02_client::client_type::ClientType;
-use crate::core::ics02_client::error::{Error, ErrorDetail};
+use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::handler::ClientResult::{self, Create, Update, Upgrade};
 use crate::core::ics24_host::identifier::ClientId;
 use crate::timestamp::Timestamp;
@@ -27,22 +27,6 @@ pub trait ClientReader {
         client_id: &ClientId,
         height: Height,
     ) -> Result<AnyConsensusState, Error>;
-
-    /// Similar to `consensus_state`, attempt to retrieve the consensus state,
-    /// but return `None` if no state exists at the given height.
-    fn maybe_consensus_state(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Option<AnyConsensusState>, Error> {
-        match self.consensus_state(client_id, height) {
-            Ok(cs) => Ok(Some(cs)),
-            Err(e) => match e.detail() {
-                ErrorDetail::ConsensusStateNotFound(_) => Ok(None),
-                _ => Err(e),
-            },
-        }
-    }
 
     /// Search for the lowest consensus state higher than `height`.
     fn next_consensus_state(
@@ -91,22 +75,6 @@ pub trait LightClientReader {
         client_id: &ClientId,
         height: Height,
     ) -> Result<Box<dyn ConsensusState>, Error>;
-
-    /// Similar to `consensus_state`, attempt to retrieve the consensus state,
-    /// but return `None` if no state exists at the given height.
-    fn maybe_consensus_state(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Option<Box<dyn ConsensusState>>, Error> {
-        match self.consensus_state(client_id, height) {
-            Ok(cs) => Ok(Some(cs)),
-            Err(e) => match e.detail() {
-                ErrorDetail::ConsensusStateNotFound(_) => Ok(None),
-                _ => Err(e),
-            },
-        }
-    }
 
     /// Search for the lowest consensus state higher than `height`.
     fn next_consensus_state(

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -80,6 +80,11 @@ pub trait ClientReader {
     fn client_counter(&self) -> Result<u64, Error>;
 }
 
+/// Defines a subset of the `ClientReader`'s methods that a light-client implementation can access.
+/// A blanket implementation of this trait is provided for all types that implement `ClientReader`.
+///
+/// Note: This trait is not a supertrait of `ClientReader` because it uses trait objects and cannot
+/// depend on `AnyClientState` and `AnyConsensusState` due to a circular dependency problem.
 pub trait LightClientReader {
     fn consensus_state(
         &self,

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -80,7 +80,7 @@ pub trait ClientReader {
     fn client_counter(&self) -> Result<u64, Error>;
 }
 
-pub trait ConsensusReader {
+pub trait LightClientReader {
     fn consensus_state(
         &self,
         client_id: &ClientId,
@@ -121,7 +121,7 @@ pub trait ConsensusReader {
     fn host_timestamp(&self) -> Timestamp;
 }
 
-impl<T: ClientReader> ConsensusReader for T {
+impl<T: ClientReader> LightClientReader for T {
     fn consensus_state(
         &self,
         client_id: &ClientId,

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -2,6 +2,8 @@
 //! that any host chain must implement to be able to process any `ClientMsg`. See
 //! "ADR 003: IBC protocol implementation" for more details.
 
+use alloc::boxed::Box;
+
 use crate::core::ics02_client::client_consensus::{AnyConsensusState, ConsensusState};
 use crate::core::ics02_client::client_state::AnyClientState;
 use crate::core::ics02_client::client_type::ClientType;
@@ -10,7 +12,6 @@ use crate::core::ics02_client::handler::ClientResult::{self, Create, Update, Upg
 use crate::core::ics24_host::identifier::ClientId;
 use crate::timestamp::Timestamp;
 use crate::Height;
-use std::prelude::v1::Box;
 
 /// Defines the read-only part of ICS2 (client functions) context.
 pub trait ClientReader {

--- a/modules/src/core/ics02_client/context.rs
+++ b/modules/src/core/ics02_client/context.rs
@@ -69,7 +69,7 @@ pub trait ClientReader {
 ///
 /// Note: This trait is not a supertrait of `ClientReader` because it uses trait objects and cannot
 /// depend on `AnyClientState` and `AnyConsensusState` due to a circular dependency problem.
-pub trait LightClientReader {
+pub trait ClientReaderLightClient {
     fn consensus_state(
         &self,
         client_id: &ClientId,
@@ -94,7 +94,7 @@ pub trait LightClientReader {
     fn host_timestamp(&self) -> Timestamp;
 }
 
-impl<T: ClientReader> LightClientReader for T {
+impl<T: ClientReader> ClientReaderLightClient for T {
     fn consensus_state(
         &self,
         client_id: &ClientId,

--- a/modules/src/core/ics02_client/error.rs
+++ b/modules/src/core/ics02_client/error.rs
@@ -1,10 +1,8 @@
 use crate::prelude::*;
 
 use flex_error::{define_error, TraceError};
-use tendermint::Error as TendermintError;
 use tendermint_proto::Error as TendermintProtoError;
 
-use crate::clients::ics07_tendermint::error::Error as Ics07Error;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::height::HeightError;
 use crate::core::ics23_commitment::error::Error as Ics23Error;
@@ -61,7 +59,6 @@ define_error! {
 
         FailedTrustThresholdConversion
             { numerator: u64, denominator: u64 }
-            [ TendermintError ]
             | e | { format_args!("failed to build Tendermint domain type trust threshold from fraction: {}/{}", e.numerator, e.denominator) },
 
         UnknownClientStateType
@@ -179,10 +176,6 @@ define_error! {
             [ Ics23Error ]
             | _ | { "invalid commitment proof bytes" },
 
-        Tendermint
-            [ Ics07Error ]
-            | _ | { "tendermint error" },
-
         InvalidPacketTimestamp
             [ crate::timestamp::ParseTimestampError ]
             | _ | { "invalid packet timeout timestamp value" },
@@ -248,10 +241,6 @@ define_error! {
                 format_args!("header not withing trusting period: expires_at={0} now={1}", e.latest_time, e.update_time)
             },
 
-        TendermintHandlerError
-            [ Ics07Error ]
-            | _ | { format_args!("Tendermint-specific handler error") },
-
         MissingLocalConsensusState
             { height: Height }
             | e | { format_args!("the local consensus state could not be retrieved for height {}", e.height) },
@@ -275,11 +264,13 @@ define_error! {
         Signer
             [ SignerError ]
             | _ | { "failed to parse signer" },
-    }
-}
 
-impl From<Ics07Error> for Error {
-    fn from(e: Ics07Error) -> Error {
-        Error::tendermint_handler_error(e)
+        Ics23Verification
+            [ Ics23Error ]
+            | _ | { "ics23 verification failure" },
+
+        ClientSpecific
+            { description: String }
+            | e | { format_args!("client specific error: {0}", e.description) },
     }
 }

--- a/modules/src/core/ics02_client/events.rs
+++ b/modules/src/core/ics02_client/events.rs
@@ -369,7 +369,6 @@ impl From<UpgradeClient> for AbciEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::ics02_client::header::Header;
     use crate::mock::header::MockHeader;
 
     #[test]
@@ -389,8 +388,8 @@ mod tests {
         let upgrade_client = UpgradeClient::from(attributes.clone());
         abci_events.push(AbciEvent::from(upgrade_client.clone()));
         let mut update_client = UpdateClient::from(attributes);
-        let header = MockHeader::new(height).wrap_any();
-        update_client.header = Some(header);
+        let header = MockHeader::new(height);
+        update_client.header = Some(header.into());
         abci_events.push(AbciEvent::from(update_client.clone()));
 
         for event in abci_events {

--- a/modules/src/core/ics02_client/handler.rs
+++ b/modules/src/core/ics02_client/handler.rs
@@ -1,6 +1,6 @@
 //! This module implements the processing logic for ICS2 (client abstractions and functions) msgs.
 
-use crate::core::ics02_client::context::{ClientReader, ConsensusReader};
+use crate::core::ics02_client::context::{ClientReader, LightClientReader};
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::msgs::ClientMsg;
 use crate::handler::HandlerOutput;
@@ -19,7 +19,7 @@ pub enum ClientResult {
 /// General entry point for processing any message related to ICS2 (client functions) protocols.
 pub fn dispatch<Ctx>(ctx: &Ctx, msg: ClientMsg) -> Result<HandlerOutput<ClientResult>, Error>
 where
-    Ctx: ClientReader + ConsensusReader,
+    Ctx: ClientReader + LightClientReader,
 {
     match msg {
         ClientMsg::CreateClient(msg) => create_client::process(ctx, msg),

--- a/modules/src/core/ics02_client/handler.rs
+++ b/modules/src/core/ics02_client/handler.rs
@@ -1,6 +1,6 @@
 //! This module implements the processing logic for ICS2 (client abstractions and functions) msgs.
 
-use crate::core::ics02_client::context::{ClientReader, LightClientReader};
+use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::msgs::ClientMsg;
 use crate::handler::HandlerOutput;
@@ -19,7 +19,7 @@ pub enum ClientResult {
 /// General entry point for processing any message related to ICS2 (client functions) protocols.
 pub fn dispatch<Ctx>(ctx: &Ctx, msg: ClientMsg) -> Result<HandlerOutput<ClientResult>, Error>
 where
-    Ctx: ClientReader + LightClientReader,
+    Ctx: ClientReader,
 {
     match msg {
         ClientMsg::CreateClient(msg) => create_client::process(ctx, msg),

--- a/modules/src/core/ics02_client/handler.rs
+++ b/modules/src/core/ics02_client/handler.rs
@@ -1,6 +1,6 @@
 //! This module implements the processing logic for ICS2 (client abstractions and functions) msgs.
 
-use crate::core::ics02_client::context::ClientReader;
+use crate::core::ics02_client::context::{ClientReader, ConsensusReader};
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::msgs::ClientMsg;
 use crate::handler::HandlerOutput;
@@ -19,7 +19,7 @@ pub enum ClientResult {
 /// General entry point for processing any message related to ICS2 (client functions) protocols.
 pub fn dispatch<Ctx>(ctx: &Ctx, msg: ClientMsg) -> Result<HandlerOutput<ClientResult>, Error>
 where
-    Ctx: ClientReader,
+    Ctx: ClientReader + ConsensusReader,
 {
     match msg {
         ClientMsg::CreateClient(msg) => create_client::process(ctx, msg),

--- a/modules/src/core/ics02_client/handler/create_client.rs
+++ b/modules/src/core/ics02_client/handler/create_client.rs
@@ -76,7 +76,6 @@ mod tests {
     };
     use crate::clients::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
     use crate::core::ics02_client::client_consensus::AnyConsensusState;
-    use crate::core::ics02_client::client_state::ClientState;
     use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::context::ClientReader;
     use crate::core::ics02_client::handler::{dispatch, ClientResult};
@@ -230,7 +229,7 @@ mod tests {
             },
         )
         .unwrap()
-        .wrap_any();
+        .into();
 
         let msg = MsgCreateAnyClient::new(
             tm_client_state,

--- a/modules/src/core/ics02_client/handler/update_client.rs
+++ b/modules/src/core/ics02_client/handler/update_client.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_def::{AnyClient, ClientDef};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
-use crate::core::ics02_client::context::{ClientReader, ConsensusReader};
+use crate::core::ics02_client::context::{ClientReader, LightClientReader};
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::events::Attributes;
 use crate::core::ics02_client::handler::ClientResult;
@@ -29,7 +29,7 @@ pub struct Result {
     pub processed_height: Height,
 }
 
-pub fn process<Ctx: ClientReader + ConsensusReader>(
+pub fn process<Ctx: ClientReader + LightClientReader>(
     ctx: &Ctx,
     msg: MsgUpdateAnyClient,
 ) -> HandlerResult<ClientResult, Error> {

--- a/modules/src/core/ics02_client/handler/update_client.rs
+++ b/modules/src/core/ics02_client/handler/update_client.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_def::{AnyClient, ClientDef};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
-use crate::core::ics02_client::context::ClientReader;
+use crate::core::ics02_client::context::{ClientReader, ConsensusReader};
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::events::Attributes;
 use crate::core::ics02_client::handler::ClientResult;
@@ -29,8 +29,8 @@ pub struct Result {
     pub processed_height: Height,
 }
 
-pub fn process(
-    ctx: &dyn ClientReader,
+pub fn process<Ctx: ClientReader + ConsensusReader>(
+    ctx: &Ctx,
     msg: MsgUpdateAnyClient,
 ) -> HandlerResult<ClientResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -54,15 +54,14 @@ pub fn process(
     }
 
     // Read consensus state from the host chain store.
-    let latest_consensus_state = ctx
-        .consensus_state(&client_id, client_state.latest_height())
-        .map_err(|_| {
-            Error::consensus_state_not_found(client_id.clone(), client_state.latest_height())
-        })?;
+    let latest_consensus_state =
+        ClientReader::consensus_state(ctx, &client_id, client_state.latest_height()).map_err(
+            |_| Error::consensus_state_not_found(client_id.clone(), client_state.latest_height()),
+        )?;
 
     debug!("latest consensus state: {:?}", latest_consensus_state);
 
-    let now = ctx.host_timestamp();
+    let now = ClientReader::host_timestamp(ctx);
     let duration = now
         .duration_since(&latest_consensus_state.timestamp())
         .ok_or_else(|| {
@@ -87,7 +86,7 @@ pub fn process(
         client_id: client_id.clone(),
         client_state: new_client_state,
         consensus_state: new_consensus_state,
-        processed_time: ctx.host_timestamp(),
+        processed_time: ClientReader::host_timestamp(ctx),
         processed_height: ctx.host_height(),
     });
 

--- a/modules/src/core/ics02_client/handler/update_client.rs
+++ b/modules/src/core/ics02_client/handler/update_client.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_def::{AnyClient, ClientDef};
 use crate::core::ics02_client::client_state::{AnyClientState, ClientState};
-use crate::core::ics02_client::context::{ClientReader, LightClientReader};
+use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::events::Attributes;
 use crate::core::ics02_client::handler::ClientResult;
@@ -29,7 +29,7 @@ pub struct Result {
     pub processed_height: Height,
 }
 
-pub fn process<Ctx: ClientReader + LightClientReader>(
+pub fn process<Ctx: ClientReader>(
     ctx: &Ctx,
     msg: MsgUpdateAnyClient,
 ) -> HandlerResult<ClientResult, Error> {

--- a/modules/src/core/ics02_client/header.rs
+++ b/modules/src/core/ics02_client/header.rs
@@ -87,7 +87,7 @@ impl TryFrom<Any> for AnyHeader {
     fn try_from(raw: Any) -> Result<Self, Error> {
         match raw.type_url.as_str() {
             TENDERMINT_HEADER_TYPE_URL => {
-                let val = decode_header(raw.value.deref()).map_err(Error::tendermint)?;
+                let val = decode_header(raw.value.deref())?;
 
                 Ok(AnyHeader::Tendermint(val))
             }

--- a/modules/src/core/ics02_client/header.rs
+++ b/modules/src/core/ics02_client/header.rs
@@ -27,9 +27,6 @@ pub trait Header: Clone + core::fmt::Debug + Send + Sync {
 
     /// The timestamp of the consensus state
     fn timestamp(&self) -> Timestamp;
-
-    /// Wrap into an `AnyHeader`
-    fn wrap_any(self) -> AnyHeader;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -66,10 +63,6 @@ impl Header for AnyHeader {
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock(header) => header.timestamp(),
         }
-    }
-
-    fn wrap_any(self) -> AnyHeader {
-        self
     }
 }
 
@@ -126,5 +119,18 @@ impl From<AnyHeader> for Any {
                     .expect("encoding to `Any` from `AnyHeader::Mock`"),
             },
         }
+    }
+}
+
+#[cfg(any(test, feature = "mocks"))]
+impl From<MockHeader> for AnyHeader {
+    fn from(header: MockHeader) -> Self {
+        Self::Mock(header)
+    }
+}
+
+impl From<TendermintHeader> for AnyHeader {
+    fn from(header: TendermintHeader) -> Self {
+        Self::Tendermint(header)
     }
 }

--- a/modules/src/core/ics02_client/header.rs
+++ b/modules/src/core/ics02_client/header.rs
@@ -18,7 +18,7 @@ pub const TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.He
 pub const MOCK_HEADER_TYPE_URL: &str = "/ibc.mock.Header";
 
 /// Abstract of consensus state update information
-pub trait Header: Clone + core::fmt::Debug + Send + Sync {
+pub trait Header: core::fmt::Debug + Send + Sync {
     /// The type of client (eg. Tendermint)
     fn client_type(&self) -> ClientType;
 

--- a/modules/src/core/ics02_client/misbehaviour.rs
+++ b/modules/src/core/ics02_client/misbehaviour.rs
@@ -19,7 +19,7 @@ pub const TENDERMINT_MISBEHAVIOR_TYPE_URL: &str = "/ibc.lightclients.tendermint.
 #[cfg(any(test, feature = "mocks"))]
 pub const MOCK_MISBEHAVIOUR_TYPE_URL: &str = "/ibc.mock.Misbehavior";
 
-pub trait Misbehaviour: Clone + core::fmt::Debug + Send + Sync {
+pub trait Misbehaviour: core::fmt::Debug + Send + Sync {
     /// The type of client (eg. Tendermint)
     fn client_id(&self) -> &ClientId;
 

--- a/modules/src/core/ics02_client/misbehaviour.rs
+++ b/modules/src/core/ics02_client/misbehaviour.rs
@@ -25,8 +25,6 @@ pub trait Misbehaviour: Clone + core::fmt::Debug + Send + Sync {
 
     /// The height of the consensus state
     fn height(&self) -> Height;
-
-    fn wrap_any(self) -> AnyMisbehaviour;
 }
 
 #[derive(Clone, Debug, PartialEq)] // TODO: Add Eq bound once possible
@@ -55,10 +53,6 @@ impl Misbehaviour for AnyMisbehaviour {
             #[cfg(any(test, feature = "mocks"))]
             Self::Mock(misbehaviour) => misbehaviour.height(),
         }
-    }
-
-    fn wrap_any(self) -> AnyMisbehaviour {
-        self
     }
 }
 
@@ -111,6 +105,19 @@ impl core::fmt::Display for AnyMisbehaviour {
             #[cfg(any(test, feature = "mocks"))]
             AnyMisbehaviour::Mock(mock) => write!(f, "{:?}", mock),
         }
+    }
+}
+
+#[cfg(any(test, feature = "mocks"))]
+impl From<MockMisbehaviour> for AnyMisbehaviour {
+    fn from(misbehaviour: MockMisbehaviour) -> Self {
+        Self::Mock(misbehaviour)
+    }
+}
+
+impl From<TmMisbehaviour> for AnyMisbehaviour {
+    fn from(misbehaviour: TmMisbehaviour) -> Self {
+        Self::Tendermint(misbehaviour)
     }
 }
 

--- a/modules/src/core/ics02_client/msgs/create_client.rs
+++ b/modules/src/core/ics02_client/msgs/create_client.rs
@@ -105,7 +105,7 @@ mod tests {
         let signer = get_dummy_account_id();
 
         let tm_header = get_dummy_tendermint_header();
-        let tm_client_state = get_dummy_tendermint_client_state(tm_header.clone());
+        let tm_client_state = get_dummy_tendermint_client_state(tm_header.clone()).into();
 
         let msg = MsgCreateAnyClient::new(
             tm_client_state,

--- a/modules/src/core/ics02_client/trust_threshold.rs
+++ b/modules/src/core/ics02_client/trust_threshold.rs
@@ -94,7 +94,7 @@ impl TryFrom<TrustThreshold> for TrustThresholdFraction {
 
     fn try_from(t: TrustThreshold) -> Result<TrustThresholdFraction, Error> {
         Self::new(t.numerator, t.denominator)
-            .map_err(|e| Error::failed_trust_threshold_conversion(t.numerator, t.denominator, e))
+            .map_err(|_| Error::failed_trust_threshold_conversion(t.numerator, t.denominator))
     }
 }
 

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -138,6 +138,8 @@ pub trait ChannelReader {
     }
 }
 
+/// Defines a subset of the `ChannelReader`'s methods that a light-client implementation can access.
+/// A blanket implementation of this trait is provided for all types that implement `ChannelReader`.
 pub trait ChannelMetaReader {
     /// Returns the current height of the local chain.
     fn host_height(&self) -> Height;

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -138,6 +138,46 @@ pub trait ChannelReader {
     }
 }
 
+pub trait ChannelMetaReader {
+    /// Returns the current height of the local chain.
+    fn host_height(&self) -> Height;
+
+    /// Returns the current timestamp of the local chain.
+    fn host_timestamp(&self) -> Timestamp;
+
+    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
+    fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error>;
+
+    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
+    fn client_update_height(&self, client_id: &ClientId, height: Height) -> Result<Height, Error>;
+
+    /// Calculates the block delay period using the connection's delay period and the maximum
+    /// expected time per block.
+    fn block_delay(&self, delay_period_time: Duration) -> u64;
+}
+
+impl<T: ChannelReader> ChannelMetaReader for T {
+    fn host_height(&self) -> Height {
+        ChannelReader::host_height(self)
+    }
+
+    fn host_timestamp(&self) -> Timestamp {
+        ChannelReader::host_timestamp(self)
+    }
+
+    fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error> {
+        ChannelReader::client_update_time(self, client_id, height)
+    }
+
+    fn client_update_height(&self, client_id: &ClientId, height: Height) -> Result<Height, Error> {
+        ChannelReader::client_update_height(self, client_id, height)
+    }
+
+    fn block_delay(&self, delay_period_time: Duration) -> u64 {
+        ChannelReader::block_delay(self, delay_period_time)
+    }
+}
+
 /// A context supplying all the necessary write-only dependencies (i.e., storage writing facility)
 /// for processing any `ChannelMsg`.
 pub trait ChannelKeeper {

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -140,7 +140,7 @@ pub trait ChannelReader {
 
 /// Defines a subset of the `ChannelReader`'s methods that a light-client implementation can access.
 /// A blanket implementation of this trait is provided for all types that implement `ChannelReader`.
-pub trait ChannelMetaReader {
+pub trait ChannelReaderLightClient {
     /// Returns the current height of the local chain.
     fn host_height(&self) -> Height;
 
@@ -158,7 +158,7 @@ pub trait ChannelMetaReader {
     fn block_delay(&self, delay_period_time: Duration) -> u64;
 }
 
-impl<T: ChannelReader> ChannelMetaReader for T {
+impl<T: ChannelReader> ChannelReaderLightClient for T {
     fn host_height(&self) -> Height {
         ChannelReader::host_height(self)
     }

--- a/modules/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/acknowledgement.rs
@@ -1,6 +1,7 @@
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{Counterparty, Order};
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::events::AcknowledgePacket;
 use crate::core::ics04_channel::handler::verify::verify_packet_acknowledgement_proofs;
 use crate::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
@@ -19,8 +20,8 @@ pub struct AckPacketResult {
     pub seq_number: Option<Sequence>,
 }
 
-pub fn process(
-    ctx: &dyn ChannelReader,
+pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgAcknowledgement,
 ) -> HandlerResult<PacketResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -110,7 +111,7 @@ pub fn process(
     output.log("success: packet ack");
 
     output.emit(IbcEvent::AcknowledgePacket(AcknowledgePacket {
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         packet: packet.clone(),
     }));
 

--- a/modules/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/acknowledgement.rs
@@ -1,7 +1,7 @@
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::AcknowledgePacket;
 use crate::core::ics04_channel::handler::verify::verify_packet_acknowledgement_proofs;
 use crate::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
@@ -20,7 +20,7 @@ pub struct AckPacketResult {
     pub seq_number: Option<Sequence>,
 }
 
-pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgAcknowledgement,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseConfirm`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,8 +11,8 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process(
-    ctx: &dyn ChannelReader,
+pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgChannelCloseConfirm,
 ) -> HandlerResult<ChannelResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -85,7 +85,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id.clone()),
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseConfirmChannel(

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseConfirm`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgChannelCloseConfirm,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseInit`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
@@ -9,7 +9,7 @@ use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgChannelCloseInit,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseInit`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
@@ -9,8 +9,8 @@ use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-pub(crate) fn process(
-    ctx: &dyn ChannelReader,
+pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgChannelCloseInit,
 ) -> HandlerResult<ChannelResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -56,7 +56,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id.clone()),
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         ..Default::default()
     };
     output.emit(IbcEvent::CloseInitChannel(

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenAck`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,8 +11,8 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process(
-    ctx: &dyn ChannelReader,
+pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgChannelOpenAck,
 ) -> HandlerResult<ChannelResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -94,7 +94,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id.clone()),
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenAckChannel(

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenAck`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgChannelOpenAck,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenConfirm`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgChannelOpenConfirm,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenConfirm`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,8 +11,8 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process(
-    ctx: &dyn ChannelReader,
+pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgChannelOpenConfirm,
 ) -> HandlerResult<ChannelResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -89,7 +89,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(msg.channel_id.clone()),
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenConfirmChannel(

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenInit`.
 
 use crate::core::ics04_channel::channel::{ChannelEnd, State};
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgChannelOpenInit,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenInit`.
 
 use crate::core::ics04_channel::channel::{ChannelEnd, State};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
@@ -11,8 +11,8 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process(
-    ctx: &dyn ChannelReader,
+pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgChannelOpenInit,
 ) -> HandlerResult<ChannelResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -65,7 +65,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(chan_id),
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenInitChannel(

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -2,7 +2,7 @@
 
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -13,7 +13,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgChannelOpenTry,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -2,7 +2,7 @@
 
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -13,8 +13,8 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process(
-    ctx: &dyn ChannelReader,
+pub(crate) fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgChannelOpenTry,
 ) -> HandlerResult<ChannelResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -135,7 +135,7 @@ pub(crate) fn process(
 
     let event_attributes = Attributes {
         channel_id: Some(channel_id),
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         ..Default::default()
     };
     output.emit(IbcEvent::OpenTryChannel(

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -1,6 +1,6 @@
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{Counterparty, Order, State};
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::ReceivePacket;
 use crate::core::ics04_channel::handler::verify::verify_packet_recv_proofs;
@@ -27,7 +27,7 @@ pub enum RecvPacketResult {
     },
 }
 
-pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgRecvPacket,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -1,6 +1,6 @@
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{Counterparty, Order, State};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::ReceivePacket;
 use crate::core::ics04_channel::handler::verify::verify_packet_recv_proofs;
@@ -27,7 +27,10 @@ pub enum RecvPacketResult {
     },
 }
 
-pub fn process(ctx: &dyn ChannelReader, msg: &MsgRecvPacket) -> HandlerResult<PacketResult, Error> {
+pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
+    msg: &MsgRecvPacket,
+) -> HandlerResult<PacketResult, Error> {
     let mut output = HandlerOutput::builder();
 
     let packet = &msg.packet;
@@ -64,7 +67,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: &MsgRecvPacket) -> HandlerResult<Pa
         ));
     }
 
-    let latest_height = ctx.host_height();
+    let latest_height = ChannelReader::host_height(ctx);
     if packet.timeout_height.has_expired(latest_height) {
         return Err(Error::low_packet_height(
             latest_height,
@@ -72,7 +75,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: &MsgRecvPacket) -> HandlerResult<Pa
         ));
     }
 
-    let latest_timestamp = ctx.host_timestamp();
+    let latest_timestamp = ChannelReader::host_timestamp(ctx);
     if let Expiry::Expired = latest_timestamp.check_expiry(&packet.timeout_timestamp) {
         return Err(Error::low_packet_timestamp());
     }
@@ -93,7 +96,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: &MsgRecvPacket) -> HandlerResult<Pa
 
         if packet.sequence < next_seq_recv {
             output.emit(IbcEvent::ReceivePacket(ReceivePacket {
-                height: ctx.host_height(),
+                height: ChannelReader::host_height(ctx),
                 packet: msg.packet.clone(),
             }));
             return Ok(output.with_result(PacketResult::Recv(RecvPacketResult::NoOp)));
@@ -119,7 +122,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: &MsgRecvPacket) -> HandlerResult<Pa
         match packet_rec {
             Ok(_receipt) => {
                 output.emit(IbcEvent::ReceivePacket(ReceivePacket {
-                    height: ctx.host_height(),
+                    height: ChannelReader::host_height(ctx),
                     packet: msg.packet.clone(),
                 }));
                 return Ok(output.with_result(PacketResult::Recv(RecvPacketResult::NoOp)));
@@ -140,7 +143,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: &MsgRecvPacket) -> HandlerResult<Pa
     output.log("success: packet receive");
 
     output.emit(IbcEvent::ReceivePacket(ReceivePacket {
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         packet: msg.packet.clone(),
     }));
 
@@ -292,7 +295,7 @@ mod tests {
 
                     for e in proto_output.events.iter() {
                         assert!(matches!(e, &IbcEvent::ReceivePacket(_)));
-                        assert_eq!(e.height(), test.ctx.host_height());
+                        assert_eq!(e.height(), ChannelReader::host_height(&test.ctx));
                     }
                 }
                 Err(e) => {

--- a/modules/src/core/ics04_channel/handler/send_packet.rs
+++ b/modules/src/core/ics04_channel/handler/send_packet.rs
@@ -94,7 +94,7 @@ pub fn send_packet(ctx: &dyn ChannelReader, packet: Packet) -> HandlerResult<Pac
     });
 
     output.emit(IbcEvent::SendPacket(SendPacket {
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         packet,
     }));
 

--- a/modules/src/core/ics04_channel/handler/timeout.rs
+++ b/modules/src/core/ics04_channel/handler/timeout.rs
@@ -1,6 +1,6 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::TimeoutPacket;
 use crate::core::ics04_channel::handler::verify::{
     verify_next_sequence_recv, verify_packet_receipt_absence,
@@ -27,7 +27,7 @@ pub struct TimeoutPacketResult {
 /// counterparty chain without the packet being committed, to prove that the
 /// packet can no longer be executed and to allow the calling module to safely
 /// perform appropriate state transitions.
-pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgTimeout,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/timeout.rs
+++ b/modules/src/core/ics04_channel/handler/timeout.rs
@@ -1,5 +1,6 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::events::TimeoutPacket;
 use crate::core::ics04_channel::handler::verify::{
     verify_next_sequence_recv, verify_packet_receipt_absence,
@@ -26,7 +27,10 @@ pub struct TimeoutPacketResult {
 /// counterparty chain without the packet being committed, to prove that the
 /// packet can no longer be executed and to allow the calling module to safely
 /// perform appropriate state transitions.
-pub fn process(ctx: &dyn ChannelReader, msg: &MsgTimeout) -> HandlerResult<PacketResult, Error> {
+pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
+    msg: &MsgTimeout,
+) -> HandlerResult<PacketResult, Error> {
     let mut output = HandlerOutput::builder();
 
     let packet = &msg.packet;
@@ -135,7 +139,7 @@ pub fn process(ctx: &dyn ChannelReader, msg: &MsgTimeout) -> HandlerResult<Packe
     output.log("success: packet timeout ");
 
     output.emit(IbcEvent::TimeoutPacket(TimeoutPacket {
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         packet: packet.clone(),
     }));
 

--- a/modules/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -1,6 +1,6 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::TimeoutOnClosePacket;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
 use crate::core::ics04_channel::handler::verify::{
@@ -15,7 +15,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     msg: &MsgTimeoutOnClose,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -1,5 +1,6 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::events::TimeoutOnClosePacket;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
 use crate::core::ics04_channel::handler::verify::{
@@ -14,8 +15,8 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub fn process(
-    ctx: &dyn ChannelReader,
+pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     msg: &MsgTimeoutOnClose,
 ) -> HandlerResult<PacketResult, Error> {
     let mut output = HandlerOutput::builder();
@@ -126,7 +127,7 @@ pub fn process(
     output.log("success: packet timeout ");
 
     output.emit(IbcEvent::TimeoutOnClosePacket(TimeoutOnClosePacket {
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         packet: packet.clone(),
     }));
 

--- a/modules/src/core/ics04_channel/handler/verify.rs
+++ b/modules/src/core/ics04_channel/handler/verify.rs
@@ -3,7 +3,7 @@ use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::{client_def::AnyClient, client_def::ClientDef};
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
-use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
@@ -12,7 +12,7 @@ use crate::proofs::Proofs;
 use crate::Height;
 
 /// Entry point for verifying all proofs bundled in any ICS4 message for channel protocols.
-pub fn verify_channel_proofs<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn verify_channel_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     height: Height,
     channel_end: &ChannelEnd,
@@ -51,7 +51,7 @@ pub fn verify_channel_proofs<Ctx: ChannelReader + ChannelMetaReader>(
 }
 
 /// Entry point for verifying all proofs bundled in a ICS4 packet recv. message.
-pub fn verify_packet_recv_proofs<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn verify_packet_recv_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     height: Height,
     packet: &Packet,
@@ -96,7 +96,7 @@ pub fn verify_packet_recv_proofs<Ctx: ChannelReader + ChannelMetaReader>(
 }
 
 /// Entry point for verifying all proofs bundled in an ICS4 packet ack message.
-pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     height: Height,
     packet: &Packet,
@@ -138,7 +138,7 @@ pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader + ChannelMetaRead
 }
 
 /// Entry point for verifying all timeout proofs.
-pub fn verify_next_sequence_recv<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn verify_next_sequence_recv<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     height: Height,
     connection_end: &ConnectionEnd,
@@ -176,7 +176,7 @@ pub fn verify_next_sequence_recv<Ctx: ChannelReader + ChannelMetaReader>(
     Ok(())
 }
 
-pub fn verify_packet_receipt_absence<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn verify_packet_receipt_absence<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     height: Height,
     connection_end: &ConnectionEnd,

--- a/modules/src/core/ics04_channel/handler/verify.rs
+++ b/modules/src/core/ics04_channel/handler/verify.rs
@@ -3,7 +3,7 @@ use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::{client_def::AnyClient, client_def::ClientDef};
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::{ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
@@ -12,8 +12,8 @@ use crate::proofs::Proofs;
 use crate::Height;
 
 /// Entry point for verifying all proofs bundled in any ICS4 message for channel protocols.
-pub fn verify_channel_proofs(
-    ctx: &dyn ChannelReader,
+pub fn verify_channel_proofs<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     height: Height,
     channel_end: &ChannelEnd,
     connection_end: &ConnectionEnd,
@@ -51,8 +51,8 @@ pub fn verify_channel_proofs(
 }
 
 /// Entry point for verifying all proofs bundled in a ICS4 packet recv. message.
-pub fn verify_packet_recv_proofs(
-    ctx: &dyn ChannelReader,
+pub fn verify_packet_recv_proofs<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     height: Height,
     packet: &Packet,
     connection_end: &ConnectionEnd,
@@ -96,8 +96,8 @@ pub fn verify_packet_recv_proofs(
 }
 
 /// Entry point for verifying all proofs bundled in an ICS4 packet ack message.
-pub fn verify_packet_acknowledgement_proofs(
-    ctx: &dyn ChannelReader,
+pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     height: Height,
     packet: &Packet,
     acknowledgement: Acknowledgement,
@@ -138,8 +138,8 @@ pub fn verify_packet_acknowledgement_proofs(
 }
 
 /// Entry point for verifying all timeout proofs.
-pub fn verify_next_sequence_recv(
-    ctx: &dyn ChannelReader,
+pub fn verify_next_sequence_recv<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     height: Height,
     connection_end: &ConnectionEnd,
     packet: Packet,
@@ -176,8 +176,8 @@ pub fn verify_next_sequence_recv(
     Ok(())
 }
 
-pub fn verify_packet_receipt_absence(
-    ctx: &dyn ChannelReader,
+pub fn verify_packet_receipt_absence<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     height: Height,
     connection_end: &ConnectionEnd,
     packet: Packet,

--- a/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -1,6 +1,6 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::commitment::AcknowledgementCommitment;
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::WriteAcknowledgement;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, PacketResult, Sequence};
@@ -20,7 +20,7 @@ pub struct WriteAckPacketResult {
     pub ack_commitment: AcknowledgementCommitment,
 }
 
-pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
     ctx: &Ctx,
     packet: Packet,
     ack: Acknowledgement,

--- a/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -1,5 +1,6 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::commitment::AcknowledgementCommitment;
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::events::WriteAcknowledgement;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, PacketResult, Sequence};
@@ -19,8 +20,8 @@ pub struct WriteAckPacketResult {
     pub ack_commitment: AcknowledgementCommitment,
 }
 
-pub fn process(
-    ctx: &dyn ChannelReader,
+pub fn process<Ctx: ChannelReader + ChannelMetaReader>(
+    ctx: &Ctx,
     packet: Packet,
     ack: Acknowledgement,
 ) -> HandlerResult<PacketResult, Error> {
@@ -66,7 +67,7 @@ pub fn process(
     output.log("success: packet write acknowledgement");
 
     output.emit(IbcEvent::WriteAcknowledgement(WriteAcknowledgement {
-        height: ctx.host_height(),
+        height: ChannelReader::host_height(ctx),
         packet,
         ack: ack.into(),
     }));

--- a/modules/src/core/ics26_routing/context.rs
+++ b/modules/src/core/ics26_routing/context.rs
@@ -7,7 +7,7 @@ use core::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::ics02_client::context::{ClientKeeper, ClientReader};
+use crate::core::ics02_client::context::{ClientKeeper, ClientReader, ConsensusReader};
 use crate::core::ics03_connection::context::{ConnectionKeeper, ConnectionReader};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
 use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader};
@@ -26,6 +26,7 @@ use crate::signer::Signer;
 /// representation of a chain from the perspective of the IBC module of that chain.
 pub trait Ics26Context:
     ClientReader
+    + ConsensusReader
     + ClientKeeper
     + ConnectionReader
     + ConnectionKeeper

--- a/modules/src/core/ics26_routing/context.rs
+++ b/modules/src/core/ics26_routing/context.rs
@@ -7,7 +7,7 @@ use core::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::ics02_client::context::{ClientKeeper, ClientReader, LightClientReader};
+use crate::core::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::core::ics03_connection::context::{ConnectionKeeper, ConnectionReader};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
 use crate::core::ics04_channel::context::{ChannelKeeper, ChannelMetaReader, ChannelReader};
@@ -26,7 +26,6 @@ use crate::signer::Signer;
 /// representation of a chain from the perspective of the IBC module of that chain.
 pub trait Ics26Context:
     ClientReader
-    + LightClientReader
     + ClientKeeper
     + ConnectionReader
     + ConnectionKeeper

--- a/modules/src/core/ics26_routing/context.rs
+++ b/modules/src/core/ics26_routing/context.rs
@@ -7,7 +7,7 @@ use core::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::ics02_client::context::{ClientKeeper, ClientReader, ConsensusReader};
+use crate::core::ics02_client::context::{ClientKeeper, ClientReader, LightClientReader};
 use crate::core::ics03_connection::context::{ConnectionKeeper, ConnectionReader};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
 use crate::core::ics04_channel::context::{ChannelKeeper, ChannelMetaReader, ChannelReader};
@@ -26,7 +26,7 @@ use crate::signer::Signer;
 /// representation of a chain from the perspective of the IBC module of that chain.
 pub trait Ics26Context:
     ClientReader
-    + ConsensusReader
+    + LightClientReader
     + ClientKeeper
     + ConnectionReader
     + ConnectionKeeper

--- a/modules/src/core/ics26_routing/context.rs
+++ b/modules/src/core/ics26_routing/context.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::ics02_client::context::{ClientKeeper, ClientReader, ConsensusReader};
 use crate::core::ics03_connection::context::{ConnectionKeeper, ConnectionReader};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelKeeper, ChannelMetaReader, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
 use crate::core::ics04_channel::packet::Packet;
@@ -32,6 +32,7 @@ pub trait Ics26Context:
     + ConnectionKeeper
     + ChannelKeeper
     + ChannelReader
+    + ChannelMetaReader
     + PortReader
 {
     type Router: Router;

--- a/modules/src/core/ics26_routing/context.rs
+++ b/modules/src/core/ics26_routing/context.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::core::ics03_connection::context::{ConnectionKeeper, ConnectionReader};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::context::{ChannelKeeper, ChannelMetaReader, ChannelReader};
+use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader, ChannelReaderLightClient};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
 use crate::core::ics04_channel::packet::Packet;
@@ -31,7 +31,7 @@ pub trait Ics26Context:
     + ConnectionKeeper
     + ChannelKeeper
     + ChannelReader
-    + ChannelMetaReader
+    + ChannelReaderLightClient
     + PortReader
 {
     type Router: Router;

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -1,6 +1,6 @@
 use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 
-use crate::core::ics02_client::client_consensus::AnyConsensusState;
+use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
 use crate::core::ics02_client::client_state::AnyClientState;
 use crate::core::ics02_client::context::ClientReader;
@@ -58,7 +58,7 @@ impl ClientDef for MockClient {
         _root: &CommitmentRoot,
         client_id: &ClientId,
         consensus_height: Height,
-        _expected_consensus_state: &AnyConsensusState,
+        _expected_consensus_state: &dyn ConsensusState,
     ) -> Result<(), Error> {
         let client_prefixed_path = Path::ClientConsensusState(ClientConsensusStatePath {
             client_id: client_id.clone(),

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -3,7 +3,7 @@ use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
 use crate::core::ics02_client::client_state::ClientState;
-use crate::core::ics02_client::context::ConsensusReader;
+use crate::core::ics02_client::context::LightClientReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
@@ -32,7 +32,7 @@ impl ClientDef for MockClient {
 
     fn check_header_and_update_state(
         &self,
-        _ctx: &dyn ConsensusReader,
+        _ctx: &dyn LightClientReader,
         _client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -3,12 +3,12 @@ use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
 use crate::core::ics02_client::client_state::ClientState;
-use crate::core::ics02_client::context::LightClientReader;
+use crate::core::ics02_client::context::ClientReaderLightClient;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelMetaReader;
+use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -32,7 +32,7 @@ impl ClientDef for MockClient {
 
     fn check_header_and_update_state(
         &self,
-        _ctx: &dyn LightClientReader,
+        _ctx: &dyn ClientReaderLightClient,
         _client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,
@@ -114,7 +114,7 @@ impl ClientDef for MockClient {
 
     fn verify_packet_data(
         &self,
-        _ctx: &dyn ChannelMetaReader,
+        _ctx: &dyn ChannelReaderLightClient,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,
@@ -130,7 +130,7 @@ impl ClientDef for MockClient {
 
     fn verify_packet_acknowledgement(
         &self,
-        _ctx: &dyn ChannelMetaReader,
+        _ctx: &dyn ChannelReaderLightClient,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,
@@ -146,7 +146,7 @@ impl ClientDef for MockClient {
 
     fn verify_next_sequence_recv(
         &self,
-        _ctx: &dyn ChannelMetaReader,
+        _ctx: &dyn ChannelReaderLightClient,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,
@@ -161,7 +161,7 @@ impl ClientDef for MockClient {
 
     fn verify_packet_receipt_absence(
         &self,
-        _ctx: &dyn ChannelMetaReader,
+        _ctx: &dyn ChannelReaderLightClient,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -3,7 +3,7 @@ use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
 use crate::core::ics02_client::client_state::ClientState;
-use crate::core::ics02_client::context::ClientReader;
+use crate::core::ics02_client::context::ConsensusReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
@@ -32,7 +32,7 @@ impl ClientDef for MockClient {
 
     fn check_header_and_update_state(
         &self,
-        _ctx: &dyn ClientReader,
+        _ctx: &dyn ConsensusReader,
         _client_id: ClientId,
         client_state: Self::ClientState,
         header: Self::Header,

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -2,7 +2,7 @@ use ibc_proto::ibc::core::commitment::v1::MerkleProof;
 
 use crate::core::ics02_client::client_consensus::ConsensusState;
 use crate::core::ics02_client::client_def::ClientDef;
-use crate::core::ics02_client::client_state::AnyClientState;
+use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
@@ -99,7 +99,7 @@ impl ClientDef for MockClient {
         Ok(())
     }
 
-    fn verify_client_full_state(
+    fn verify_client_full_state<U>(
         &self,
         _client_state: &Self::ClientState,
         _height: Height,
@@ -107,7 +107,7 @@ impl ClientDef for MockClient {
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
         _client_id: &ClientId,
-        _expected_client_state: &AnyClientState,
+        _expected_client_state: &dyn ClientState<UpgradeOptions = U>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -8,7 +8,7 @@ use crate::core::ics02_client::error::Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelReader;
+use crate::core::ics04_channel::context::ChannelMetaReader;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -114,7 +114,7 @@ impl ClientDef for MockClient {
 
     fn verify_packet_data(
         &self,
-        _ctx: &dyn ChannelReader,
+        _ctx: &dyn ChannelMetaReader,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,
@@ -130,7 +130,7 @@ impl ClientDef for MockClient {
 
     fn verify_packet_acknowledgement(
         &self,
-        _ctx: &dyn ChannelReader,
+        _ctx: &dyn ChannelMetaReader,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,
@@ -146,7 +146,7 @@ impl ClientDef for MockClient {
 
     fn verify_next_sequence_recv(
         &self,
-        _ctx: &dyn ChannelReader,
+        _ctx: &dyn ChannelMetaReader,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,
@@ -161,7 +161,7 @@ impl ClientDef for MockClient {
 
     fn verify_packet_receipt_absence(
         &self,
-        _ctx: &dyn ChannelReader,
+        _ctx: &dyn ChannelMetaReader,
         _client_state: &Self::ClientState,
         _height: Height,
         _connection_end: &ConnectionEnd,

--- a/modules/src/mock/client_state.rs
+++ b/modules/src/mock/client_state.rs
@@ -2,7 +2,6 @@ use crate::prelude::*;
 
 use alloc::collections::btree_map::BTreeMap as HashMap;
 
-use core::convert::Infallible;
 use core::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -177,8 +176,6 @@ impl From<MockConsensusState> for AnyConsensusState {
 }
 
 impl ConsensusState for MockConsensusState {
-    type Error = Infallible;
-
     fn client_type(&self) -> ClientType {
         ClientType::Mock
     }
@@ -189,5 +186,9 @@ impl ConsensusState for MockConsensusState {
 
     fn wrap_any(self) -> AnyConsensusState {
         AnyConsensusState::Mock(self)
+    }
+
+    fn encode_vec(&self) -> Result<Vec<u8>, Error> {
+        Protobuf::encode_vec(self).map_err(Error::invalid_any_consensus_state)
     }
 }

--- a/modules/src/mock/client_state.rs
+++ b/modules/src/mock/client_state.rs
@@ -65,12 +65,6 @@ impl MockClientState {
     }
 }
 
-impl From<MockClientState> for AnyClientState {
-    fn from(mcs: MockClientState) -> Self {
-        Self::Mock(mcs)
-    }
-}
-
 impl TryFrom<RawMockClientState> for MockClientState {
     type Error = Error;
 
@@ -111,10 +105,6 @@ impl ClientState for MockClientState {
 
     fn upgrade(&mut self, _upgrade_height: Height, _upgrade_options: (), _chain_id: ChainId) {
         todo!()
-    }
-
-    fn wrap_any(self) -> AnyClientState {
-        AnyClientState::Mock(self)
     }
 
     fn encode_vec(&self) -> Result<Vec<u8>, Error> {
@@ -173,12 +163,6 @@ impl From<MockConsensusState> for RawMockConsensusState {
     }
 }
 
-impl From<MockConsensusState> for AnyConsensusState {
-    fn from(mcs: MockConsensusState) -> Self {
-        Self::Mock(mcs)
-    }
-}
-
 impl ConsensusState for MockConsensusState {
     fn client_type(&self) -> ClientType {
         ClientType::Mock
@@ -186,10 +170,6 @@ impl ConsensusState for MockConsensusState {
 
     fn root(&self) -> &CommitmentRoot {
         &self.root
-    }
-
-    fn wrap_any(self) -> AnyConsensusState {
-        AnyConsensusState::Mock(self)
     }
 
     fn encode_vec(&self) -> Result<Vec<u8>, Error> {

--- a/modules/src/mock/client_state.rs
+++ b/modules/src/mock/client_state.rs
@@ -109,12 +109,16 @@ impl ClientState for MockClientState {
         self.frozen_height
     }
 
-    fn upgrade(self, _upgrade_height: Height, _upgrade_options: (), _chain_id: ChainId) -> Self {
+    fn upgrade(&mut self, _upgrade_height: Height, _upgrade_options: (), _chain_id: ChainId) {
         todo!()
     }
 
     fn wrap_any(self) -> AnyClientState {
         AnyClientState::Mock(self)
+    }
+
+    fn encode_vec(&self) -> Result<Vec<u8>, Error> {
+        Protobuf::encode_vec(self).map_err(Error::invalid_any_client_state)
     }
 }
 

--- a/modules/src/mock/context.rs
+++ b/modules/src/mock/context.rs
@@ -209,7 +209,7 @@ impl MockContext {
 
                 let consensus_state = AnyConsensusState::from(light_block.clone());
                 let client_state =
-                    get_dummy_tendermint_client_state(light_block.signed_header.header);
+                    get_dummy_tendermint_client_state(light_block.signed_header.header).into();
 
                 // Return the tuple.
                 (Some(client_state), consensus_state)
@@ -261,7 +261,7 @@ impl MockContext {
 
                 let consensus_state = AnyConsensusState::from(light_block.clone());
                 let client_state =
-                    get_dummy_tendermint_client_state(light_block.signed_header.header);
+                    get_dummy_tendermint_client_state(light_block.signed_header.header).into();
 
                 // Return the tuple.
                 (Some(client_state), consensus_state)

--- a/modules/src/mock/header.rs
+++ b/modules/src/mock/header.rs
@@ -93,11 +93,12 @@ impl From<MockHeader> for AnyConsensusState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::ics02_client::header::AnyHeader;
 
     #[test]
     fn encode_any() {
         let header = MockHeader::new(Height::new(1, 10).unwrap()).with_timestamp(Timestamp::none());
-        let bytes = header.encode_vec().unwrap();
+        let bytes = AnyHeader::from(header).encode_vec().unwrap();
 
         assert_eq!(
             &bytes,

--- a/modules/src/mock/header.rs
+++ b/modules/src/mock/header.rs
@@ -6,7 +6,6 @@ use ibc_proto::ibc::mock::Header as RawMockHeader;
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error;
-use crate::core::ics02_client::header::AnyHeader;
 use crate::core::ics02_client::header::Header;
 use crate::mock::client_state::MockConsensusState;
 use crate::timestamp::Timestamp;
@@ -71,12 +70,6 @@ impl MockHeader {
     }
 }
 
-impl From<MockHeader> for AnyHeader {
-    fn from(mh: MockHeader) -> Self {
-        Self::Mock(mh)
-    }
-}
-
 impl Header for MockHeader {
     fn client_type(&self) -> ClientType {
         ClientType::Mock
@@ -88,10 +81,6 @@ impl Header for MockHeader {
 
     fn timestamp(&self) -> Timestamp {
         self.timestamp
-    }
-
-    fn wrap_any(self) -> AnyHeader {
-        AnyHeader::Mock(self)
     }
 }
 
@@ -108,7 +97,7 @@ mod tests {
     #[test]
     fn encode_any() {
         let header = MockHeader::new(Height::new(1, 10).unwrap()).with_timestamp(Timestamp::none());
-        let bytes = header.wrap_any().encode_vec().unwrap();
+        let bytes = header.encode_vec().unwrap();
 
         assert_eq!(
             &bytes,

--- a/modules/src/mock/misbehaviour.rs
+++ b/modules/src/mock/misbehaviour.rs
@@ -5,7 +5,6 @@ use tendermint_proto::Protobuf;
 use ibc_proto::ibc::mock::Misbehaviour as RawMisbehaviour;
 
 use crate::core::ics02_client::error::Error;
-use crate::core::ics02_client::misbehaviour::AnyMisbehaviour;
 use crate::core::ics24_host::identifier::ClientId;
 use crate::mock::header::MockHeader;
 use crate::Height;
@@ -24,10 +23,6 @@ impl crate::core::ics02_client::misbehaviour::Misbehaviour for Misbehaviour {
 
     fn height(&self) -> Height {
         self.header1.height()
-    }
-
-    fn wrap_any(self) -> AnyMisbehaviour {
-        AnyMisbehaviour::Mock(self)
     }
 }
 

--- a/modules/src/relayer/ics18_relayer/utils.rs
+++ b/modules/src/relayer/ics18_relayer/utils.rs
@@ -152,14 +152,14 @@ mod tests {
             // Update client on chain B to latest height of B.
             // - create the client update message with the latest header from B
             // The test uses LightClientBlock that does not store the trusted height
-            let b_latest_header = match ctx_b.query_latest_header().unwrap() {
+            let b_latest_header: AnyHeader = match ctx_b.query_latest_header().unwrap() {
                 AnyHeader::Tendermint(header) => {
                     let th = header.height();
                     let mut hheader = header.clone();
                     hheader.trusted_height = th.decrement().unwrap();
-                    hheader.wrap_any()
+                    hheader.into()
                 }
-                AnyHeader::Mock(header) => header.wrap_any(),
+                AnyHeader::Mock(header) => header.into(),
             };
 
             assert_eq!(

--- a/relayer/src/chain/endpoint.rs
+++ b/relayer/src/chain/endpoint.rs
@@ -10,7 +10,7 @@ use ibc::core::ics02_client::client_consensus::{
 use ibc::core::ics02_client::client_state::{
     AnyClientState, ClientState, IdentifiedAnyClientState,
 };
-use ibc::core::ics02_client::header::Header;
+use ibc::core::ics02_client::header::{AnyHeader, Header};
 use ibc::core::ics03_connection::connection::{ConnectionEnd, IdentifiedConnectionEnd, State};
 use ibc::core::ics03_connection::version::{get_compatible_versions, Version};
 use ibc::core::ics04_channel::channel::{ChannelEnd, IdentifiedChannelEnd};
@@ -69,13 +69,13 @@ pub trait ChainEndpoint: Sized {
     type LightBlock: Send + Sync;
 
     /// Type of headers for this chain
-    type Header: Header;
+    type Header: Header + Into<AnyHeader>;
 
     /// Type of consensus state for this chain
-    type ConsensusState: ConsensusState;
+    type ConsensusState: ConsensusState + Into<AnyConsensusState>;
 
     /// Type of the client state for this chain
-    type ClientState: ClientState;
+    type ClientState: ClientState + Into<AnyClientState>;
 
     type LightClient: LightClient<Self>;
 

--- a/relayer/src/chain/runtime.rs
+++ b/relayer/src/chain/runtime.rs
@@ -8,10 +8,10 @@ use tracing::error;
 use ibc::{
     core::{
         ics02_client::{
-            client_consensus::{AnyConsensusState, AnyConsensusStateWithHeight, ConsensusState},
-            client_state::{AnyClientState, ClientState, IdentifiedAnyClientState},
+            client_consensus::{AnyConsensusState, AnyConsensusStateWithHeight},
+            client_state::{AnyClientState, IdentifiedAnyClientState},
             events::UpdateClient,
-            header::{AnyHeader, Header},
+            header::AnyHeader,
             misbehaviour::MisbehaviourEvidence,
         },
         ics03_connection::{
@@ -538,8 +538,8 @@ where
                 &mut self.light_client,
             )
             .map(|(header, support)| {
-                let header = header.wrap_any();
-                let support = support.into_iter().map(|h| h.wrap_any()).collect();
+                let header = header.into();
+                let support = support.into_iter().map(|h| h.into()).collect();
                 (header, support)
             });
 
@@ -556,7 +556,7 @@ where
         let client_state = self
             .chain
             .build_client_state(height, settings)
-            .map(|cs| cs.wrap_any());
+            .map(|cs| cs.into());
 
         reply_to.send(client_state).map_err(Error::send)
     }
@@ -574,7 +574,7 @@ where
         let consensus_state = self
             .chain
             .build_consensus_state(verified.target)
-            .map(|cs| cs.wrap_any());
+            .map(|cs| cs.into());
 
         reply_to.send(consensus_state).map_err(Error::send)
     }
@@ -608,8 +608,7 @@ where
             height,
         );
 
-        let result = result
-            .map(|(opt_client_state, proofs)| (opt_client_state.map(|cs| cs.wrap_any()), proofs));
+        let result = result.map(|(opt_client_state, proofs)| (opt_client_state, proofs));
 
         reply_to.send(result).map_err(Error::send)
     }
@@ -638,10 +637,7 @@ where
         include_proof: IncludeProof,
         reply_to: ReplyTo<(AnyClientState, Option<MerkleProof>)>,
     ) -> Result<(), Error> {
-        let res = self
-            .chain
-            .query_client_state(request, include_proof)
-            .map(|(cs, proof)| (cs.wrap_any(), proof));
+        let res = self.chain.query_client_state(request, include_proof);
 
         reply_to.send(res).map_err(Error::send)
     }
@@ -651,10 +647,7 @@ where
         request: QueryUpgradedClientStateRequest,
         reply_to: ReplyTo<(AnyClientState, MerkleProof)>,
     ) -> Result<(), Error> {
-        let result = self
-            .chain
-            .query_upgraded_client_state(request)
-            .map(|(cl, proof)| (cl.wrap_any(), proof));
+        let result = self.chain.query_upgraded_client_state(request);
 
         reply_to.send(result).map_err(Error::send)
     }
@@ -684,10 +677,7 @@ where
         request: QueryUpgradedConsensusStateRequest,
         reply_to: ReplyTo<(AnyConsensusState, MerkleProof)>,
     ) -> Result<(), Error> {
-        let result = self
-            .chain
-            .query_upgraded_consensus_state(request)
-            .map(|(cs, proof)| (cs.wrap_any(), proof));
+        let result = self.chain.query_upgraded_consensus_state(request);
 
         reply_to.send(result).map_err(Error::send)
     }
@@ -897,7 +887,7 @@ where
         let result = self
             .chain
             .query_host_consensus_state(request)
-            .map(|h| h.wrap_any());
+            .map(|h| h.into());
 
         reply_to.send(result).map_err(Error::send)?;
 

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -13,9 +13,7 @@ use itertools::Itertools;
 use tracing::{debug, error, info, span, trace, warn, Level};
 
 use flex_error::define_error;
-use ibc::core::ics02_client::client_consensus::{
-    AnyConsensusState, AnyConsensusStateWithHeight, ConsensusState,
-};
+use ibc::core::ics02_client::client_consensus::{AnyConsensusState, AnyConsensusStateWithHeight};
 use ibc::core::ics02_client::client_state::AnyClientState;
 use ibc::core::ics02_client::client_state::ClientState;
 use ibc::core::ics02_client::error::Error as ClientError;
@@ -591,7 +589,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
         })?;
         let settings = ClientSettings::for_create_command(options, &src_config, &dst_config);
 
-        let client_state = self
+        let client_state: AnyClientState = self
             .src_chain
             .build_client_state(latest_height, settings)
             .map_err(|e| {
@@ -600,8 +598,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
                     "failed when building client state".to_string(),
                     e,
                 )
-            })?
-            .wrap_any();
+            })?;
 
         let consensus_state = self
             .src_chain
@@ -616,8 +613,7 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
                     "failed while building client consensus state from src chain".to_string(),
                     e,
                 )
-            })?
-            .wrap_any();
+            })?;
 
         //TODO Get acct_prefix
         let msg = MsgCreateAnyClient::new(client_state, consensus_state, signer)

--- a/relayer/src/light_client/tendermint.rs
+++ b/relayer/src/light_client/tendermint.rs
@@ -19,11 +19,8 @@ use ibc::{
     },
     core::{
         ics02_client::{
-            client_state::AnyClientState,
-            client_type::ClientType,
-            events::UpdateClient,
-            header::{AnyHeader, Header},
-            misbehaviour::{Misbehaviour, MisbehaviourEvidence},
+            client_state::AnyClientState, client_type::ClientType, events::UpdateClient,
+            header::AnyHeader, misbehaviour::MisbehaviourEvidence,
         },
         ics24_host::identifier::ChainId,
     },
@@ -153,11 +150,11 @@ impl super::LightClient<CosmosSdkChain> for LightClient {
                 header1: update_header,
                 header2: witness,
             }
-            .wrap_any();
+            .into();
 
             Ok(Some(MisbehaviourEvidence {
                 misbehaviour,
-                supporting_headers: supporting.into_iter().map(TmHeader::wrap_any).collect(),
+                supporting_headers: supporting.into_iter().map(Into::into).collect(),
             }))
         } else {
             Ok(None)

--- a/relayer/src/upgrade_chain.rs
+++ b/relayer/src/upgrade_chain.rs
@@ -84,7 +84,7 @@ pub fn build_and_send_ibc_upgrade_proposal(
         )
         .map_err(UpgradeChainError::query)?;
 
-    let client_state = downcast!(client_state => AnyClientState::Tendermint)
+    let mut client_state = downcast!(client_state => AnyClientState::Tendermint)
         .ok_or_else(UpgradeChainError::tendermint_only)?;
 
     // Retain the old unbonding period in case the user did not specify a new one
@@ -94,7 +94,7 @@ pub fn build_and_send_ibc_upgrade_proposal(
             .unwrap_or(client_state.unbonding_period),
     };
 
-    let upgraded_client_state = client_state.upgrade(
+    client_state.upgrade(
         upgrade_height.increment(),
         upgrade_options,
         opts.upgraded_chain_id.clone(),
@@ -103,7 +103,7 @@ pub fn build_and_send_ibc_upgrade_proposal(
     let proposal = UpgradeProposal {
         title: "proposal 0".to_string(),
         description: "upgrade the chain software and unbonding period".to_string(),
-        upgraded_client_state: Some(Any::from(upgraded_client_state.wrap_any())),
+        upgraded_client_state: Some(Any::from(client_state.wrap_any())),
         plan: Some(Plan {
             name: opts.upgrade_plan_name.clone(),
             height: upgrade_height.revision_height() as i64,

--- a/relayer/src/upgrade_chain.rs
+++ b/relayer/src/upgrade_chain.rs
@@ -103,7 +103,7 @@ pub fn build_and_send_ibc_upgrade_proposal(
     let proposal = UpgradeProposal {
         title: "proposal 0".to_string(),
         description: "upgrade the chain software and unbonding period".to_string(),
-        upgraded_client_state: Some(Any::from(client_state.wrap_any())),
+        upgraded_client_state: Some(Any::from(AnyClientState::from(client_state))),
         plan: Some(Plan {
             name: opts.upgrade_plan_name.clone(),
             height: upgrade_height.revision_height() as i64,


### PR DESCRIPTION
Partially addresses: #2335 

## Description
Implements phase-1 of #2335: 
* Attempts to make light-client traits object safe. 
* Removes all usages of `Any*` enums from light-client code. 

Note: The target branch is a long-lived branch [hu55a1n1/light-client-extraction](https://github.com/informalsystems/ibc-rs/tree/hu55a1n1/light-client-extraction). The plan is to merge PRs (addressing #2335) such as this into [hu55a1n1/light-client-extraction](https://github.com/informalsystems/ibc-rs/tree/hu55a1n1/light-client-extraction) and ultimately merge that into master. 
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).