### PR TITLE
Print out both STDOUT and STDERR when full nodes fail to start in tests

### DIFF
--- a/tools/test-framework/src/bootstrap/single.rs
+++ b/tools/test-framework/src/bootstrap/single.rs
@@ -53,7 +53,7 @@ pub fn bootstrap_single_node(
     // Evmos requires of at least 1_000_000_000_000_000_000 or else there will be the
     // error `error during handshake: error on replay: validator set is nil in genesis and still empty after InitChain`
     // when running `evmosd start`.
-    let initial_amount = random_u64_range(1_000_000_000_000_000_000, u64::MAX);
+    let initial_amount = random_u64_range(1_000_000_000_000_000_000, 2_000_000_000_000_000_000);
 
     let chain_driver = builder.new_chain(prefix, use_random_id)?;
 

--- a/tools/test-framework/src/chain/cli/bootstrap.rs
+++ b/tools/test-framework/src/chain/cli/bootstrap.rs
@@ -173,10 +173,13 @@ pub fn start_chain(
     match status {
         None => Ok(ChildProcess::new(child)),
         Some(status) => {
+            let stdout_output = fs::read_to_string(stdout_path)?;
             let stderr_output = fs::read_to_string(stderr_path)?;
+
             Err(eyre!(
-                "expected full node process to be running, but it exited immediately with exit status {} and STDERR: {}",
+                "expected full node process to be running, but it exited immediately with exit status {} and output: {}\n{}",
                 status,
+                stdout_output,
                 stderr_output,
             ).into())
         }


### PR DESCRIPTION
## Description

Try to debug the flaky failures in CI caused by full nodes failing to start during integration tests.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
