### PR TITLE
Add timeout limit to CI tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -41,6 +41,7 @@ env:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         chain:
@@ -104,6 +105,7 @@ jobs:
 
   ordered-channel-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v15
@@ -167,6 +169,7 @@ jobs:
 
   model-based-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         gaiad:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,6 +92,7 @@ jobs:
 
   test-stable:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,12 +2613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,10 +2911,11 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
 dependencies = [
+ "dashmap 5.3.4",
  "futures",
  "lazy_static",
  "log",
@@ -2930,14 +2925,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 


### PR DESCRIPTION
## Description

Sometimes the integration tests may hang indefinitely. When that happens, by default GitHub Actions only terminate the job after 6 hours. This adds a 60 minutes time limit so that failing tests do not overspend our CI budget.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
