### PR TITLE
Make `ClientState` not optional in `MsgConnectionOpen{Try,Ack}`

### DIFF
--- a/.changelog/unreleased/breaking-changes/159-clientstate-not-optional.md
+++ b/.changelog/unreleased/breaking-changes/159-clientstate-not-optional.md
@@ -1,0 +1,3 @@
+- Make `client_state` field required in `MsgConnectionOpenTry` and
+  `MsgConnectionOpenAck`. Necessary for correctness according to spec.  
+  ([#159](https://github.com/cosmos/ibc-rs/issues/159)).

--- a/crates/ibc/src/core/ics03_connection/error.rs
+++ b/crates/ibc/src/core/ics03_connection/error.rs
@@ -122,6 +122,8 @@ define_error! {
 
         MissingCounterpartyPrefix
             | _ | { "missing counterparty prefix" },
+        MissingClientState
+            | _ | { "missing client state" },
 
         NullClientProof
             | _ | { "client proof must be present" },

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -4,7 +4,7 @@ use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, Sta
 use crate::core::ics03_connection::context::ConnectionReader;
 use crate::core::ics03_connection::error::Error;
 use crate::core::ics03_connection::events::Attributes;
-use crate::core::ics03_connection::handler::verify::verify_proofs;
+use crate::core::ics03_connection::handler::verify;
 use crate::core::ics03_connection::handler::{ConnectionIdState, ConnectionResult};
 use crate::core::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenConfirm;
 use crate::events::IbcEvent;
@@ -39,15 +39,17 @@ pub(crate) fn process(
         conn_end.delay_period(),
     );
 
-    // 2. Pass the details to the verification function.
-    verify_proofs(
+    verify::verify_connection_proof(
         ctx,
-        None,
         msg.proofs.height(),
         &conn_end,
         &expected_conn,
-        &msg.proofs,
+        msg.proofs.height(),
+        msg.proofs.object_proof(),
     )?;
+    if let Some(proof) = msg.proofs.consensus_proof() {
+        verify::verify_consensus_proof(ctx, msg.proofs.height(), &conn_end, &proof)?;
+    }
 
     output.log("success: connection verification passed");
 

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -47,9 +47,6 @@ pub(crate) fn process(
         msg.proofs.height(),
         msg.proofs.object_proof(),
     )?;
-    if let Some(proof) = msg.proofs.consensus_proof() {
-        verify::verify_consensus_proof(ctx, msg.proofs.height(), &conn_end, &proof)?;
-    }
 
     output.log("success: connection verification passed");
 

--- a/crates/ibc/src/core/ics03_connection/handler/verify.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/verify.rs
@@ -12,7 +12,7 @@ use crate::Height;
 /// Entry point for verifying all proofs bundled in any ICS3 message.
 pub fn verify_proofs(
     ctx: &dyn ConnectionReader,
-    client_state: Option<Any>,
+    expected_client_state: Any,
     height: Height,
     connection_end: &ConnectionEnd,
     expected_conn: &ConnectionEnd,
@@ -28,19 +28,17 @@ pub fn verify_proofs(
     )?;
 
     // If the message includes a client state, then verify the proof for that state.
-    if let Some(expected_client_state) = client_state {
-        verify_client_proof(
-            ctx,
-            height,
-            connection_end,
-            expected_client_state,
-            proofs.height(),
-            proofs
-                .client_proof()
-                .as_ref()
-                .ok_or_else(Error::null_client_proof)?,
-        )?;
-    }
+    verify_client_proof(
+        ctx,
+        height,
+        connection_end,
+        expected_client_state,
+        proofs.height(),
+        proofs
+            .client_proof()
+            .as_ref()
+            .ok_or_else(Error::null_client_proof)?,
+    )?;
 
     // If a consensus proof is attached to the message, then verify it.
     if let Some(proof) = proofs.consensus_proof() {

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -126,8 +126,11 @@ impl From<MsgConnectionOpenAck> for RawMsgConnectionOpenAck {
 
 #[cfg(test)]
 pub mod test_util {
+    use crate::core::ics02_client::height::Height;
+    use crate::mock::client_state::MockClientState;
+    use crate::mock::header::MockHeader;
     use crate::prelude::*;
-    use ibc_proto::ibc::core::client::v1::Height;
+    use ibc_proto::ibc::core::client::v1::Height as RawHeight;
     use ibc_proto::ibc::core::connection::v1::MsgConnectionOpenAck as RawMsgConnectionOpenAck;
 
     use crate::core::ics03_connection::version::Version;
@@ -138,20 +141,21 @@ pub mod test_util {
         proof_height: u64,
         consensus_height: u64,
     ) -> RawMsgConnectionOpenAck {
+        let client_state_height = Height::new(0, consensus_height).unwrap();
         RawMsgConnectionOpenAck {
             connection_id: ConnectionId::new(0).to_string(),
             counterparty_connection_id: ConnectionId::new(1).to_string(),
             proof_try: get_dummy_proof(),
-            proof_height: Some(Height {
+            proof_height: Some(RawHeight {
                 revision_number: 0,
                 revision_height: proof_height,
             }),
             proof_consensus: get_dummy_proof(),
-            consensus_height: Some(Height {
+            consensus_height: Some(RawHeight {
                 revision_number: 0,
                 revision_height: consensus_height,
             }),
-            client_state: None,
+            client_state: Some(MockClientState::new(MockHeader::new(client_state_height)).into()),
             proof_client: get_dummy_proof(),
             version: Some(Version::default().into()),
             signer: get_dummy_bech32_account(),

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -20,7 +20,7 @@ pub const TYPE_URL: &str = "/ibc.core.connection.v1.MsgConnectionOpenAck";
 pub struct MsgConnectionOpenAck {
     pub connection_id: ConnectionId,
     pub counterparty_connection_id: ConnectionId,
-    pub client_state: Option<Any>,
+    pub client_state: Any,
     pub proofs: Proofs,
     pub version: Version,
     pub signer: Signer,
@@ -82,7 +82,7 @@ impl TryFrom<RawMsgConnectionOpenAck> for MsgConnectionOpenAck {
                 .counterparty_connection_id
                 .parse()
                 .map_err(Error::invalid_identifier)?,
-            client_state: msg.client_state,
+            client_state: msg.client_state.ok_or_else(Error::missing_client_state)?,
             version: msg.version.ok_or_else(Error::empty_versions)?.try_into()?,
             proofs: Proofs::new(
                 msg.proof_try.try_into().map_err(Error::invalid_proof)?,
@@ -102,7 +102,7 @@ impl From<MsgConnectionOpenAck> for RawMsgConnectionOpenAck {
         RawMsgConnectionOpenAck {
             connection_id: ics_msg.connection_id.as_str().to_string(),
             counterparty_connection_id: ics_msg.counterparty_connection_id.as_str().to_string(),
-            client_state: ics_msg.client_state,
+            client_state: Some(ics_msg.client_state),
             proof_height: Some(ics_msg.proofs.height().into()),
             proof_try: ics_msg.proofs.object_proof().clone().into(),
             proof_client: ics_msg

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -161,8 +161,11 @@ impl From<MsgConnectionOpenTry> for RawMsgConnectionOpenTry {
 
 #[cfg(test)]
 pub mod test_util {
+    use crate::core::ics02_client::height::Height;
+    use crate::mock::client_state::MockClientState;
+    use crate::mock::header::MockHeader;
     use crate::prelude::*;
-    use ibc_proto::ibc::core::client::v1::Height;
+    use ibc_proto::ibc::core::client::v1::Height as RawHeight;
     use ibc_proto::ibc::core::connection::v1::MsgConnectionOpenTry as RawMsgConnectionOpenTry;
 
     use crate::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
@@ -198,10 +201,11 @@ pub mod test_util {
         proof_height: u64,
         consensus_height: u64,
     ) -> RawMsgConnectionOpenTry {
+        let client_state_height = Height::new(0, consensus_height).unwrap();
         RawMsgConnectionOpenTry {
             client_id: ClientId::default().to_string(),
             previous_connection_id: ConnectionId::default().to_string(),
-            client_state: None,
+            client_state: Some(MockClientState::new(MockHeader::new(client_state_height)).into()),
             counterparty: Some(get_dummy_raw_counterparty()),
             delay_period: 0,
             counterparty_versions: get_compatible_versions()
@@ -209,12 +213,12 @@ pub mod test_util {
                 .map(|v| v.clone().into())
                 .collect(),
             proof_init: get_dummy_proof(),
-            proof_height: Some(Height {
+            proof_height: Some(RawHeight {
                 revision_number: 0,
                 revision_height: proof_height,
             }),
             proof_consensus: get_dummy_proof(),
-            consensus_height: Some(Height {
+            consensus_height: Some(RawHeight {
                 revision_number: 0,
                 revision_height: consensus_height,
             }),

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -29,7 +29,7 @@ pub const TYPE_URL: &str = "/ibc.core.connection.v1.MsgConnectionOpenTry";
 pub struct MsgConnectionOpenTry {
     pub previous_connection_id: Option<ConnectionId>,
     pub client_id: ClientId,
-    pub client_state: Option<Any>,
+    pub client_state: Any,
     pub counterparty: Counterparty,
     pub counterparty_versions: Vec<Version>,
     pub proofs: Proofs,
@@ -104,7 +104,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
         Ok(Self {
             previous_connection_id,
             client_id: msg.client_id.parse().map_err(Error::invalid_identifier)?,
-            client_state: msg.client_state,
+            client_state: msg.client_state.ok_or_else(Error::missing_client_state)?,
             counterparty: msg
                 .counterparty
                 .ok_or_else(Error::missing_counterparty)?
@@ -131,7 +131,7 @@ impl From<MsgConnectionOpenTry> for RawMsgConnectionOpenTry {
             previous_connection_id: ics_msg
                 .previous_connection_id
                 .map_or_else(|| "".to_string(), |v| v.as_str().to_string()),
-            client_state: ics_msg.client_state,
+            client_state: Some(ics_msg.client_state),
             counterparty: Some(ics_msg.counterparty.into()),
             delay_period: ics_msg.delay_period.as_nanos() as u64,
             counterparty_versions: ics_msg

--- a/crates/ibc/tests/runner/mod.rs
+++ b/crates/ibc/tests/runner/mod.rs
@@ -380,7 +380,7 @@ impl IbcTestRunner {
                         previous_connection_id: previous_connection_id.map(Self::connection_id),
                         client_id: Self::client_id(client_id),
                         // TODO: is this ever needed?
-                        client_state: None,
+                        client_state: Self::client_state(client_state).into(),
                         counterparty: Self::counterparty(
                             counterparty_client_id,
                             Some(counterparty_connection_id),
@@ -409,7 +409,7 @@ impl IbcTestRunner {
                         connection_id: Self::connection_id(connection_id),
                         counterparty_connection_id: Self::connection_id(counterparty_connection_id),
                         // TODO: is this ever needed?
-                        client_state: None,
+                        client_state: Self::client_state(client_state).into(),
                         proofs: Self::proofs(client_state),
                         version: Self::version(),
                         signer: Self::signer(),


### PR DESCRIPTION
Closes: #159
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
