### PR TITLE
Show `ERROR` in red when a command fails

### DIFF
--- a/.changelog/unreleased/improvement/ibc-relayer-cli/2431-colored_output.md
+++ b/.changelog/unreleased/improvement/ibc-relayer-cli/2431-colored_output.md
@@ -1,0 +1,2 @@
+- Output status is now colored in green for success and red for error
+  ([#2431](https://github.com/informalsystems/ibc-rs/issues/2431))

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -55,8 +55,8 @@
 //! Output::success(h).with_result(end).exit();
 //! ```
 
-use core::fmt;
 use console::style;
+use core::fmt;
 
 use serde::Serialize;
 use tracing::warn;

--- a/relayer-cli/src/conclude.rs
+++ b/relayer-cli/src/conclude.rs
@@ -56,6 +56,7 @@
 //! ```
 
 use core::fmt;
+use console::style;
 
 use serde::Serialize;
 use tracing::warn;
@@ -72,7 +73,11 @@ pub fn exit_with(out: Output) -> ! {
     if json() {
         println!("{}", serde_json::to_string(&out.into_json()).unwrap());
     } else {
-        println!("{}: {}", out.status, out.result);
+        let status = match out.status {
+            Status::Success => style("SUCCESS").green(),
+            Status::Error => style("ERROR").red(),
+        };
+        println!("{} {}", status, out.result);
     }
 
     // The return code


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/informalsystems/ibc-rs/issues/2431

Same PR as https://github.com/informalsystems/ibc-rs/pull/2460 but without commits from another branch

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
The output of CLI can be confusing (see linked issue). This PR shows the status of the output in green if the command succeeds or in red if it fails.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules). 
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).