### PR TITLE
Fix MsgTimeoutOnClose to verify the proof of the channel

### DIFF
--- a/.changelog/unreleased/bug/2534-fix-timeout-on-close.md
+++ b/.changelog/unreleased/bug/2534-fix-timeout-on-close.md
@@ -1,0 +1,2 @@
+- Fix MsgTimeoutOnClose ([#2534](https://github.com/informalsystems/ibc-
+  rs/issues/2534))

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -124,7 +124,7 @@ mod tests {
         let raw = get_dummy_raw_msg_timeout_on_close(height, timeout_timestamp);
 
         let msg = MsgTimeoutOnClose::try_from(raw.clone()).unwrap();
-        let raw_back = RawMsgTimeoutOnClose::from(msg.clone());
+        let raw_back = RawMsgTimeoutOnClose::from(msg);
         assert_eq!(raw, raw_back);
     }
 
@@ -174,7 +174,7 @@ mod tests {
                 name: "Missing proof height".to_string(),
                 raw: RawMsgTimeoutOnClose {
                     proof_height: None,
-                    ..default_raw_msg.clone()
+                    ..default_raw_msg
                 },
                 want_pass: false,
             },

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -109,6 +109,82 @@ impl From<MsgTimeoutOnClose> for RawMsgTimeoutOnClose {
 }
 
 #[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use ibc_proto::ibc::core::channel::v1::MsgTimeoutOnClose as RawMsgTimeoutOnClose;
+    use test_log::test;
+
+    use crate::core::ics04_channel::msgs::timeout_on_close::test_util::get_dummy_raw_msg_timeout_on_close;
+    use crate::core::ics04_channel::msgs::timeout_on_close::MsgTimeoutOnClose;
+
+    #[test]
+    fn msg_timeout_on_close_try_from_raw() {
+        struct Test {
+            name: String,
+            raw: RawMsgTimeoutOnClose,
+            want_pass: bool,
+        }
+
+        let height = 50;
+        let timeout_timestamp = 5;
+        let default_raw_msg = get_dummy_raw_msg_timeout_on_close(height, timeout_timestamp);
+
+        let tests: Vec<Test> = vec![
+            Test {
+                name: "Good parameters".to_string(),
+                raw: default_raw_msg.clone(),
+                want_pass: true,
+            },
+            Test {
+                name: "Missing packet".to_string(),
+                raw: RawMsgTimeoutOnClose {
+                    packet: None,
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Missing unreceived proof".to_string(),
+                raw: RawMsgTimeoutOnClose {
+                    proof_unreceived: Vec::new(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Missing channel proof".to_string(),
+                raw: RawMsgTimeoutOnClose {
+                    proof_close: Vec::new(),
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+            Test {
+                name: "Missing proof height".to_string(),
+                raw: RawMsgTimeoutOnClose {
+                    proof_height: None,
+                    ..default_raw_msg.clone()
+                },
+                want_pass: false,
+            },
+        ];
+
+        for test in tests {
+            let res_msg = MsgTimeoutOnClose::try_from(test.raw.clone());
+
+            assert_eq!(
+                test.want_pass,
+                res_msg.is_ok(),
+                "MsgTimeoutOnClose::try_from raw failed for test {}, \nraw msg {:?} with error {:?}",
+                test.name,
+                test.raw,
+                res_msg.err(),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 pub mod test_util {
     use ibc_proto::ibc::core::channel::v1::MsgTimeoutOnClose as RawMsgTimeoutOnClose;
     use ibc_proto::ibc::core::client::v1::Height as RawHeight;

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -119,6 +119,17 @@ mod tests {
 
     #[test]
     fn msg_timeout_on_close_try_from_raw() {
+        let height = 50;
+        let timeout_timestamp = 5;
+        let raw = get_dummy_raw_msg_timeout_on_close(height, timeout_timestamp);
+
+        let msg = MsgTimeoutOnClose::try_from(raw.clone()).unwrap();
+        let raw_back = RawMsgTimeoutOnClose::from(msg.clone());
+        assert_eq!(raw, raw_back);
+    }
+
+    #[test]
+    fn parse_timeout_on_close_msg() {
         struct Test {
             name: String,
             raw: RawMsgTimeoutOnClose,
@@ -144,7 +155,7 @@ mod tests {
                 want_pass: false,
             },
             Test {
-                name: "Missing unreceived proof".to_string(),
+                name: "Missing jnreceived proof".to_string(),
                 raw: RawMsgTimeoutOnClose {
                     proof_unreceived: Vec::new(),
                     ..default_raw_msg.clone()

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -64,7 +64,12 @@ impl TryFrom<RawMsgTimeoutOnClose> for MsgTimeoutOnClose {
                 .map_err(Error::invalid_proof)?,
             None,
             None,
-            None,
+            Some(
+                raw_msg
+                    .proof_close
+                    .try_into()
+                    .map_err(Error::invalid_proof)?,
+            ),
             raw_msg
                 .proof_height
                 .and_then(|raw_height| raw_height.try_into().ok())

--- a/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -155,7 +155,7 @@ mod tests {
                 want_pass: false,
             },
             Test {
-                name: "Missing jnreceived proof".to_string(),
+                name: "Missing proof of unreceived packet".to_string(),
                 raw: RawMsgTimeoutOnClose {
                     proof_unreceived: Vec::new(),
                     ..default_raw_msg.clone()
@@ -163,7 +163,7 @@ mod tests {
                 want_pass: false,
             },
             Test {
-                name: "Missing channel proof".to_string(),
+                name: "Missing proof of channel".to_string(),
                 raw: RawMsgTimeoutOnClose {
                     proof_close: Vec::new(),
                     ..default_raw_msg.clone()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2534 

## Description
- Fix the conversion from `RawMsgTimeoutOnClose` to set `proof_close` to `other_proof` in `MsgTimeoutOnClose`
- Replace the proof to be used for the channel verification


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
