### PR TITLE
Avoid decoding expected client state on counterparty

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_def.rs
+++ b/modules/src/clients/ics07_tendermint/client_def.rs
@@ -292,14 +292,13 @@ impl ClientDef for TendermintClient {
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
         client_id: &ClientId,
-        expected_client_state: &dyn ClientState,
+        expected_client_state: Any,
     ) -> Result<(), Ics02Error> {
         let client_state = downcast_tm_client_state(client_state)?;
         client_state.verify_height(height)?;
 
         let path = ClientStatePath(client_id.clone());
-        let value = Protobuf::<Any>::encode_vec(expected_client_state)
-            .map_err(Ics02Error::invalid_any_client_state)?;
+        let value = expected_client_state.encode_to_vec();
         verify_membership(client_state, prefix, proof, root, path, value)
     }
 

--- a/modules/src/core/ics02_client/client_def.rs
+++ b/modules/src/core/ics02_client/client_def.rs
@@ -103,7 +103,7 @@ pub trait ClientDef {
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
         client_id: &ClientId,
-        expected_client_state: &dyn ClientState,
+        expected_client_state: Any,
     ) -> Result<(), Error>;
 
     /// Verify a `proof` that a packet has been commited.
@@ -334,7 +334,7 @@ impl ClientDef for AnyClient {
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
         client_id: &ClientId,
-        client_state_on_counterparty: &dyn ClientState,
+        client_state_on_counterparty: Any,
     ) -> Result<(), Error> {
         match self {
             Self::Tendermint(client) => client.verify_client_full_state(

--- a/modules/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -67,15 +67,10 @@ pub(crate) fn process(
         )
     };
 
-    let client_state = msg
-        .client_state
-        .map(|cs| ctx.decode_client_state(cs))
-        .transpose()?;
-
     // 2. Pass the details to the verification function.
     verify_proofs(
         ctx,
-        client_state.as_deref(),
+        msg.client_state,
         msg.proofs.height(),
         &conn_end,
         &expected_conn,

--- a/modules/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/modules/src/core/ics03_connection/handler/conn_open_try.rs
@@ -80,15 +80,10 @@ pub(crate) fn process(
         msg.delay_period,
     );
 
-    let client_state = msg
-        .client_state
-        .map(|cs| ctx.decode_client_state(cs))
-        .transpose()?;
-
     // 2. Pass the details to the verification function.
     verify_proofs(
         ctx,
-        client_state.as_deref(),
+        msg.client_state,
         msg.proofs.height(),
         &new_connection_end,
         &expected_conn,

--- a/modules/src/core/ics03_connection/handler/verify.rs
+++ b/modules/src/core/ics03_connection/handler/verify.rs
@@ -1,6 +1,7 @@
 //! ICS3 verification functions, common across all four handlers of ICS3.
 
-use crate::core::ics02_client::client_state::ClientState;
+use ibc_proto::google::protobuf::Any;
+
 use crate::core::ics02_client::{client_def::AnyClient, client_def::ClientDef};
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics03_connection::context::ConnectionReader;
@@ -12,7 +13,7 @@ use crate::Height;
 /// Entry point for verifying all proofs bundled in any ICS3 message.
 pub fn verify_proofs(
     ctx: &dyn ConnectionReader,
-    client_state: Option<&dyn ClientState>,
+    client_state: Option<Any>,
     height: Height,
     connection_end: &ConnectionEnd,
     expected_conn: &ConnectionEnd,
@@ -106,7 +107,7 @@ pub fn verify_client_proof(
     ctx: &dyn ConnectionReader,
     height: Height,
     connection_end: &ConnectionEnd,
-    expected_client_state: &dyn ClientState,
+    expected_client_state: Any,
     proof_height: Height,
     proof: &CommitmentProofBytes,
 ) -> Result<(), Error> {

--- a/modules/src/mock/client_def.rs
+++ b/modules/src/mock/client_def.rs
@@ -113,7 +113,7 @@ impl ClientDef for MockClient {
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
         _client_id: &ClientId,
-        _expected_client_state: &dyn ClientState,
+        _expected_client_state: Any,
     ) -> Result<(), Error> {
         Ok(())
     }


### PR DESCRIPTION
## Description

Avoid decoding the expected client state on counterparty in `MsgConnOpen{Try, Ack}`. The expected client state in these cases is verified by converting to `Any` as that is how the counterparty would have stored the client state, so we can skip trying to decode the client state. 

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
