### PR TITLE
New metric `client_update_message_count` to count the number of MsgUpdateAnyClient relayed

### DIFF
--- a/.changelog/unreleased/features/ibc-telemetry/2408-new-client-metrics.md
+++ b/.changelog/unreleased/features/ibc-telemetry/2408-new-client-metrics.md
@@ -1,0 +1,3 @@
+- Added new metric `client_update_message_count` in order to
+  count the number of MsgUpdateAnyClient relayed by Hermes.
+  ([#2408](https://github.com/informalsystems/ibc-rs/issues/2408))

--- a/guide/src/telemetry.md
+++ b/guide/src/telemetry.md
@@ -51,6 +51,7 @@ The following table describes the metrics currently tracked by the telemetry ser
 | `cleared_count`              | Number of SendPacket relayed through ClearPendingPackets | `u64` Counter   |
 | `oldest_sequence`            | The sequence number of the oldest pending SendPacket. If this value is 0, it means there are no pending SendPacket | `u64` ValueRecorder |
 | `oldest_timestamp`           | The timestamp of the oldest sequence number in seconds | `u64` ValueRecorder |
+| `client_update_message_count` | Number of MsgUpdateAnyClient relayed                | `u64` Counter       |
 
 ## Integration with Prometheus
 
@@ -75,6 +76,10 @@ cache_hits{chain="ibc-1",query_type="query_connection"} 12
 cache_hits{chain="ibc-2",query_type="query_channel"} 10
 cache_hits{chain="ibc-2",query_type="query_client_state"} 17
 cache_hits{chain="ibc-2",query_type="query_connection"} 13
+# HELP client_update_message_count Number of MsgUpdateAnyClient relayed
+# TYPE client_update_message_count counter
+client_update_message_count{chain="ibc-0",counterparty="ibc-1"} 1
+client_update_message_count{chain="ibc-1",counterparty="ibc-0"} 1
 # HELP ibc_acknowledgment_packets Number of acknowledgment packets relayed per channel
 # TYPE ibc_acknowledgment_packets counter
 ibc_acknowledgment_packets{src_chain="ibc-0",src_channel="channel-0",src_port="transfer"} 0

--- a/relayer/src/foreign_client.rs
+++ b/relayer/src/foreign_client.rs
@@ -1069,6 +1069,8 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
                 }
                 .to_any(),
             );
+            ibc_telemetry::global()
+                .client_update_message_count(&self.src_chain.id(), &self.dst_chain.id());
         }
 
         debug!(
@@ -1086,6 +1088,8 @@ impl<DstChain: ChainHandle, SrcChain: ChainHandle> ForeignClient<DstChain, SrcCh
             }
             .to_any(),
         );
+        ibc_telemetry::global()
+            .client_update_message_count(&self.src_chain.id(), &self.dst_chain.id());
 
         Ok(msgs)
     }

--- a/telemetry/src/state.rs
+++ b/telemetry/src/state.rs
@@ -115,6 +115,9 @@ pub struct TelemetryState {
 
     /// History of SendPacket sequence numbers received and not yet Acknowledged.
     sequences_histories: DashMap<PathIdentifier, DashMap<u64, u64>>,
+
+    /// Counts the number of MsgUpdateAnyClient relayed
+    client_update_message_count: Counter<u64>,
 }
 
 impl TelemetryState {
@@ -474,6 +477,14 @@ impl TelemetryState {
             }
         }
     }
+
+    pub fn client_update_message_count(&self, chain_id: &ChainId, counterparty_chain_id: &ChainId) {
+        let labels = &[
+            KeyValue::new("chain", chain_id.to_string()),
+            KeyValue::new("counterparty", counterparty_chain_id.to_string()),
+        ];
+        self.client_update_message_count.add(1, labels);
+    }
 }
 
 use std::sync::Arc;
@@ -622,6 +633,11 @@ impl Default for TelemetryState {
                 .u64_value_recorder("oldest_timestamp")
                 .with_unit(Unit::new("seconds"))
                 .with_description("The timestamp of the oldest sequence number in seconds")
+                .init(),
+
+            client_update_message_count: meter
+                .u64_counter("client_update_message_count")
+                .with_description("Number of MsgUpdateAnyClient relayed")
                 .init(),
         }
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2408

## Description

This PR adds the new metric `client_update_message_count`

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).