### PR TITLE
ics26_routing: Derive Hash for ModuleId

### DIFF
--- a/.changelog/unreleased/improvements/179-derive-hash-for-moduleid.md
+++ b/.changelog/unreleased/improvements/179-derive-hash-for-moduleid.md
@@ -1,0 +1,1 @@
+- Derive Hash for ModuleId ([#179](https://github.com/cosmos/ibc-rs/issues/179))

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -45,7 +45,7 @@ pub trait Ics26Context:
 #[derive(Debug, PartialEq, Eq)]
 pub struct InvalidModuleId;
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct ModuleId(String);
 
 impl ModuleId {


### PR DESCRIPTION
Signed-off-by: Kevin Ji <1146876+kevinji@users.noreply.github.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Derive Hash for ModuleId so it can be stored in a HashMap.
______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
