### PR TITLE
Fix `Ics20Reader::get_channel_escrow_address()` default impl

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc/2387-fix-get_channel_escrow_address.md
+++ b/.changelog/unreleased/bug-fixes/ibc/2387-fix-get_channel_escrow_address.md
@@ -1,0 +1,3 @@
+- Remove provided `Ics20Reader::get_channel_escrow_address()` implementation and make `cosmos_adr028_escrow_address()`
+  public.
+  ([#2035](https://github.com/informalsystems/ibc-rs/issues/2387))

--- a/modules/src/applications/transfer/context.rs
+++ b/modules/src/applications/transfer/context.rs
@@ -51,7 +51,7 @@ pub trait Ics20Reader: ChannelReader {
 }
 
 // https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-028-public-key-addresses.md
-fn cosmos_adr028_escrow_address(port_id: &PortId, channel_id: &ChannelId) -> Vec<u8> {
+pub fn cosmos_adr028_escrow_address(port_id: &PortId, channel_id: &ChannelId) -> Vec<u8> {
     let contents = format!("{}/{}", port_id, channel_id);
 
     let mut hasher = Sha256::new();

--- a/modules/src/applications/transfer/context.rs
+++ b/modules/src/applications/transfer/context.rs
@@ -1,5 +1,4 @@
 use sha2::{Digest, Sha256};
-use subtle_encoding::hex;
 
 use super::error::Error as Ics20Error;
 use crate::applications::transfer::acknowledgement::Acknowledgement;
@@ -36,15 +35,7 @@ pub trait Ics20Reader: ChannelReader {
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
-    ) -> Result<<Self as Ics20Reader>::AccountId, Ics20Error> {
-        let hash = cosmos_adr028_escrow_address(port_id, channel_id);
-        String::from_utf8(hex::encode_upper(hash))
-            .expect("hex encoded bytes are not valid UTF8")
-            .parse::<Signer>()
-            .map_err(Ics20Error::signer)?
-            .try_into()
-            .map_err(|_| Ics20Error::parse_account_failure())
-    }
+    ) -> Result<<Self as Ics20Reader>::AccountId, Ics20Error>;
 
     /// Returns true iff send is enabled.
     fn is_send_enabled(&self) -> bool;

--- a/modules/src/test_utils.rs
+++ b/modules/src/test_utils.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use subtle_encoding::bech32;
 
+use subtle_encoding::bech32;
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
 use crate::applications::transfer::context::{

--- a/modules/src/test_utils.rs
+++ b/modules/src/test_utils.rs
@@ -1,9 +1,12 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use subtle_encoding::bech32;
 
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
-use crate::applications::transfer::context::{BankKeeper, Ics20Context, Ics20Keeper, Ics20Reader};
+use crate::applications::transfer::context::{
+    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, Ics20Keeper, Ics20Reader,
+};
 use crate::applications::transfer::{error::Error as Ics20Error, PrefixedCoin};
 use crate::core::ics02_client::client_consensus::AnyConsensusState;
 use crate::core::ics02_client::client_state::AnyClientState;
@@ -225,6 +228,15 @@ impl Ics20Reader for DummyTransferModule {
 
     fn get_port(&self) -> Result<PortId, Ics20Error> {
         Ok(PortId::transfer())
+    }
+
+    fn get_channel_escrow_address(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<<Self as Ics20Reader>::AccountId, Ics20Error> {
+        let addr = cosmos_adr028_escrow_address(port_id, channel_id);
+        Ok(bech32::encode("cosmos", addr).parse().unwrap())
     }
 
     fn is_send_enabled(&self) -> bool {


### PR DESCRIPTION
Closes: #2387 

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).