### PR TITLE
New optional flag `--host-chain` for `upgrade clients` command

### DIFF
--- a/.changelog/unreleased/features/ibc-relayer-cli/2311-new-optional-flag-upgrade-clients.md
+++ b/.changelog/unreleased/features/ibc-relayer-cli/2311-new-optional-flag-upgrade-clients.md
@@ -1,0 +1,3 @@
+- Added new optional flag `--host-chain` to filter which clients are upgraded when
+  running `upgrade clients` command ([#2311](https://github.com/informalsystems/ibc-
+  rs/issues/2311))

--- a/.changelog/unreleased/features/ibc-relayer-cli/2311-new-optional-flag-upgrade-clients.md
+++ b/.changelog/unreleased/features/ibc-relayer-cli/2311-new-optional-flag-upgrade-clients.md
@@ -1,3 +1,3 @@
 - Added new optional flag `--host-chain` to filter which clients are upgraded when
-  running `upgrade clients` command ([#2311](https://github.com/informalsystems/ibc-
-  rs/issues/2311))
+  running `upgrade clients` command
+  ([#2311](https://github.com/informalsystems/ibc-rs/issues/2311))

--- a/docs/architecture/adr-010-unified-cli-arguments-hermes.md
+++ b/docs/architecture/adr-010-unified-cli-arguments-hermes.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 * 15.06.2022: Proposed.
+* 28.06.2022: Accepted.
 
 ## Context
 
@@ -184,6 +185,10 @@ The following are not yet implemented:
 * Updating `query channel ends` to `query channel full`
 
 The PR which updates the flags for all the commands as described in this ADR: [#2275](https://github.com/informalsystems/ibc-rs/pull/2275)
+
+__08.07.22__
+
+* Created a new PR, [#2384](https://github.com/informalsystems/ibc-rs/pull/2384), to add the optional flag for the `upgrade clients` command, issue [#2311](https://github.com/informalsystems/ibc-rs/issues/2311)
 
 ## Consequences
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2311

## Description

This PR adds a new optional flag, `--host-chain` to the command `hermes upgrade clients`. This flag allows to upgrade all clients that target a specific chain, given by `--reference-chain`, and are hosted on the chain specified by `--host-chain`.

### Testing

In order to test the new flag, follow the instructions to test the `upgrade client` command in the Hermes guide https://hermes.informal.systems/commands/upgrade/test.html with the following modifications:

- Use the following `gm.toml`:
```
[global]
  add_to_hermes = true
  auto_maintain_config = true
  extra_wallets = 2
  gaiad_binary = "$HOME/go/bin/gaiad"
  hdpath = ""
  home_dir = "$HOME/.gm"
  ports_start_at = 27040
  validator_mnemonic = ""
  wallet_mnemonic = ""

  [global.hermes]
    binary = "$HOME/.hermes/bin/hermes"
    config = "$HOME/.hermes/config.toml"
    log_level = "debug"
    telemetry_enabled = true
    telemetry_host = "127.0.0.1"
    telemetry_port = 3001

[ibc-0]
  ports_start_at = 27000

[ibc-1]
  ports_start_at = 27010

[ibc-2]
  ports_start_at = 27020
```
- At step `1.` create an additional client on chain `ibc-2` which references `ibc-0` using the following command:
`hermes create client --host-chain ibc-2 --reference-chain ibc-0`
- At step `2.` modify the the `upgrade-chain` and add the flag `--new-chain` to have a different chain name after the upgrade:
`hermes tx raw upgrade-chain --dst-chain ibc-0 --src-chain ibc-1 --src-client 07-tendermint-0 --amount 10000000 --height-offset 60 --new-chain upgraded-ibc-0`
- At step `5.` instead of using the command in the guide, upgrade only client on `ibc-1` using the following command:
`hermes upgrade clients --reference-chain ibc-0 --upgrade-height XX --host-chain ibc-1`

The output of the `upgrade clients` should only show that one client has been successfully upgraded.

### Check the state of the clients

Once the `upgrade clients` command completes, query the state of the client on `ibc-1` with:
`hermes query client state --chain ibc-1 --client 07-tendermint-0`
This should give an output which start with:
```
Success: Tendermint(
    ClientState {
        chain_id: ChainId {
            id: "upgraded-ibc-0",
            version: 0,
        },
...
```
And query the state of the client on `ibc-2` with:
`hermes query client state --chain ibc-2 --client 07-tendermint-0`
This should give an output which start with:
```
Success: Tendermint(
    ClientState {
        chain_id: ChainId {
            id: "ibc-0",
            version: 0,
        },
...
```

If the `--host-chain` command is not given to `hermes upgrade clients` then both client states will output that the chain id is `upgraded-ibc-0`.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `guide/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).