### PR TITLE
Remove ChannelReaderLightClient

### DIFF
--- a/modules/src/clients/ics07_tendermint/client_state.rs
+++ b/modules/src/clients/ics07_tendermint/client_state.rs
@@ -1,7 +1,6 @@
 use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -38,6 +37,7 @@ use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::{Error as Ics02Error, ErrorDetail as Ics02ErrorDetail};
 use crate::core::ics02_client::trust_threshold::TrustThreshold;
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics23_commitment::specs::ProofSpecs;
 use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
 use crate::timestamp::{Timestamp, ZERO_DURATION};
@@ -533,7 +533,7 @@ impl ClientState for TmClientState {
 
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -565,7 +565,7 @@ impl ClientState for TmClientState {
 
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -596,7 +596,7 @@ impl ClientState for TmClientState {
 
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -628,7 +628,7 @@ impl ClientState for TmClientState {
 
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -698,7 +698,7 @@ fn verify_non_membership(
 }
 
 fn verify_delay_passed(
-    ctx: &dyn ChannelReaderLightClient,
+    ctx: &dyn ChannelReader,
     height: Height,
     connection_end: &ConnectionEnd,
 ) -> Result<(), Ics02Error> {

--- a/modules/src/core/ics02_client/client_state.rs
+++ b/modules/src/core/ics02_client/client_state.rs
@@ -12,7 +12,7 @@ use crate::core::ics02_client::error::Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -151,7 +151,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_data(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -166,7 +166,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -181,7 +181,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -195,7 +195,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ChannelReaderLightClient,
+        ctx: &dyn ChannelReader,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,

--- a/modules/src/core/ics04_channel/context.rs
+++ b/modules/src/core/ics04_channel/context.rs
@@ -138,48 +138,6 @@ pub trait ChannelReader {
     }
 }
 
-/// Defines a subset of the `ChannelReader`'s methods that a light-client implementation can access.
-/// A blanket implementation of this trait is provided for all types that implement `ChannelReader`.
-pub trait ChannelReaderLightClient {
-    /// Returns the current height of the local chain.
-    fn host_height(&self) -> Height;
-
-    /// Returns the current timestamp of the local chain.
-    fn host_timestamp(&self) -> Timestamp;
-
-    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error>;
-
-    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_height(&self, client_id: &ClientId, height: Height) -> Result<Height, Error>;
-
-    /// Calculates the block delay period using the connection's delay period and the maximum
-    /// expected time per block.
-    fn block_delay(&self, delay_period_time: Duration) -> u64;
-}
-
-impl<T: ChannelReader> ChannelReaderLightClient for T {
-    fn host_height(&self) -> Height {
-        ChannelReader::host_height(self)
-    }
-
-    fn host_timestamp(&self) -> Timestamp {
-        ChannelReader::host_timestamp(self)
-    }
-
-    fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error> {
-        ChannelReader::client_update_time(self, client_id, height)
-    }
-
-    fn client_update_height(&self, client_id: &ClientId, height: Height) -> Result<Height, Error> {
-        ChannelReader::client_update_height(self, client_id, height)
-    }
-
-    fn block_delay(&self, delay_period_time: Duration) -> u64 {
-        ChannelReader::block_delay(self, delay_period_time)
-    }
-}
-
 /// A context supplying all the necessary write-only dependencies (i.e., storage writing facility)
 /// for processing any `ChannelMsg`.
 pub trait ChannelKeeper {

--- a/modules/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/acknowledgement.rs
@@ -1,7 +1,6 @@
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::AcknowledgePacket;
 use crate::core::ics04_channel::handler::verify::verify_packet_acknowledgement_proofs;
 use crate::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
@@ -20,7 +19,7 @@ pub struct AckPacketResult {
     pub seq_number: Option<Sequence>,
 }
 
-pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgAcknowledgement,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseConfirm`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub(crate) fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgChannelCloseConfirm,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_close_init.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseInit`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::State;
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
@@ -9,7 +9,7 @@ use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub(crate) fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgChannelCloseInit,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenAck`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub(crate) fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgChannelOpenAck,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenConfirm`.
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub(crate) fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgChannelOpenConfirm,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_init.rs
@@ -1,7 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenInit`.
 
 use crate::core::ics04_channel::channel::{ChannelEnd, State};
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
@@ -11,7 +11,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub(crate) fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgChannelOpenInit,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/modules/src/core/ics04_channel/handler/chan_open_try.rs
@@ -2,7 +2,7 @@
 
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::Attributes;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
@@ -13,7 +13,7 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
-pub(crate) fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub(crate) fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgChannelOpenTry,
 ) -> HandlerResult<ChannelResult, Error> {

--- a/modules/src/core/ics04_channel/handler/recv_packet.rs
+++ b/modules/src/core/ics04_channel/handler/recv_packet.rs
@@ -1,6 +1,6 @@
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{Counterparty, Order, State};
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::events::ReceivePacket;
 use crate::core::ics04_channel::handler::verify::verify_packet_recv_proofs;
@@ -27,7 +27,7 @@ pub enum RecvPacketResult {
     },
 }
 
-pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgRecvPacket,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/timeout.rs
+++ b/modules/src/core/ics04_channel/handler/timeout.rs
@@ -1,6 +1,5 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::TimeoutPacket;
 use crate::core::ics04_channel::handler::verify::{
     verify_next_sequence_recv, verify_packet_receipt_absence,
@@ -27,7 +26,7 @@ pub struct TimeoutPacketResult {
 /// counterparty chain without the packet being committed, to prove that the
 /// packet can no longer be executed and to allow the calling module to safely
 /// perform appropriate state transitions.
-pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgTimeout,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/modules/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -1,6 +1,5 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::TimeoutOnClosePacket;
 use crate::core::ics04_channel::handler::verify::verify_channel_proofs;
 use crate::core::ics04_channel::handler::verify::{
@@ -16,7 +15,7 @@ use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 use crate::proofs::{ProofError, Proofs};
 
-pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     msg: &MsgTimeoutOnClose,
 ) -> HandlerResult<PacketResult, Error> {

--- a/modules/src/core/ics04_channel/handler/verify.rs
+++ b/modules/src/core/ics04_channel/handler/verify.rs
@@ -1,6 +1,6 @@
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
-use crate::core::ics04_channel::context::{ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
@@ -9,7 +9,7 @@ use crate::proofs::Proofs;
 use crate::Height;
 
 /// Entry point for verifying all proofs bundled in any ICS4 message for channel protocols.
-pub fn verify_channel_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn verify_channel_proofs<Ctx: ChannelReader>(
     ctx: &Ctx,
     height: Height,
     channel_end: &ChannelEnd,
@@ -45,7 +45,7 @@ pub fn verify_channel_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
 }
 
 /// Entry point for verifying all proofs bundled in a ICS4 packet recv. message.
-pub fn verify_packet_recv_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn verify_packet_recv_proofs<Ctx: ChannelReader>(
     ctx: &Ctx,
     height: Height,
     packet: &Packet,
@@ -87,7 +87,7 @@ pub fn verify_packet_recv_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
 }
 
 /// Entry point for verifying all proofs bundled in an ICS4 packet ack message.
-pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader>(
     ctx: &Ctx,
     height: Height,
     packet: &Packet,
@@ -126,7 +126,7 @@ pub fn verify_packet_acknowledgement_proofs<Ctx: ChannelReader + ChannelReaderLi
 }
 
 /// Entry point for verifying all timeout proofs.
-pub fn verify_next_sequence_recv<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn verify_next_sequence_recv<Ctx: ChannelReader>(
     ctx: &Ctx,
     height: Height,
     connection_end: &ConnectionEnd,
@@ -161,7 +161,7 @@ pub fn verify_next_sequence_recv<Ctx: ChannelReader + ChannelReaderLightClient>(
     Ok(())
 }
 
-pub fn verify_packet_receipt_absence<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn verify_packet_receipt_absence<Ctx: ChannelReader>(
     ctx: &Ctx,
     height: Height,
     connection_end: &ConnectionEnd,

--- a/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/modules/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -1,6 +1,5 @@
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::commitment::AcknowledgementCommitment;
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
 use crate::core::ics04_channel::events::WriteAcknowledgement;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, PacketResult, Sequence};
@@ -20,7 +19,7 @@ pub struct WriteAckPacketResult {
     pub ack_commitment: AcknowledgementCommitment,
 }
 
-pub fn process<Ctx: ChannelReader + ChannelReaderLightClient>(
+pub fn process<Ctx: ChannelReader>(
     ctx: &Ctx,
     packet: Packet,
     ack: Acknowledgement,

--- a/modules/src/core/ics26_routing/context.rs
+++ b/modules/src/core/ics26_routing/context.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::ics02_client::context::{ClientKeeper, ClientReader};
 use crate::core::ics03_connection::context::{ConnectionKeeper, ConnectionReader};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader, ChannelReaderLightClient};
+use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader};
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
 use crate::core::ics04_channel::packet::Packet;
@@ -31,7 +31,6 @@ pub trait Ics26Context:
     + ConnectionKeeper
     + ChannelKeeper
     + ChannelReader
-    + ChannelReaderLightClient
     + PortReader
 {
     type Router: Router;

--- a/modules/src/mock/client_state.rs
+++ b/modules/src/mock/client_state.rs
@@ -2,7 +2,7 @@ use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::ChannelReaderLightClient;
+use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -257,7 +257,7 @@ impl ClientState for MockClientState {
 
     fn verify_packet_data(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -272,7 +272,7 @@ impl ClientState for MockClientState {
 
     fn verify_packet_acknowledgement(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -287,7 +287,7 @@ impl ClientState for MockClientState {
 
     fn verify_next_sequence_recv(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -301,7 +301,7 @@ impl ClientState for MockClientState {
 
     fn verify_packet_receipt_absence(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,

--- a/relayer/src/client_state.rs
+++ b/relayer/src/client_state.rs
@@ -20,7 +20,7 @@ use ibc::core::ics02_client::trust_threshold::TrustThreshold;
 use ibc::core::ics03_connection::connection::ConnectionEnd;
 use ibc::core::ics04_channel::channel::ChannelEnd;
 use ibc::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use ibc::core::ics04_channel::context::ChannelReaderLightClient;
+use ibc::core::ics04_channel::context::ChannelReader;
 use ibc::core::ics04_channel::packet::Sequence;
 use ibc::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
@@ -292,7 +292,7 @@ impl ClientState for AnyClientState {
 
     fn verify_packet_data(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -307,7 +307,7 @@ impl ClientState for AnyClientState {
 
     fn verify_packet_acknowledgement(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -322,7 +322,7 @@ impl ClientState for AnyClientState {
 
     fn verify_next_sequence_recv(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -336,7 +336,7 @@ impl ClientState for AnyClientState {
 
     fn verify_packet_receipt_absence(
         &self,
-        _ctx: &dyn ChannelReaderLightClient,
+        _ctx: &dyn ChannelReader,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,


### PR DESCRIPTION
See comment -> https://github.com/informalsystems/ibc-rs/pull/2332#discussion_r932524874
The initial idea was to make `ChannelReaderLightClient` a supertrait of `ChannelReader`, and restrict access for the light clients to methods defined in `ChannelReaderLightClient`, but I found it more robust to remove `ChannelReaderLightClient` altogether and not enforce such restrictions. 

**Note**: Target branch is `plafer/merge-clientdef-clientstate`, so the plan is to merge this into #2570 first before merging with the long-lived branch. 
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
