### PR TITLE
relayer: Fix one-past-the-limit flaw in message batching

### DIFF
--- a/.changelog/unreleased/bug-fixes/ibc-relayer/2477-prevent-oversized-tx-batch.md
+++ b/.changelog/unreleased/bug-fixes/ibc-relayer/2477-prevent-oversized-tx-batch.md
@@ -1,0 +1,3 @@
+- Fix code that could result in message batch size growing above
+  the transaction size limit
+  ([#2477](https://github.com/informalsystems/ibc-rs/issues/2477)).

--- a/relayer/src/chain/cosmos/batch.rs
+++ b/relayer/src/chain/cosmos/batch.rs
@@ -228,4 +228,10 @@ mod tests {
         let res = batch_messages(MaxMsgNum::default(), MaxTxSize::new(21).unwrap(), messages);
         assert!(res.is_err());
     }
+
+    #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value")]
+    fn test_max_msg_num_of_zero_panics() {
+        let _batches = batch_messages(MaxMsgNum::new(0).unwrap(), MaxTxSize::default(), vec![]);
+    }
 }

--- a/relayer/src/chain/cosmos/batch.rs
+++ b/relayer/src/chain/cosmos/batch.rs
@@ -200,12 +200,14 @@ mod tests {
         ];
         let batches =
             batch_messages(MaxMsgNum::default(), MaxTxSize::new(42).unwrap(), messages).unwrap();
+
         assert_eq!(batches.len(), 2);
         assert_eq!(batches[0].len(), 2);
         assert_eq!(batches[0][0].type_url, "/example.Foo");
         assert_eq!(batches[0][0].value.len(), 6);
         assert_eq!(batches[0][1].type_url, "/example.Bar");
         assert_eq!(batches[0][1].value.len(), 4);
+
         assert_eq!(batches[1].len(), 1);
         assert_eq!(batches[1][0].type_url, "/example.Baz");
         assert_eq!(batches[1][0].value.len(), 2);
@@ -223,9 +225,12 @@ mod tests {
             messages.clone(),
         )
         .unwrap();
+
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].len(), 1);
+
         let res = batch_messages(MaxMsgNum::default(), MaxTxSize::new(21).unwrap(), messages);
+
         assert!(res.is_err());
     }
 
@@ -328,7 +333,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value")]
+    #[should_panic(expected = "`max_msg_num` must be greater than or equal to 1, found 0")]
     fn test_max_msg_num_of_zero_panics() {
         let _batches = batch_messages(MaxMsgNum::new(0).unwrap(), MaxTxSize::default(), vec![]);
     }

--- a/relayer/src/chain/cosmos/batch.rs
+++ b/relayer/src/chain/cosmos/batch.rs
@@ -146,7 +146,7 @@ fn batch_messages(
     let mut current_size = 0;
     let mut current_batch = vec![];
 
-    for message in messages.into_iter() {
+    for message in messages {
         let message_len = message.encoded_len();
 
         if message_len > max_tx_size {
@@ -155,10 +155,12 @@ fn batch_messages(
 
         if current_count >= max_message_count || current_size + message_len > max_tx_size {
             let insert_batch = mem::take(&mut current_batch);
+
             assert!(
                 !insert_batch.is_empty(),
                 "max message count should not be 0"
             );
+
             batches.push(insert_batch);
             current_count = 0;
             current_size = 0;
@@ -219,6 +221,7 @@ mod tests {
             type_url: "/example.Foo".into(),
             value: vec![0; 6],
         }];
+
         let batches = batch_messages(
             MaxMsgNum::default(),
             MaxTxSize::new(22).unwrap(),

--- a/relayer/src/chain/cosmos/batch.rs
+++ b/relayer/src/chain/cosmos/batch.rs
@@ -149,11 +149,11 @@ fn batch_messages(
     for message in messages.into_iter() {
         let message_len = message.encoded_len();
 
-        if message_len >= max_tx_size {
+        if message_len > max_tx_size {
             return Err(Error::message_exceeds_max_tx_size(message_len));
         }
 
-        if current_count >= max_message_count || current_size + message_len >= max_tx_size {
+        if current_count >= max_message_count || current_size + message_len > max_tx_size {
             let insert_batch = mem::take(&mut current_batch);
             assert!(
                 !insert_batch.is_empty(),

--- a/relayer/src/chain/cosmos/batch.rs
+++ b/relayer/src/chain/cosmos/batch.rs
@@ -154,7 +154,7 @@ fn batch_messages(
         }
 
         if current_count >= max_message_count || current_size + message_len >= max_tx_size {
-            let insert_batch = mem::replace(&mut current_batch, vec![]);
+            let insert_batch = mem::take(&mut current_batch);
             assert!(
                 !insert_batch.is_empty(),
                 "max message count should not be 0"

--- a/relayer/src/config/types.rs
+++ b/relayer/src/config/types.rs
@@ -113,7 +113,7 @@ pub mod max_tx_size {
 
     impl MaxTxSize {
         const DEFAULT: usize = 2 * 1048576; // 2 MBytes
-        const MAX_BOUND: usize = 8 * 1048576; // 8 MBytes
+        pub const MAX_BOUND: usize = 8 * 1048576; // 8 MBytes
 
         pub fn new(value: usize) -> Result<Self, Error> {
             if value > Self::MAX_BOUND {
@@ -121,6 +121,10 @@ pub mod max_tx_size {
             }
 
             Ok(Self(value))
+        }
+
+        pub fn max() -> Self {
+            Self(Self::MAX_BOUND)
         }
 
         pub fn to_usize(self) -> usize {

--- a/relayer/src/config/types.rs
+++ b/relayer/src/config/types.rs
@@ -113,7 +113,7 @@ pub mod max_tx_size {
 
     impl MaxTxSize {
         const DEFAULT: usize = 2 * 1048576; // 2 MBytes
-        pub const MAX_BOUND: usize = 8 * 1048576; // 8 MBytes
+        const MAX_BOUND: usize = 8 * 1048576; // 8 MBytes
 
         pub fn new(value: usize) -> Result<Self, Error> {
             if value > Self::MAX_BOUND {

--- a/relayer/src/error.rs
+++ b/relayer/src/error.rs
@@ -506,11 +506,17 @@ define_error! {
             },
 
         EmptyDenomTrace
-        { hash: String }
-        |e| {
-            format_args!(
-                "Query/DenomTrace RPC returned an empty denom trace for trace hash: {}", e.hash)
-        },
+            { hash: String }
+            |e| {
+                format_args!(
+                    "Query/DenomTrace RPC returned an empty denom trace for trace hash: {}", e.hash)
+            },
+
+        MessageExceedsMaxTxSize
+            { len: usize }
+            |e| {
+                format_args!("message length {} exceeds maximum transaction size", e.len)
+            }
     }
 }
 


### PR DESCRIPTION
Closes: #2477

## Description

Prevent the batch data size from exceeding the given tx size limit.
Previous code pushed the offending last message to the end of the tx,
resulting in an oversized transaction.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [x] Reviewed `Files changed` in the GitHub PR explorer.
- [x] Manually tested (in case integration/unit/mock tests are absent).
