### PR TITLE
Change `max_tx_size`'s default value from 2MB to ~180kb

### DIFF
--- a/relayer/src/config/types.rs
+++ b/relayer/src/config/types.rs
@@ -112,7 +112,7 @@ pub mod max_tx_size {
     pub struct MaxTxSize(usize);
 
     impl MaxTxSize {
-        const DEFAULT: usize = 2 * 1048576; // 2 MBytes
+        const DEFAULT: usize = 180000;
         const MAX_BOUND: usize = 8 * 1048576; // 8 MBytes
 
         pub fn new(value: usize) -> Result<Self, Error> {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #2595 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Change `max_tx_size`'s default value from 2MB to ~180kb to avoid warnings when using a config with the default value as described in #2595. The value (180kb) was chosen from operator's config.
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests: integration (for Hermes) or unit/mock tests (for modules).
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
