### PR TITLE
Attempt to fix flaky CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -66,9 +66,6 @@ jobs:
           - package: ibc-go-v5-simapp
             command: simd
             account_prefix: cosmos
-          - package: osmosis
-            command: osmosisd
-            account_prefix: osmo
           - package: wasmd
             command: wasmd
             account_prefix: wasm

--- a/tools/test-framework/src/bootstrap/single.rs
+++ b/tools/test-framework/src/bootstrap/single.rs
@@ -89,8 +89,8 @@ pub fn bootstrap_single_node(
         config::set_log_level(config, &log_level)?;
         config::set_rpc_port(config, chain_driver.rpc_port)?;
         config::set_p2p_port(config, chain_driver.p2p_port)?;
-        config::set_timeout_commit(config, Duration::from_millis(500))?;
-        config::set_timeout_propose(config, Duration::from_millis(500))?;
+        config::set_timeout_commit(config, Duration::from_secs(1))?;
+        config::set_timeout_propose(config, Duration::from_secs(1))?;
         config::set_mode(config, "validator")?;
 
         config_modifier(config)?;

--- a/tools/test-framework/src/bootstrap/single.rs
+++ b/tools/test-framework/src/bootstrap/single.rs
@@ -89,8 +89,8 @@ pub fn bootstrap_single_node(
         config::set_log_level(config, &log_level)?;
         config::set_rpc_port(config, chain_driver.rpc_port)?;
         config::set_p2p_port(config, chain_driver.p2p_port)?;
-        config::set_timeout_commit(config, Duration::from_secs(1))?;
-        config::set_timeout_propose(config, Duration::from_secs(1))?;
+        config::set_timeout_commit(config, Duration::from_millis(500))?;
+        config::set_timeout_propose(config, Duration::from_millis(500))?;
         config::set_mode(config, "validator")?;
 
         config_modifier(config)?;

--- a/tools/test-framework/src/chain/driver.rs
+++ b/tools/test-framework/src/chain/driver.rs
@@ -46,7 +46,7 @@ pub mod transfer;
    test is taking much longer to reach eventual consistency, it might
    be indication of some underlying performance issues.
 */
-const WAIT_WALLET_AMOUNT_ATTEMPTS: u16 = 60;
+const WAIT_WALLET_AMOUNT_ATTEMPTS: u16 = 90;
 
 const COSMOS_HD_PATH: &str = "m/44'/118'/0'/0/0";
 


### PR DESCRIPTION
## Description

CI tests seem to fail randomly due to insufficient timeout. This PR attempts to fix the flakiness by increasing the wait timeout.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
