### PR TITLE
Update ibc-go v5 in Nix to v5.0.0-rc0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         "wasmvm_1_beta7-src": "wasmvm_1_beta7-src"
       },
       "locked": {
-        "lastModified": 1660724476,
-        "narHash": "sha256-kGicJwpss+cIJKBH/iGdKGGtRTbelBh9LLivadWp/mI=",
+        "lastModified": 1661339879,
+        "narHash": "sha256-vqa9bMZ6o5UceNRm0ccAzkdl0U08L6Ya2zjWwEvHhjI=",
         "owner": "informalsystems",
         "repo": "cosmos.nix",
-        "rev": "8fc379f4a2d2bfb5d7c8f51ac13d0ceb1b1a7e37",
+        "rev": "be31b0dd7df0da1eb7a9b47be9fe18ed1e77a067",
         "type": "github"
       },
       "original": {
@@ -311,16 +311,16 @@
     "ibc-go-v5-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1659384529,
-        "narHash": "sha256-tMV4Aesa9IY6TXxpLo9aIsRFKJDVSIlZqR8OlWP9/3g=",
+        "lastModified": 1661286040,
+        "narHash": "sha256-FMA4xixPb25Qq2nzjj6Io3+QpCWFL5nJ5yYzQFZCJaE=",
         "owner": "cosmos",
         "repo": "ibc-go",
-        "rev": "662a9a82735e1928ec914058589fe0f36b0283ae",
+        "rev": "f106b747a0f3895e9b468d25057f2d949cfdb9a7",
         "type": "github"
       },
       "original": {
         "owner": "cosmos",
-        "ref": "v5.0.0-beta1",
+        "ref": "v5.0.0-rc0",
         "repo": "ibc-go",
         "type": "github"
       }
@@ -458,11 +458,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1660639432,
-        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
+        "lastModified": 1661239106,
+        "narHash": "sha256-C5OCLnrv2c4CHs9DMEtYKkjJmGL7ySAZ1PqPkHBonxQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
+        "rev": "963d27a0767422be9b8686a8493dcade6acee992",
         "type": "github"
       },
       "original": {

--- a/tools/integration-test/src/tests/tendermint/sequential.rs
+++ b/tools/integration-test/src/tests/tendermint/sequential.rs
@@ -24,7 +24,7 @@ impl TestOverrides for SequentialCommitTest {
         config::set_timeout_commit(config, BLOCK_TIME)?;
         config::set_timeout_propose(config, BLOCK_TIME)?;
 
-        // Enable priority mempool. Note that this is not working currently
+        // Enable priority mempool
         config::set_mempool_version(config, "v1")?;
 
         Ok(())

--- a/tools/test-framework/src/chain/config.rs
+++ b/tools/test-framework/src/chain/config.rs
@@ -79,7 +79,7 @@ pub fn set_mempool_version(config: &mut Value, version: &str) -> Result<(), Erro
         .ok_or_else(|| eyre!("expect mempool section"))?
         .as_table_mut()
         .ok_or_else(|| eyre!("expect object"))?
-        .insert("mempool_version".to_string(), version.into());
+        .insert("version".to_string(), version.into());
 
     Ok(())
 }


### PR DESCRIPTION
Follow up on https://github.com/informalsystems/cosmos.nix/pull/96

## Description

The priority mempool feature is now properly working in ibc-go v5.0.0-rc0. You can manually check it by setting the mempool version to an invalid version like `v2`, which should cause the test to fail. This can be tested in `test_sequential_commit`, which calls `config::set_mempool_version` to set the version to `v1`, which has the prority mempool.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
