### PR TITLE
Do not retry clearing with same height forever

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer/2155-remove-infinite-loop.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/2155-remove-infinite-loop.md
@@ -1,2 +1,2 @@
-- Do not retry infinitely on cmd handling failure
+- Do not retry indefinitely on command handling failure in the packet worker
   ([#2155](https://github.com/informalsystems/ibc-rs/issues/2155))

--- a/.changelog/unreleased/improvements/ibc-relayer/2155-remove-infinite-loop.md
+++ b/.changelog/unreleased/improvements/ibc-relayer/2155-remove-infinite-loop.md
@@ -1,0 +1,2 @@
+- Do not retry infinitely on cmd handling failure
+  ([#2155](https://github.com/informalsystems/ibc-rs/issues/2155))

--- a/relayer/src/link/cli.rs
+++ b/relayer/src/link/cli.rs
@@ -144,7 +144,7 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
         tracking_id: TrackingId,
     ) -> Result<Vec<IbcEvent>, LinkError> {
         let mut results = vec![];
-        
+
         for events_chunk in query_packet_events_with(
             &sequences,
             src_response_height,

--- a/relayer/src/link/cli.rs
+++ b/relayer/src/link/cli.rs
@@ -143,8 +143,8 @@ impl<ChainA: ChainHandle, ChainB: ChainHandle> Link<ChainA, ChainB> {
         ) -> Result<Vec<IbcEvent>, LinkError>,
         tracking_id: TrackingId,
     ) -> Result<Vec<IbcEvent>, LinkError> {
-        dbg!(src_response_height);
         let mut results = vec![];
+        
         for events_chunk in query_packet_events_with(
             &sequences,
             src_response_height,

--- a/relayer/src/worker/packet.rs
+++ b/relayer/src/worker/packet.rs
@@ -72,27 +72,20 @@ pub fn spawn_packet_cmd_worker<ChainA: ChainHandle, ChainB: ChainHandle>(
         )
     };
 
-    let mut current_command = None;
-
     spawn_background_task(span, Some(Duration::from_millis(200)), move || {
-        if current_command.is_none() {
-            // Only try to receive the next command if the
-            // previous command was processed successfully.
-            current_command = cmd_rx.try_recv().ok();
-        }
-
-        if let Some(cmd) = &current_command {
+        if let Ok(cmd) = cmd_rx.try_recv() {
+            // Try to clear pending packets. At different levels down in `handle_packet_cmd` there
+            // are retries mechanisms for MAX_RETRIES (current value hardcoded at 5).
+            // If clearing fails after all these retries with ignorable error the task continues
+            // (see `handle_link_error_in_task`) and clearing is retried with the next
+            // (`NewBlock`) `cmd` that matches the clearing interval.
             handle_packet_cmd(
                 &mut link.lock().unwrap(),
                 &mut should_clear_on_start,
                 clear_interval,
                 &path,
-                cmd.clone(),
+                cmd,
             )?;
-
-            // Only reset current_command if handle_packet_cmd succeeds.
-            // Otherwise the same command will be retried in the next step.
-            current_command = None;
         }
 
         Ok(Next::Continue)
@@ -142,12 +135,12 @@ fn handle_packet_cmd<ChainA: ChainHandle, ChainB: ChainHandle>(
     };
 
     if do_clear {
-        handle_clear_packet(link, clear_interval, path, maybe_height)?;
-
-        // Reset the `clear_on_start` flag
+        // Reset the `clear_on_start` flag and attempt packet clearing once now.
+        // More clearing will be done at clear interval.
         if *should_clear_on_start {
             *should_clear_on_start = false;
         }
+        handle_clear_packet(link, clear_interval, path, maybe_height)?;
     }
 
     // Handle command-specific task

--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -146,7 +146,7 @@ fi
 
 # Start gaia
 echo "Start gaia on grpc port: $GRPC_PORT..."
-$BINARY --home $CHAIN_DIR/$CHAIN_ID start --pruning=nothing --grpc.address="0.0.0.0:$GRPC_PORT" --log_level error > $CHAIN_DIR/$CHAIN_ID.log 2>&1 &
+$BINARY --home $CHAIN_DIR/$CHAIN_ID start --pruning=everything --grpc.address="0.0.0.0:$GRPC_PORT" --log_level error > $CHAIN_DIR/$CHAIN_ID.log 2>&1 &
 
 # Show validator's and user's balance
 sleep 3

--- a/scripts/one-chain
+++ b/scripts/one-chain
@@ -146,7 +146,7 @@ fi
 
 # Start gaia
 echo "Start gaia on grpc port: $GRPC_PORT..."
-$BINARY --home $CHAIN_DIR/$CHAIN_ID start --pruning=everything --grpc.address="0.0.0.0:$GRPC_PORT" --log_level error > $CHAIN_DIR/$CHAIN_ID.log 2>&1 &
+$BINARY --home $CHAIN_DIR/$CHAIN_ID start --pruning=nothing --grpc.address="0.0.0.0:$GRPC_PORT" --log_level error > $CHAIN_DIR/$CHAIN_ID.log 2>&1 &
 
 # Show validator's and user's balance
 sleep 3


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2155

## Description
`spawn_packet_cmd_worker` runs `handle_packet_cmd` passing a "command" that can be `NewBlock`.
The first thing it does is to try clearing packets. If this fails with ignorable error, the old code will retry immediately with same command and height. If the error persists (as in #2155) then the worker enters an infinite loop and new IBC events (coming via `IbcEvent` commands) are never processed.

I believe the infinite loop started with https://github.com/informalsystems/ibc-rs/pull/2238. Before that the worker would abort (due to `TaskError::Fatal(RunError::retry(e))`)

The propose change is to move to the next command even if previous has failed. The reasons are:
- it avoids the infinite loop
- the failed events will still be processed at next clear interval with a fresh height
- at different levels down in `handle_packet_cmd` there are retries mechanisms for MAX_RETRIES (current value hardcoded at 5). 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).