### PR TITLE
Add an overwrite check for command `keys add`

### DIFF
--- a/.changelog/unreleased/improvements/ibc-relayer-cli/2375-keys-add-overwrite.md
+++ b/.changelog/unreleased/improvements/ibc-relayer-cli/2375-keys-add-overwrite.md
@@ -1,0 +1,3 @@
+- Hermes command `keys add` now checks for existing key
+  and overwrites only if the flag `--overwrite` is passed.
+  ([#2375](https://github.com/informalsystems/ibc-rs/issues/2375))

--- a/guide/src/commands/keys/index.md
+++ b/guide/src/commands/keys/index.md
@@ -66,7 +66,8 @@ You can save this to a file (e.g. `key_seed.json`) and use it to add to the rela
 
 ### Adding and restoring Keys
 
-The command `keys add` has two exclusive flags, `--key-file` and `--mnemonic-file` which are respectively used to add and restore a key.
+The command `keys add` has two exclusive flags, `--key-file` and `--mnemonic-file` which are respectively used to add and restore a key.  
+If a key with the same `key_name` already exists, the flag `--overwrite` must be passed in order to overwrite the existing key or else the command will abort.
 
 ```shell
     hermes keys add [OPTIONS] --chain <CHAIN_ID> --key-file <KEY_FILE>
@@ -79,6 +80,7 @@ DESCRIPTION:
 OPTIONS:
         --hd-path <HD_PATH>      Derivation path for this key [default: m/44'/118'/0'/0/0]
         --key-name <KEY_NAME>    Name of the key (defaults to the `key_name` defined in the config)
+        --overwrite              Overwrite the key if there is already one with the same key name
 
 FLAGS:
         --chain <CHAIN_ID>                 Identifier of the chain
@@ -97,6 +99,7 @@ DESCRIPTION:
 OPTIONS:
         --hd-path <HD_PATH>      Derivation path for this key [default: m/44'/118'/0'/0/0]
         --key-name <KEY_NAME>    Name of the key (defaults to the `key_name` defined in the config)
+        --overwrite              Overwrite the key if there is already one with the same key name
 
 FLAGS:
         --chain <CHAIN_ID>                 Identifier of the chain
@@ -146,6 +149,7 @@ DESCRIPTION:
 OPTIONS:
         --hd-path <HD_PATH>      Derivation path for this key [default: m/44'/118'/0'/0/0]
         --key-name <KEY_NAME>    Name of the key (defaults to the `key_name` defined in the config)
+        --overwrite              Overwrite the key if there is already one with the same key name
 
 FLAGS:
         --chain <CHAIN_ID>                 Identifier of the chain

--- a/relayer-cli/src/commands/keys/add.rs
+++ b/relayer-cli/src/commands/keys/add.rs
@@ -224,7 +224,7 @@ pub fn restore_key(
 /// If it already exists and overwrite is false, abort the command with an error.
 /// If overwrite is true, output a warning message informing the key will be overwritten.
 fn check_key_exists(keyring: &KeyRing, key_name: &str, overwrite: bool) {
-    if let Ok(_) = keyring.get_key(key_name) {
+    if keyring.get_key(key_name).is_ok() {
         if overwrite {
             warn!("Key {} will be overwritten", key_name);
         } else {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2375

## Description

This PR improves the command `keys add` by checking if a key with the same `key_name` already exists.
* If a key already exists and the optional flag `--overwrite` is not passed, the command aborts with an error message.
* If a key already exists but the optional flag `--overwrite` is passed, a warning message informing the key will be overwritten is displayed.
* If the key doesn't exist, the normal behaviour of adding/restoring a key is unchanged.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `guide/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).