### PR TITLE
Make `ClientType` allow any string value

### DIFF
--- a/.changelog/unreleased/breaking-changes/188-clienttype.md
+++ b/.changelog/unreleased/breaking-changes/188-clienttype.md
@@ -1,0 +1,2 @@
+- Make ClientType allow any string value as opposed to just Tendermint
+  ([#188](https://github.com/cosmos/ibc-rs/issues/188))

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -47,6 +47,8 @@ use crate::Height;
 
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 
+pub(crate) const TENDERMINT_CLIENT_TYPE: &'static str = "07-tendermint";
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClientState {
     chain_id: ChainId,
@@ -262,7 +264,7 @@ impl Ics2ClientState for ClientState {
     }
 
     fn client_type(&self) -> ClientType {
-        ClientType::Tendermint
+        ClientType::new(TENDERMINT_CLIENT_TYPE)
     }
 
     fn latest_height(&self) -> Height {
@@ -764,15 +766,17 @@ fn verify_delay_passed(
 }
 
 fn downcast_tm_client_state(cs: &dyn Ics2ClientState) -> Result<&ClientState, Ics02Error> {
-    cs.as_any()
-        .downcast_ref::<ClientState>()
-        .ok_or_else(|| Ics02Error::client_args_type_mismatch(ClientType::Tendermint))
+    cs.as_any().downcast_ref::<ClientState>().ok_or_else(|| {
+        Ics02Error::client_args_type_mismatch(ClientType::new(TENDERMINT_CLIENT_TYPE))
+    })
 }
 
 fn downcast_tm_consensus_state(cs: &dyn ConsensusState) -> Result<TmConsensusState, Ics02Error> {
     cs.as_any()
         .downcast_ref::<TmConsensusState>()
-        .ok_or_else(|| Ics02Error::client_args_type_mismatch(ClientType::Tendermint))
+        .ok_or_else(|| {
+            Ics02Error::client_args_type_mismatch(ClientType::new(TENDERMINT_CLIENT_TYPE))
+        })
         .map(Clone::clone)
 }
 

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -45,9 +45,9 @@ use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, Connecti
 use crate::timestamp::{Timestamp, ZERO_DURATION};
 use crate::Height;
 
-pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
+use super::client_type as tm_client_type;
 
-pub(crate) const TENDERMINT_CLIENT_TYPE: &str = "07-tendermint";
+pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClientState {
@@ -264,7 +264,7 @@ impl Ics2ClientState for ClientState {
     }
 
     fn client_type(&self) -> ClientType {
-        ClientType::new(TENDERMINT_CLIENT_TYPE)
+        tm_client_type()
     }
 
     fn latest_height(&self) -> Height {
@@ -766,17 +766,15 @@ fn verify_delay_passed(
 }
 
 fn downcast_tm_client_state(cs: &dyn Ics2ClientState) -> Result<&ClientState, Ics02Error> {
-    cs.as_any().downcast_ref::<ClientState>().ok_or_else(|| {
-        Ics02Error::client_args_type_mismatch(ClientType::new(TENDERMINT_CLIENT_TYPE))
-    })
+    cs.as_any()
+        .downcast_ref::<ClientState>()
+        .ok_or_else(|| Ics02Error::client_args_type_mismatch(tm_client_type()))
 }
 
 fn downcast_tm_consensus_state(cs: &dyn ConsensusState) -> Result<TmConsensusState, Ics02Error> {
     cs.as_any()
         .downcast_ref::<TmConsensusState>()
-        .ok_or_else(|| {
-            Ics02Error::client_args_type_mismatch(ClientType::new(TENDERMINT_CLIENT_TYPE))
-        })
+        .ok_or_else(|| Ics02Error::client_args_type_mismatch(tm_client_type()))
         .map(Clone::clone)
 }
 

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -47,7 +47,7 @@ use crate::Height;
 
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 
-pub(crate) const TENDERMINT_CLIENT_TYPE: &'static str = "07-tendermint";
+pub(crate) const TENDERMINT_CLIENT_TYPE: &str = "07-tendermint";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClientState {

--- a/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
@@ -14,6 +14,8 @@ use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
 use crate::timestamp::Timestamp;
 
+use super::client_state::TENDERMINT_CLIENT_TYPE;
+
 pub const TENDERMINT_CONSENSUS_STATE_TYPE_URL: &str =
     "/ibc.lightclients.tendermint.v1.ConsensusState";
 
@@ -36,7 +38,7 @@ impl ConsensusState {
 
 impl crate::core::ics02_client::consensus_state::ConsensusState for ConsensusState {
     fn client_type(&self) -> ClientType {
-        ClientType::Tendermint
+        ClientType::new(TENDERMINT_CLIENT_TYPE)
     }
 
     fn root(&self) -> &CommitmentRoot {

--- a/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
@@ -14,7 +14,7 @@ use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
 use crate::timestamp::Timestamp;
 
-use super::client_state::TENDERMINT_CLIENT_TYPE;
+use super::client_type as tm_client_type;
 
 pub const TENDERMINT_CONSENSUS_STATE_TYPE_URL: &str =
     "/ibc.lightclients.tendermint.v1.ConsensusState";
@@ -38,7 +38,7 @@ impl ConsensusState {
 
 impl crate::core::ics02_client::consensus_state::ConsensusState for ConsensusState {
     fn client_type(&self) -> ClientType {
-        ClientType::new(TENDERMINT_CLIENT_TYPE)
+        tm_client_type()
     }
 
     fn root(&self) -> &CommitmentRoot {

--- a/crates/ibc/src/clients/ics07_tendermint/header.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/header.rs
@@ -19,6 +19,8 @@ use crate::timestamp::Timestamp;
 use crate::utils::pretty::{PrettySignedHeader, PrettyValidatorSet};
 use crate::Height;
 
+use super::client_state::TENDERMINT_CLIENT_TYPE;
+
 pub const TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.Header";
 
 /// Tendermint consensus header
@@ -79,7 +81,7 @@ pub fn headers_compatible(header: &SignedHeader, other: &SignedHeader) -> bool {
 
 impl crate::core::ics02_client::header::Header for Header {
     fn client_type(&self) -> ClientType {
-        ClientType::Tendermint
+        ClientType::new(TENDERMINT_CLIENT_TYPE)
     }
 
     fn height(&self) -> Height {

--- a/crates/ibc/src/clients/ics07_tendermint/header.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/header.rs
@@ -19,7 +19,7 @@ use crate::timestamp::Timestamp;
 use crate::utils::pretty::{PrettySignedHeader, PrettyValidatorSet};
 use crate::Height;
 
-use super::client_state::TENDERMINT_CLIENT_TYPE;
+use super::client_type as tm_client_type;
 
 pub const TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.Header";
 
@@ -81,7 +81,7 @@ pub fn headers_compatible(header: &SignedHeader, other: &SignedHeader) -> bool {
 
 impl crate::core::ics02_client::header::Header for Header {
     fn client_type(&self) -> ClientType {
-        ClientType::new(TENDERMINT_CLIENT_TYPE)
+        tm_client_type()
     }
 
     fn height(&self) -> Height {

--- a/crates/ibc/src/clients/ics07_tendermint/mod.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/mod.rs
@@ -1,8 +1,16 @@
 //! ICS 07: Tendermint Client implements a client verification algorithm for blockchains which use
 //! the Tendermint consensus algorithm.
 
+use crate::core::ics02_client::client_type::ClientType;
+
 pub mod client_state;
 pub mod consensus_state;
 pub mod error;
 pub mod header;
 pub mod misbehaviour;
+
+pub(crate) const TENDERMINT_CLIENT_TYPE: &str = "07-tendermint";
+
+pub fn client_type() -> ClientType {
+    ClientType::new(TENDERMINT_CLIENT_TYPE)
+}

--- a/crates/ibc/src/core/ics02_client/client_type.rs
+++ b/crates/ibc/src/core/ics02_client/client_type.rs
@@ -2,111 +2,22 @@ use crate::prelude::*;
 use core::fmt::{Display, Error as FmtError, Formatter};
 use serde_derive::{Deserialize, Serialize};
 
-use super::error::Error;
-
 /// Type of the client, depending on the specific consensus algorithm.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub enum ClientType {
-    Tendermint = 1,
-
-    #[cfg(any(test, feature = "mocks"))]
-    Mock = 9999,
-}
+pub struct ClientType(&'static str);
 
 impl ClientType {
-    const TENDERMINT_STR: &'static str = "07-tendermint";
-
-    #[cfg_attr(not(test), allow(dead_code))]
-    const MOCK_STR: &'static str = "9999-mock";
-
+    pub fn new(s: &'static str) -> Self {
+        Self(s)
+    }
     /// Yields the identifier of this client type as a string
     pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Tendermint => Self::TENDERMINT_STR,
-
-            #[cfg(any(test, feature = "mocks"))]
-            Self::Mock => Self::MOCK_STR,
-        }
+        self.0
     }
 }
 
 impl Display for ClientType {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(f, "ClientType({})", self.as_str())
-    }
-}
-
-impl core::str::FromStr for ClientType {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            Self::TENDERMINT_STR => Ok(Self::Tendermint),
-
-            #[cfg(any(test, feature = "mocks"))]
-            Self::MOCK_STR => Ok(Self::Mock),
-
-            _ => Err(Error::unknown_client_type(s.to_string())),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use core::str::FromStr;
-    use test_log::test;
-
-    use super::ClientType;
-    use crate::core::ics02_client::error::{Error, ErrorDetail};
-
-    #[test]
-    fn parse_tendermint_client_type() {
-        let client_type = ClientType::from_str("07-tendermint");
-
-        match client_type {
-            Ok(ClientType::Tendermint) => (),
-            _ => panic!("parse failed"),
-        }
-    }
-
-    #[test]
-    fn parse_mock_client_type() {
-        let client_type = ClientType::from_str("9999-mock");
-
-        match client_type {
-            Ok(ClientType::Mock) => (),
-            _ => panic!("parse failed"),
-        }
-    }
-
-    #[test]
-    fn parse_unknown_client_type() {
-        let client_type_str = "some-random-client-type";
-        let result = ClientType::from_str(client_type_str);
-
-        match result {
-            Err(Error(ErrorDetail::UnknownClientType(e), _)) => {
-                assert_eq!(&e.client_type, client_type_str)
-            }
-            _ => {
-                panic!("Expected ClientType::from_str to fail with UnknownClientType, instead got",)
-            }
-        }
-    }
-
-    #[test]
-    fn parse_mock_as_string_result() {
-        let client_type = ClientType::Mock;
-        let type_string = client_type.as_str();
-        let client_type_from_str = ClientType::from_str(type_string).unwrap();
-        assert_eq!(client_type_from_str, client_type);
-    }
-
-    #[test]
-    fn parse_tendermint_as_string_result() {
-        let client_type = ClientType::Tendermint;
-        let type_string = client_type.as_str();
-        let client_type_from_str = ClientType::from_str(type_string).unwrap();
-        assert_eq!(client_type_from_str, client_type);
     }
 }

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -83,7 +83,7 @@ mod tests {
     use test_log::test;
 
     use crate::clients::ics07_tendermint::client_state::{
-        AllowUpdate, ClientState as TmClientState,
+        AllowUpdate, ClientState as TmClientState, TENDERMINT_CLIENT_TYPE,
     };
     use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConsensusState;
     use crate::clients::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
@@ -95,7 +95,7 @@ mod tests {
     use crate::core::ics23_commitment::specs::ProofSpecs;
     use crate::core::ics24_host::identifier::ClientId;
     use crate::handler::HandlerOutput;
-    use crate::mock::client_state::MockClientState;
+    use crate::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
     use crate::mock::consensus_state::MockConsensusState;
     use crate::mock::context::MockContext;
     use crate::mock::header::MockHeader;
@@ -119,10 +119,10 @@ mod tests {
 
         match output {
             Ok(HandlerOutput { result, .. }) => {
-                let expected_client_id = ClientId::new(ClientType::Mock, 0).unwrap();
+                let expected_client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
                 match result {
                     ClientResult::Create(create_result) => {
-                        assert_eq!(create_result.client_type, ClientType::Mock);
+                        assert_eq!(create_result.client_type, ClientType::new(MOCK_CLIENT_TYPE));
                         assert_eq!(create_result.client_id, expected_client_id);
                         assert_eq!(
                             create_result.client_state.as_ref().clone_into(),
@@ -180,7 +180,7 @@ mod tests {
         // The expected client id that will be generated will be identical to "9999-mock-0" for all
         // tests. This is because we're not persisting any client results (which is done via the
         // tests for `ics26_routing::dispatch`.
-        let expected_client_id = ClientId::new(ClientType::Mock, 0).unwrap();
+        let expected_client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
 
         for msg in create_client_msgs {
             let output = dispatch(&ctx, ClientMsg::CreateClient(msg.clone()));
@@ -250,10 +250,10 @@ mod tests {
 
         match output {
             Ok(HandlerOutput { result, .. }) => {
-                let expected_client_id = ClientId::new(ClientType::Tendermint, 0).unwrap();
+                let expected_client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
                 match result {
                     ClientResult::Create(create_res) => {
-                        assert_eq!(create_res.client_type, ClientType::Tendermint);
+                        assert_eq!(create_res.client_type, ClientType::new(TENDERMINT_CLIENT_TYPE));
                         assert_eq!(create_res.client_id, expected_client_id);
                         assert_eq!(
                             create_res.client_state.as_ref().clone_into(),

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -119,7 +119,8 @@ mod tests {
 
         match output {
             Ok(HandlerOutput { result, .. }) => {
-                let expected_client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
+                let expected_client_id =
+                    ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
                 match result {
                     ClientResult::Create(create_result) => {
                         assert_eq!(create_result.client_type, ClientType::new(MOCK_CLIENT_TYPE));
@@ -250,10 +251,14 @@ mod tests {
 
         match output {
             Ok(HandlerOutput { result, .. }) => {
-                let expected_client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+                let expected_client_id =
+                    ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
                 match result {
                     ClientResult::Create(create_res) => {
-                        assert_eq!(create_res.client_type, ClientType::new(TENDERMINT_CLIENT_TYPE));
+                        assert_eq!(
+                            create_res.client_type,
+                            ClientType::new(TENDERMINT_CLIENT_TYPE)
+                        );
                         assert_eq!(create_res.client_id, expected_client_id);
                         assert_eq!(
                             create_res.client_state.as_ref().clone_into(),

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -77,13 +77,14 @@ pub fn process(ctx: &dyn ClientReader, msg: MsgCreateClient) -> HandlerResult<Cl
 
 #[cfg(test)]
 mod tests {
+    use crate::clients::ics07_tendermint::client_type as tm_client_type;
     use crate::prelude::*;
 
     use core::time::Duration;
     use test_log::test;
 
     use crate::clients::ics07_tendermint::client_state::{
-        AllowUpdate, ClientState as TmClientState, TENDERMINT_CLIENT_TYPE,
+        AllowUpdate, ClientState as TmClientState,
     };
     use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConsensusState;
     use crate::clients::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
@@ -251,14 +252,10 @@ mod tests {
 
         match output {
             Ok(HandlerOutput { result, .. }) => {
-                let expected_client_id =
-                    ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+                let expected_client_id = ClientId::new(tm_client_type(), 0).unwrap();
                 match result {
                     ClientResult::Create(create_res) => {
-                        assert_eq!(
-                            create_res.client_type,
-                            ClientType::new(TENDERMINT_CLIENT_TYPE)
-                        );
+                        assert_eq!(create_res.client_type, tm_client_type());
                         assert_eq!(create_res.client_id, expected_client_id);
                         assert_eq!(
                             create_res.client_state.as_ref().clone_into(),

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -88,7 +88,6 @@ mod tests {
     };
     use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConsensusState;
     use crate::clients::ics07_tendermint::header::test_util::get_dummy_tendermint_header;
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::handler::{dispatch, ClientResult};
     use crate::core::ics02_client::msgs::create_client::MsgCreateClient;
     use crate::core::ics02_client::msgs::ClientMsg;
@@ -96,7 +95,7 @@ mod tests {
     use crate::core::ics23_commitment::specs::ProofSpecs;
     use crate::core::ics24_host::identifier::ClientId;
     use crate::handler::HandlerOutput;
-    use crate::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
+    use crate::mock::client_state::{client_type as mock_client_type, MockClientState};
     use crate::mock::consensus_state::MockConsensusState;
     use crate::mock::context::MockContext;
     use crate::mock::header::MockHeader;
@@ -120,11 +119,10 @@ mod tests {
 
         match output {
             Ok(HandlerOutput { result, .. }) => {
-                let expected_client_id =
-                    ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
+                let expected_client_id = ClientId::new(mock_client_type(), 0).unwrap();
                 match result {
                     ClientResult::Create(create_result) => {
-                        assert_eq!(create_result.client_type, ClientType::new(MOCK_CLIENT_TYPE));
+                        assert_eq!(create_result.client_type, mock_client_type());
                         assert_eq!(create_result.client_id, expected_client_id);
                         assert_eq!(
                             create_result.client_state.as_ref().clone_into(),
@@ -182,7 +180,7 @@ mod tests {
         // The expected client id that will be generated will be identical to "9999-mock-0" for all
         // tests. This is because we're not persisting any client results (which is done via the
         // tests for `ics26_routing::dispatch`.
-        let expected_client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
+        let expected_client_id = ClientId::new(mock_client_type(), 0).unwrap();
 
         for msg in create_client_msgs {
             let output = dispatch(&ctx, ClientMsg::CreateClient(msg.clone()));

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -107,6 +107,7 @@ mod tests {
     use ibc_proto::google::protobuf::Any;
     use test_log::test;
 
+    use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
     use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConsensusState;
     use crate::core::ics02_client::client_state::ClientState;
     use crate::core::ics02_client::client_type::ClientType;
@@ -119,7 +120,7 @@ mod tests {
     use crate::core::ics24_host::identifier::{ChainId, ClientId};
     use crate::events::IbcEvent;
     use crate::handler::HandlerOutput;
-    use crate::mock::client_state::MockClientState;
+    use crate::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
     use crate::mock::context::MockContext;
     use crate::mock::header::MockHeader;
     use crate::mock::host::{HostBlock, HostType};
@@ -239,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_adjacent_ok() {
-        let client_id = ClientId::new(ClientType::Tendermint, 0).unwrap();
+        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let update_height = Height::new(1, 21).unwrap();
 
@@ -252,7 +253,7 @@ mod tests {
         .with_client_parametrized(
             &client_id,
             client_height,
-            Some(ClientType::Tendermint), // The target host chain (B) is synthetic TM.
+            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -302,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_non_adjacent_ok() {
-        let client_id = ClientId::new(ClientType::Tendermint, 0).unwrap();
+        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let update_height = Height::new(1, 21).unwrap();
 
@@ -315,7 +316,7 @@ mod tests {
         .with_client_parametrized_history(
             &client_id,
             client_height,
-            Some(ClientType::Tendermint), // The target host chain (B) is synthetic TM.
+            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -366,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_duplicate_ok() {
-        let client_id = ClientId::new(ClientType::Tendermint, 0).unwrap();
+        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
 
         let chain_start_height = Height::new(1, 11).unwrap();
@@ -380,7 +381,7 @@ mod tests {
         .with_client_parametrized(
             &client_id,
             client_height,
-            Some(ClientType::Tendermint), // The target host chain (B) is synthetic TM.
+            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -442,7 +443,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_lower_height() {
-        let client_id = ClientId::new(ClientType::Tendermint, 0).unwrap();
+        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
 
         let client_update_height = Height::new(1, 19).unwrap();
@@ -458,7 +459,7 @@ mod tests {
         .with_client_parametrized(
             &client_id,
             client_height,
-            Some(ClientType::Tendermint), // The target host chain (B) is synthetic TM.
+            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -513,7 +514,7 @@ mod tests {
             downcast!(output.events.first().unwrap() => IbcEvent::UpdateClient).unwrap();
 
         assert_eq!(update_client_event.client_id(), &client_id);
-        assert_eq!(update_client_event.client_type(), &ClientType::Mock);
+        assert_eq!(update_client_event.client_type(), &ClientType::new(MOCK_CLIENT_TYPE));
         assert_eq!(update_client_event.consensus_height(), &height);
         assert_eq!(update_client_event.consensus_heights(), &vec![height]);
         assert_eq!(update_client_event.header(), &header);

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -514,7 +514,10 @@ mod tests {
             downcast!(output.events.first().unwrap() => IbcEvent::UpdateClient).unwrap();
 
         assert_eq!(update_client_event.client_id(), &client_id);
-        assert_eq!(update_client_event.client_type(), &ClientType::new(MOCK_CLIENT_TYPE));
+        assert_eq!(
+            update_client_event.client_type(),
+            &ClientType::new(MOCK_CLIENT_TYPE)
+        );
         assert_eq!(update_client_event.consensus_height(), &height);
         assert_eq!(update_client_event.consensus_heights(), &vec![height]);
         assert_eq!(update_client_event.header(), &header);

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -107,7 +107,7 @@ mod tests {
     use ibc_proto::google::protobuf::Any;
     use test_log::test;
 
-    use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
+    use crate::clients::ics07_tendermint::client_type as tm_client_type;
     use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConsensusState;
     use crate::core::ics02_client::client_state::ClientState;
     use crate::core::ics02_client::client_type::ClientType;
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_adjacent_ok() {
-        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+        let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let update_height = Height::new(1, 21).unwrap();
 
@@ -253,7 +253,7 @@ mod tests {
         .with_client_parametrized(
             &client_id,
             client_height,
-            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_non_adjacent_ok() {
-        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+        let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let update_height = Height::new(1, 21).unwrap();
 
@@ -316,7 +316,7 @@ mod tests {
         .with_client_parametrized_history(
             &client_id,
             client_height,
-            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_duplicate_ok() {
-        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+        let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
 
         let chain_start_height = Height::new(1, 11).unwrap();
@@ -381,7 +381,7 @@ mod tests {
         .with_client_parametrized(
             &client_id,
             client_height,
-            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 
@@ -443,7 +443,7 @@ mod tests {
 
     #[test]
     fn test_update_synthetic_tendermint_client_lower_height() {
-        let client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+        let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
 
         let client_update_height = Height::new(1, 19).unwrap();
@@ -459,7 +459,7 @@ mod tests {
         .with_client_parametrized(
             &client_id,
             client_height,
-            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
             Some(client_height),
         );
 

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -110,7 +110,6 @@ mod tests {
     use crate::clients::ics07_tendermint::client_type as tm_client_type;
     use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConsensusState;
     use crate::core::ics02_client::client_state::ClientState;
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::consensus_state::downcast_consensus_state;
     use crate::core::ics02_client::error::{Error, ErrorDetail};
     use crate::core::ics02_client::handler::dispatch;
@@ -120,7 +119,8 @@ mod tests {
     use crate::core::ics24_host::identifier::{ChainId, ClientId};
     use crate::events::IbcEvent;
     use crate::handler::HandlerOutput;
-    use crate::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
+    use crate::mock::client_state::client_type as mock_client_type;
+    use crate::mock::client_state::MockClientState;
     use crate::mock::context::MockContext;
     use crate::mock::header::MockHeader;
     use crate::mock::host::{HostBlock, HostType};
@@ -514,10 +514,7 @@ mod tests {
             downcast!(output.events.first().unwrap() => IbcEvent::UpdateClient).unwrap();
 
         assert_eq!(update_client_event.client_id(), &client_id);
-        assert_eq!(
-            update_client_event.client_type(),
-            &ClientType::new(MOCK_CLIENT_TYPE)
-        );
+        assert_eq!(update_client_event.client_type(), &mock_client_type());
         assert_eq!(update_client_event.consensus_height(), &height);
         assert_eq!(update_client_event.consensus_heights(), &vec![height]);
         assert_eq!(update_client_event.header(), &header);

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -222,7 +222,10 @@ mod tests {
         let upgrade_client_event =
             downcast!(output.events.first().unwrap() => IbcEvent::UpgradeClient).unwrap();
         assert_eq!(upgrade_client_event.client_id(), &client_id);
-        assert_eq!(upgrade_client_event.client_type(), &ClientType::new(MOCK_CLIENT_TYPE));
+        assert_eq!(
+            upgrade_client_event.client_type(),
+            &ClientType::new(MOCK_CLIENT_TYPE)
+        );
         assert_eq!(upgrade_client_event.consensus_height(), &upgrade_height);
     }
 }

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -89,7 +89,7 @@ mod tests {
     use crate::core::ics02_client::msgs::ClientMsg;
     use crate::core::ics24_host::identifier::ClientId;
     use crate::handler::HandlerOutput;
-    use crate::mock::client_state::MockClientState;
+    use crate::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
     use crate::mock::consensus_state::MockConsensusState;
     use crate::mock::context::MockContext;
     use crate::mock::header::MockHeader;
@@ -222,7 +222,7 @@ mod tests {
         let upgrade_client_event =
             downcast!(output.events.first().unwrap() => IbcEvent::UpgradeClient).unwrap();
         assert_eq!(upgrade_client_event.client_id(), &client_id);
-        assert_eq!(upgrade_client_event.client_type(), &ClientType::Mock);
+        assert_eq!(upgrade_client_event.client_type(), &ClientType::new(MOCK_CLIENT_TYPE));
         assert_eq!(upgrade_client_event.consensus_height(), &upgrade_height);
     }
 }

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -76,7 +76,6 @@ pub fn process(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::events::IbcEvent;
     use crate::{downcast, prelude::*};
 
@@ -89,7 +88,8 @@ mod tests {
     use crate::core::ics02_client::msgs::ClientMsg;
     use crate::core::ics24_host::identifier::ClientId;
     use crate::handler::HandlerOutput;
-    use crate::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
+    use crate::mock::client_state::client_type as mock_client_type;
+    use crate::mock::client_state::MockClientState;
     use crate::mock::consensus_state::MockConsensusState;
     use crate::mock::context::MockContext;
     use crate::mock::header::MockHeader;
@@ -222,10 +222,7 @@ mod tests {
         let upgrade_client_event =
             downcast!(output.events.first().unwrap() => IbcEvent::UpgradeClient).unwrap();
         assert_eq!(upgrade_client_event.client_id(), &client_id);
-        assert_eq!(
-            upgrade_client_event.client_type(),
-            &ClientType::new(MOCK_CLIENT_TYPE)
-        );
+        assert_eq!(upgrade_client_event.client_type(), &mock_client_type());
         assert_eq!(upgrade_client_event.consensus_height(), &upgrade_height);
     }
 }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -103,10 +103,8 @@ mod tests {
     use crate::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
     use crate::core::ics04_channel::msgs::ChannelMsg;
     use crate::events::IbcEvent;
-    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics03_connection::connection::ConnectionEnd;
     use crate::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
     use crate::core::ics03_connection::connection::State as ConnectionState;
@@ -119,12 +117,13 @@ mod tests {
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
 
+    use crate::mock::client_state::client_type as mock_client_type;
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
 
     #[test]
     fn chan_close_confirm_event_height() {
-        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 24).unwrap();
+        let client_id = ClientId::new(mock_client_type(), 24).unwrap();
         let conn_id = ConnectionId::new(2);
         let default_context = MockContext::default();
         let client_consensus_state_height = default_context.host_height();

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -103,6 +103,7 @@ mod tests {
     use crate::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
     use crate::core::ics04_channel::msgs::ChannelMsg;
     use crate::events::IbcEvent;
+    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
     use crate::core::ics02_client::client_type::ClientType;
@@ -123,7 +124,7 @@ mod tests {
 
     #[test]
     fn chan_close_confirm_event_height() {
-        let client_id = ClientId::new(ClientType::Mock, 24).unwrap();
+        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 24).unwrap();
         let conn_id = ConnectionId::new(2);
         let default_context = MockContext::default();
         let client_consensus_state_height = default_context.host_height();

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
@@ -74,10 +74,8 @@ mod tests {
     use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
     use crate::core::ics04_channel::msgs::ChannelMsg;
     use crate::events::IbcEvent;
-    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics03_connection::connection::ConnectionEnd;
     use crate::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
     use crate::core::ics03_connection::connection::State as ConnectionState;
@@ -90,12 +88,13 @@ mod tests {
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
 
+    use crate::mock::client_state::client_type as mock_client_type;
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
 
     #[test]
     fn chan_close_init_event_height() {
-        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 24).unwrap();
+        let client_id = ClientId::new(mock_client_type(), 24).unwrap();
         let conn_id = ConnectionId::new(2);
 
         let conn_end = ConnectionEnd::new(

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
@@ -74,6 +74,7 @@ mod tests {
     use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
     use crate::core::ics04_channel::msgs::ChannelMsg;
     use crate::events::IbcEvent;
+    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
     use crate::core::ics02_client::client_type::ClientType;
@@ -94,7 +95,7 @@ mod tests {
 
     #[test]
     fn chan_close_init_event_height() {
-        let client_id = ClientId::new(ClientType::Mock, 24).unwrap();
+        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 24).unwrap();
         let conn_id = ConnectionId::new(2);
 
         let conn_end = ConnectionEnd::new(

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -102,6 +102,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
 #[cfg(test)]
 mod tests {
+    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
     use test_log::test;
@@ -134,7 +135,7 @@ mod tests {
             msg: ChannelMsg,
             want_pass: bool,
         }
-        let client_id = ClientId::new(ClientType::Mock, 24).unwrap();
+        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 24).unwrap();
         let conn_id = ConnectionId::new(2);
         let context = MockContext::default();
         let client_consensus_state_height = context.host_current_height().revision_height();

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -102,12 +102,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
 #[cfg(test)]
 mod tests {
-    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
     use test_log::test;
 
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics03_connection::connection::ConnectionEnd;
     use crate::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
     use crate::core::ics03_connection::connection::State as ConnectionState;
@@ -122,6 +120,7 @@ mod tests {
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
     use crate::events::IbcEvent;
+    use crate::mock::client_state::client_type as mock_client_type;
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
     use crate::Height;
@@ -135,7 +134,7 @@ mod tests {
             msg: ChannelMsg,
             want_pass: bool,
         }
-        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 24).unwrap();
+        let client_id = ClientId::new(mock_client_type(), 24).unwrap();
         let conn_id = ConnectionId::new(2);
         let context = MockContext::default();
         let client_consensus_state_height = context.host_current_height().revision_height();

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -354,7 +354,11 @@ mod tests {
                                 ics03_error::Ics02ClientSubdetail {
                                     source: ics02_error::ErrorDetail::ClientNotFound(
                                         ics02_error::ClientNotFoundSubdetail {
-                                            client_id: ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 45).unwrap()
+                                            client_id: ClientId::new(
+                                                ClientType::new(MOCK_CLIENT_TYPE),
+                                                45
+                                            )
+                                            .unwrap()
                                         }
                                     )
                                 }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -148,12 +148,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
 #[cfg(test)]
 mod tests {
-    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
     use test_log::test;
 
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::error as ics02_error;
     use crate::core::ics03_connection::connection::ConnectionEnd;
     use crate::core::ics03_connection::connection::Counterparty as ConnectionCounterparty;
@@ -169,6 +167,7 @@ mod tests {
     use crate::core::ics04_channel::{error, Version};
     use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId};
     use crate::events::IbcEvent;
+    use crate::mock::client_state::client_type as mock_client_type;
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
     use crate::Height;
@@ -186,7 +185,7 @@ mod tests {
         // Some general-purpose variable to parametrize the messages and the context.
         let proof_height = 10;
         let conn_id = ConnectionId::new(2);
-        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 45).unwrap();
+        let client_id = ClientId::new(mock_client_type(), 45).unwrap();
 
         // The context. We'll reuse this same one across all tests.
         let context = MockContext::default();
@@ -354,11 +353,8 @@ mod tests {
                                 ics03_error::Ics02ClientSubdetail {
                                     source: ics02_error::ErrorDetail::ClientNotFound(
                                         ics02_error::ClientNotFoundSubdetail {
-                                            client_id: ClientId::new(
-                                                ClientType::new(MOCK_CLIENT_TYPE),
-                                                45
-                                            )
-                                            .unwrap()
+                                            client_id: ClientId::new(mock_client_type(), 45)
+                                                .unwrap()
                                         }
                                     )
                                 }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -148,6 +148,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
 #[cfg(test)]
 mod tests {
+    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::prelude::*;
 
     use test_log::test;
@@ -185,7 +186,7 @@ mod tests {
         // Some general-purpose variable to parametrize the messages and the context.
         let proof_height = 10;
         let conn_id = ConnectionId::new(2);
-        let client_id = ClientId::new(ClientType::Mock, 45).unwrap();
+        let client_id = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 45).unwrap();
 
         // The context. We'll reuse this same one across all tests.
         let context = MockContext::default();
@@ -353,7 +354,7 @@ mod tests {
                                 ics03_error::Ics02ClientSubdetail {
                                     source: ics02_error::ErrorDetail::ClientNotFound(
                                         ics02_error::ClientNotFoundSubdetail {
-                                            client_id: ClientId::new(ClientType::Mock, 45).unwrap()
+                                            client_id: ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 45).unwrap()
                                         }
                                     )
                                 }

--- a/crates/ibc/src/core/ics24_host/identifier.rs
+++ b/crates/ibc/src/core/ics24_host/identifier.rs
@@ -5,7 +5,7 @@ use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use super::validate::*;
-use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
+use crate::clients::ics07_tendermint::client_type as tm_client_type;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics24_host::error::ValidationError;
 use crate::prelude::*;
@@ -189,7 +189,7 @@ impl FromStr for ClientId {
 
 impl Default for ClientId {
     fn default() -> Self {
-        Self::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap()
+        Self::new(tm_client_type(), 0).unwrap()
     }
 }
 

--- a/crates/ibc/src/core/ics24_host/identifier.rs
+++ b/crates/ibc/src/core/ics24_host/identifier.rs
@@ -5,6 +5,7 @@ use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use super::validate::*;
+use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics24_host::error::ValidationError;
 use crate::prelude::*;
@@ -150,12 +151,12 @@ impl ClientId {
     /// ```
     /// # use ibc::core::ics24_host::identifier::ClientId;
     /// # use ibc::core::ics02_client::client_type::ClientType;
-    /// let tm_client_id = ClientId::new(ClientType::Tendermint, 0);
+    /// let tm_client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0);
     /// assert!(tm_client_id.is_ok());
     /// tm_client_id.map(|id| { assert_eq!(&id, "07-tendermint-0") });
     /// ```
-    pub fn new(ctype: ClientType, counter: u64) -> Result<Self, ValidationError> {
-        let prefix = Self::prefix(ctype);
+    pub fn new(client_type: ClientType, counter: u64) -> Result<Self, ValidationError> {
+        let prefix = client_type.as_str();
         let id = format!("{}-{}", prefix, counter);
         Self::from_str(id.as_str())
     }
@@ -163,18 +164,6 @@ impl ClientId {
     /// Get this identifier as a borrowed `&str`
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-
-    /// Returns one of the prefixes that should be present in any client identifiers.
-    /// The prefix is deterministic for a given chain type, hence all clients for a Tendermint-type
-    /// chain, for example, will have the prefix '07-tendermint'.
-    pub fn prefix(client_type: ClientType) -> &'static str {
-        match client_type {
-            ClientType::Tendermint => ClientType::Tendermint.as_str(),
-
-            #[cfg(any(test, feature = "mocks"))]
-            ClientType::Mock => ClientType::Mock.as_str(),
-        }
     }
 
     /// Get this identifier as a borrowed byte slice
@@ -200,7 +189,7 @@ impl FromStr for ClientId {
 
 impl Default for ClientId {
     fn default() -> Self {
-        Self::new(ClientType::Tendermint, 0).unwrap()
+        Self::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap()
     }
 }
 

--- a/crates/ibc/src/core/ics24_host/identifier.rs
+++ b/crates/ibc/src/core/ics24_host/identifier.rs
@@ -151,7 +151,7 @@ impl ClientId {
     /// ```
     /// # use ibc::core::ics24_host::identifier::ClientId;
     /// # use ibc::core::ics02_client::client_type::ClientType;
-    /// let tm_client_id = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0);
+    /// let tm_client_id = ClientId::new(ClientType::new("07-tendermint"), 0);
     /// assert!(tm_client_id.is_ok());
     /// tm_client_id.map(|id| { assert_eq!(&id, "07-tendermint-0") });
     /// ```

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -33,7 +33,7 @@ use crate::Height;
 
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 
-pub(crate) const MOCK_CLIENT_TYPE: &'static str = "9999-mock";
+pub const MOCK_CLIENT_TYPE: &str = "9999-mock";
 
 /// A mock of an IBC client record as it is stored in a mock context.
 /// For testing ICS02 handlers mostly, cf. `MockClientContext`.

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -27,6 +27,7 @@ use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
+use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::consensus_state::MockConsensusState;
 use crate::mock::header::MockHeader;
 use crate::Height;
@@ -34,6 +35,10 @@ use crate::Height;
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 
 pub const MOCK_CLIENT_TYPE: &str = "9999-mock";
+
+pub fn client_type() -> ClientType {
+    ClientType::new(MOCK_CLIENT_TYPE)
+}
 
 /// A mock of an IBC client record as it is stored in a mock context.
 /// For testing ICS02 handlers mostly, cf. `MockClientContext`.
@@ -136,7 +141,7 @@ impl ClientState for MockClientState {
     }
 
     fn client_type(&self) -> ClientType {
-        ClientType::new(MOCK_CLIENT_TYPE)
+        mock_client_type()
     }
 
     fn latest_height(&self) -> Height {

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -33,6 +33,8 @@ use crate::Height;
 
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 
+pub(crate) const MOCK_CLIENT_TYPE: &'static str = "9999-mock";
+
 /// A mock of an IBC client record as it is stored in a mock context.
 /// For testing ICS02 handlers mostly, cf. `MockClientContext`.
 #[derive(Clone, Debug)]
@@ -134,7 +136,7 @@ impl ClientState for MockClientState {
     }
 
     fn client_type(&self) -> ClientType {
-        ClientType::Mock
+        ClientType::new(MOCK_CLIENT_TYPE)
     }
 
     fn latest_height(&self) -> Height {

--- a/crates/ibc/src/mock/consensus_state.rs
+++ b/crates/ibc/src/mock/consensus_state.rs
@@ -12,6 +12,8 @@ use crate::core::ics23_commitment::commitment::CommitmentRoot;
 use crate::mock::header::MockHeader;
 use crate::timestamp::Timestamp;
 
+use super::client_state::MOCK_CLIENT_TYPE;
+
 pub const MOCK_CONSENSUS_STATE_TYPE_URL: &str = "/ibc.mock.ConsensusState";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,7 +98,7 @@ impl From<MockConsensusState> for Any {
 
 impl ConsensusState for MockConsensusState {
     fn client_type(&self) -> ClientType {
-        ClientType::Mock
+        ClientType::new(MOCK_CLIENT_TYPE)
     }
 
     fn root(&self) -> &CommitmentRoot {

--- a/crates/ibc/src/mock/consensus_state.rs
+++ b/crates/ibc/src/mock/consensus_state.rs
@@ -9,10 +9,9 @@ use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
+use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::header::MockHeader;
 use crate::timestamp::Timestamp;
-
-use super::client_state::MOCK_CLIENT_TYPE;
 
 pub const MOCK_CONSENSUS_STATE_TYPE_URL: &str = "/ibc.mock.ConsensusState";
 
@@ -98,7 +97,7 @@ impl From<MockConsensusState> for Any {
 
 impl ConsensusState for MockConsensusState {
     fn client_type(&self) -> ClientType {
-        ClientType::new(MOCK_CLIENT_TYPE)
+        mock_client_type()
     }
 
     fn root(&self) -> &CommitmentRoot {

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -41,7 +41,9 @@ use crate::core::ics26_routing::context::{Ics26Context, Module, ModuleId, Router
 use crate::core::ics26_routing::handler::{deliver, dispatch, MsgReceipt};
 use crate::core::ics26_routing::msgs::Ics26Envelope;
 use crate::events::IbcEvent;
-use crate::mock::client_state::{MockClientRecord, MockClientState};
+use crate::mock::client_state::{
+    client_type as mock_client_type, MockClientRecord, MockClientState,
+};
 use crate::mock::consensus_state::MockConsensusState;
 use crate::mock::header::MockHeader;
 use crate::mock::host::{HostBlock, HostType};
@@ -180,12 +182,7 @@ impl MockContext {
     /// to this client a mock client state and a mock consensus state for height `height`. The type
     /// of this client is implicitly assumed to be Mock.
     pub fn with_client(self, client_id: &ClientId, height: Height) -> Self {
-        self.with_client_parametrized(
-            client_id,
-            height,
-            Some(ClientType::new(MOCK_CLIENT_TYPE)),
-            Some(height),
-        )
+        self.with_client_parametrized(client_id, height, Some(mock_client_type()), Some(height))
     }
 
     /// Similar to `with_client`, this function associates a client record to this context, but
@@ -202,7 +199,7 @@ impl MockContext {
     ) -> Self {
         let cs_height = consensus_state_height.unwrap_or(client_state_height);
 
-        let client_type = client_type.unwrap_or_else(|| ClientType::new(MOCK_CLIENT_TYPE));
+        let client_type = client_type.unwrap_or_else(mock_client_type);
         let (client_state, consensus_state) = if client_type.as_str() == MOCK_CLIENT_TYPE {
             (
                 Some(MockClientState::new(MockHeader::new(client_state_height)).into_box()),
@@ -251,7 +248,7 @@ impl MockContext {
         let cs_height = consensus_state_height.unwrap_or(client_state_height);
         let prev_cs_height = cs_height.clone().sub(1).unwrap_or(client_state_height);
 
-        let client_type = client_type.unwrap_or_else(|| ClientType::new(MOCK_CLIENT_TYPE));
+        let client_type = client_type.unwrap_or_else(mock_client_type);
         let now = Timestamp::now();
 
         let (client_state, consensus_state) = if client_type.as_str() == MOCK_CLIENT_TYPE {
@@ -1353,7 +1350,7 @@ impl ClientKeeper for MockContext {
             .clients
             .entry(client_id)
             .or_insert(MockClientRecord {
-                client_type: ClientType::new(MOCK_CLIENT_TYPE),
+                client_type: mock_client_type(),
                 consensus_states: Default::default(),
                 client_state: Default::default(),
             });

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1,5 +1,6 @@
 //! Implementation of a global context mock. Used in testing handlers of all IBC modules.
 
+use crate::clients::ics07_tendermint::TENDERMINT_CLIENT_TYPE;
 use crate::prelude::*;
 
 use alloc::collections::btree_map::BTreeMap;
@@ -16,9 +17,7 @@ use sha2::Digest;
 use tracing::debug;
 
 use crate::clients::ics07_tendermint::client_state::test_util::get_dummy_tendermint_client_state;
-use crate::clients::ics07_tendermint::client_state::{
-    ClientState as TmClientState, TENDERMINT_CLIENT_TYPE,
-};
+use crate::clients::ics07_tendermint::client_state::ClientState as TmClientState;
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;

--- a/crates/ibc/src/mock/header.rs
+++ b/crates/ibc/src/mock/header.rs
@@ -12,6 +12,8 @@ use crate::core::ics02_client::header::Header;
 use crate::timestamp::Timestamp;
 use crate::Height;
 
+use super::client_state::MOCK_CLIENT_TYPE;
+
 pub const MOCK_HEADER_TYPE_URL: &str = "/ibc.mock.Header";
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -85,7 +87,7 @@ impl MockHeader {
 
 impl Header for MockHeader {
     fn client_type(&self) -> ClientType {
-        ClientType::Mock
+        ClientType::new(MOCK_CLIENT_TYPE)
     }
 
     fn height(&self) -> Height {

--- a/crates/ibc/src/mock/header.rs
+++ b/crates/ibc/src/mock/header.rs
@@ -9,10 +9,9 @@ use serde_derive::{Deserialize, Serialize};
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::header::Header;
+use crate::mock::client_state::client_type as mock_client_type;
 use crate::timestamp::Timestamp;
 use crate::Height;
-
-use super::client_state::MOCK_CLIENT_TYPE;
 
 pub const MOCK_HEADER_TYPE_URL: &str = "/ibc.mock.Header";
 
@@ -87,7 +86,7 @@ impl MockHeader {
 
 impl Header for MockHeader {
     fn client_type(&self) -> ClientType {
-        ClientType::new(MOCK_CLIENT_TYPE)
+        mock_client_type()
     }
 
     fn height(&self) -> Height {

--- a/crates/ibc/src/mock/host.rs
+++ b/crates/ibc/src/mock/host.rs
@@ -8,6 +8,7 @@ use tendermint::block::Header as TmHeader;
 use tendermint_testgen::light_block::TmLightBlock;
 use tendermint_testgen::{Generator, LightBlock as TestgenLightBlock};
 
+use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
 use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TMConsensusState;
 use crate::clients::ics07_tendermint::header::TENDERMINT_HEADER_TYPE_URL;
 use crate::core::ics02_client::client_type::ClientType;
@@ -20,6 +21,8 @@ use crate::mock::header::MockHeader;
 use crate::prelude::*;
 use crate::timestamp::Timestamp;
 use crate::Height;
+
+use super::client_state::MOCK_CLIENT_TYPE;
 
 /// Defines the different types of host chains that a mock context can emulate.
 /// The variants are as follows:
@@ -177,8 +180,8 @@ impl From<HostBlock> for Any {
 impl Header for HostBlock {
     fn client_type(&self) -> ClientType {
         match self {
-            HostBlock::Mock(_) => ClientType::Mock,
-            HostBlock::SyntheticTendermint(_) => ClientType::Tendermint,
+            HostBlock::Mock(_) => ClientType::new(MOCK_CLIENT_TYPE),
+            HostBlock::SyntheticTendermint(_) => ClientType::new(TENDERMINT_CLIENT_TYPE),
         }
     }
 

--- a/crates/ibc/src/mock/host.rs
+++ b/crates/ibc/src/mock/host.rs
@@ -8,7 +8,7 @@ use tendermint::block::Header as TmHeader;
 use tendermint_testgen::light_block::TmLightBlock;
 use tendermint_testgen::{Generator, LightBlock as TestgenLightBlock};
 
-use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
+use crate::clients::ics07_tendermint::client_type as tm_client_type;
 use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TMConsensusState;
 use crate::clients::ics07_tendermint::header::TENDERMINT_HEADER_TYPE_URL;
 use crate::core::ics02_client::client_type::ClientType;
@@ -181,7 +181,7 @@ impl Header for HostBlock {
     fn client_type(&self) -> ClientType {
         match self {
             HostBlock::Mock(_) => ClientType::new(MOCK_CLIENT_TYPE),
-            HostBlock::SyntheticTendermint(_) => ClientType::new(TENDERMINT_CLIENT_TYPE),
+            HostBlock::SyntheticTendermint(_) => tm_client_type(),
         }
     }
 

--- a/crates/ibc/src/mock/host.rs
+++ b/crates/ibc/src/mock/host.rs
@@ -16,13 +16,12 @@ use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::Error;
 use crate::core::ics02_client::header::Header;
 use crate::core::ics24_host::identifier::ChainId;
+use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::consensus_state::MockConsensusState;
 use crate::mock::header::MockHeader;
 use crate::prelude::*;
 use crate::timestamp::Timestamp;
 use crate::Height;
-
-use super::client_state::MOCK_CLIENT_TYPE;
 
 /// Defines the different types of host chains that a mock context can emulate.
 /// The variants are as follows:
@@ -180,7 +179,7 @@ impl From<HostBlock> for Any {
 impl Header for HostBlock {
     fn client_type(&self) -> ClientType {
         match self {
-            HostBlock::Mock(_) => ClientType::new(MOCK_CLIENT_TYPE),
+            HostBlock::Mock(_) => mock_client_type(),
             HostBlock::SyntheticTendermint(_) => tm_client_type(),
         }
     }

--- a/crates/ibc/src/relayer/ics18_relayer/utils.rs
+++ b/crates/ibc/src/relayer/ics18_relayer/utils.rs
@@ -49,7 +49,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
+    use crate::clients::ics07_tendermint::client_type as tm_client_type;
     use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::header::{downcast_header, Header};
     use crate::core::ics24_host::identifier::{ChainId, ClientId};
@@ -76,7 +76,7 @@ mod tests {
         let client_on_a_for_b_height = Height::new(1, 20).unwrap(); // Should be smaller than `chain_b_start_height`
         let num_iterations = 4;
 
-        let client_on_a_for_b = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+        let client_on_a_for_b = ClientId::new(tm_client_type(), 0).unwrap();
         let client_on_b_for_a = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
 
         // Create two mock contexts, one for each chain.
@@ -89,7 +89,7 @@ mod tests {
         .with_client_parametrized(
             &client_on_a_for_b,
             client_on_a_for_b_height,
-            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
             Some(client_on_a_for_b_height),
         );
         let mut ctx_b = MockContext::new(
@@ -164,10 +164,10 @@ mod tests {
 
             assert_eq!(
                 b_latest_header.client_type(),
-                ClientType::new(TENDERMINT_CLIENT_TYPE),
+                tm_client_type(),
                 "Client type verification in header failed for context B (TM); got {:?} but expected {:?}",
                 b_latest_header.client_type(),
-                ClientType::new(TENDERMINT_CLIENT_TYPE)
+                tm_client_type(),
             );
 
             let client_msg_a_res = build_client_update_datagram(

--- a/crates/ibc/src/relayer/ics18_relayer/utils.rs
+++ b/crates/ibc/src/relayer/ics18_relayer/utils.rs
@@ -50,11 +50,10 @@ where
 #[cfg(test)]
 mod tests {
     use crate::clients::ics07_tendermint::client_type as tm_client_type;
-    use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::header::{downcast_header, Header};
     use crate::core::ics24_host::identifier::{ChainId, ClientId};
     use crate::core::ics26_routing::msgs::Ics26Envelope;
-    use crate::mock::client_state::MOCK_CLIENT_TYPE;
+    use crate::mock::client_state::client_type as mock_client_type;
     use crate::mock::context::MockContext;
     use crate::mock::host::{HostBlock, HostType};
     use crate::prelude::*;
@@ -77,7 +76,7 @@ mod tests {
         let num_iterations = 4;
 
         let client_on_a_for_b = ClientId::new(tm_client_type(), 0).unwrap();
-        let client_on_b_for_a = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
+        let client_on_b_for_a = ClientId::new(mock_client_type(), 0).unwrap();
 
         // Create two mock contexts, one for each chain.
         let mut ctx_a = MockContext::new(
@@ -101,7 +100,7 @@ mod tests {
         .with_client_parametrized(
             &client_on_b_for_a,
             client_on_b_for_a_height,
-            Some(ClientType::new(MOCK_CLIENT_TYPE)), // The target host chain is mock.
+            Some(mock_client_type()), // The target host chain is mock.
             Some(client_on_b_for_a_height),
         );
 
@@ -111,10 +110,10 @@ mod tests {
             let a_latest_header = ctx_a.query_latest_header().unwrap();
             assert_eq!(
                 a_latest_header.client_type(),
-                ClientType::new(MOCK_CLIENT_TYPE),
+                mock_client_type(),
                 "Client type verification in header failed for context A (Mock); got {:?} but expected {:?}",
                 a_latest_header.client_type(),
-                ClientType::new(MOCK_CLIENT_TYPE)
+                mock_client_type()
             );
 
             let client_msg_b_res =

--- a/crates/ibc/src/relayer/ics18_relayer/utils.rs
+++ b/crates/ibc/src/relayer/ics18_relayer/utils.rs
@@ -49,10 +49,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::clients::ics07_tendermint::client_state::TENDERMINT_CLIENT_TYPE;
     use crate::core::ics02_client::client_type::ClientType;
     use crate::core::ics02_client::header::{downcast_header, Header};
     use crate::core::ics24_host::identifier::{ChainId, ClientId};
     use crate::core::ics26_routing::msgs::Ics26Envelope;
+    use crate::mock::client_state::MOCK_CLIENT_TYPE;
     use crate::mock::context::MockContext;
     use crate::mock::host::{HostBlock, HostType};
     use crate::prelude::*;
@@ -74,8 +76,8 @@ mod tests {
         let client_on_a_for_b_height = Height::new(1, 20).unwrap(); // Should be smaller than `chain_b_start_height`
         let num_iterations = 4;
 
-        let client_on_a_for_b = ClientId::new(ClientType::Tendermint, 0).unwrap();
-        let client_on_b_for_a = ClientId::new(ClientType::Mock, 0).unwrap();
+        let client_on_a_for_b = ClientId::new(ClientType::new(TENDERMINT_CLIENT_TYPE), 0).unwrap();
+        let client_on_b_for_a = ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), 0).unwrap();
 
         // Create two mock contexts, one for each chain.
         let mut ctx_a = MockContext::new(
@@ -87,7 +89,7 @@ mod tests {
         .with_client_parametrized(
             &client_on_a_for_b,
             client_on_a_for_b_height,
-            Some(ClientType::Tendermint), // The target host chain (B) is synthetic TM.
+            Some(ClientType::new(TENDERMINT_CLIENT_TYPE)), // The target host chain (B) is synthetic TM.
             Some(client_on_a_for_b_height),
         );
         let mut ctx_b = MockContext::new(
@@ -99,7 +101,7 @@ mod tests {
         .with_client_parametrized(
             &client_on_b_for_a,
             client_on_b_for_a_height,
-            Some(ClientType::Mock), // The target host chain is mock.
+            Some(ClientType::new(MOCK_CLIENT_TYPE)), // The target host chain is mock.
             Some(client_on_b_for_a_height),
         );
 
@@ -109,10 +111,10 @@ mod tests {
             let a_latest_header = ctx_a.query_latest_header().unwrap();
             assert_eq!(
                 a_latest_header.client_type(),
-                ClientType::Mock,
+                ClientType::new(MOCK_CLIENT_TYPE),
                 "Client type verification in header failed for context A (Mock); got {:?} but expected {:?}",
                 a_latest_header.client_type(),
-                ClientType::Mock
+                ClientType::new(MOCK_CLIENT_TYPE)
             );
 
             let client_msg_b_res =
@@ -162,10 +164,10 @@ mod tests {
 
             assert_eq!(
                 b_latest_header.client_type(),
-                ClientType::Tendermint,
+                ClientType::new(TENDERMINT_CLIENT_TYPE),
                 "Client type verification in header failed for context B (TM); got {:?} but expected {:?}",
                 b_latest_header.client_type(),
-                ClientType::Tendermint
+                ClientType::new(TENDERMINT_CLIENT_TYPE)
             );
 
             let client_msg_a_res = build_client_update_datagram(

--- a/crates/ibc/tests/runner/mod.rs
+++ b/crates/ibc/tests/runner/mod.rs
@@ -131,7 +131,7 @@ impl IbcTestRunner {
     }
 
     pub fn client_id(client_id: u64) -> ClientId {
-        ClientId::new(ClientType::Mock, client_id)
+        ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), client_id)
             .expect("it should be possible to create the client identifier")
     }
 

--- a/crates/ibc/tests/runner/mod.rs
+++ b/crates/ibc/tests/runner/mod.rs
@@ -25,7 +25,7 @@ use ibc::core::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofB
 use ibc::core::ics24_host::identifier::{ChainId, ClientId, ConnectionId};
 use ibc::core::ics26_routing::error as routing_error;
 use ibc::core::ics26_routing::msgs::Ics26Envelope;
-use ibc::mock::client_state::MockClientState;
+use ibc::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
 use ibc::mock::consensus_state::MockConsensusState;
 use ibc::mock::context::MockContext;
 use ibc::mock::header::MockHeader;

--- a/crates/ibc/tests/runner/mod.rs
+++ b/crates/ibc/tests/runner/mod.rs
@@ -5,7 +5,6 @@ use core::convert::TryInto;
 use core::fmt::Debug;
 use core::time::Duration;
 
-use ibc::core::ics02_client::client_type::ClientType;
 use ibc::core::ics02_client::context::ClientReader;
 use ibc::core::ics02_client::error as client_error;
 use ibc::core::ics02_client::msgs::create_client::MsgCreateClient;
@@ -25,7 +24,8 @@ use ibc::core::ics23_commitment::commitment::{CommitmentPrefix, CommitmentProofB
 use ibc::core::ics24_host::identifier::{ChainId, ClientId, ConnectionId};
 use ibc::core::ics26_routing::error as routing_error;
 use ibc::core::ics26_routing::msgs::Ics26Envelope;
-use ibc::mock::client_state::{MockClientState, MOCK_CLIENT_TYPE};
+use ibc::mock::client_state::client_type as mock_client_type;
+use ibc::mock::client_state::MockClientState;
 use ibc::mock::consensus_state::MockConsensusState;
 use ibc::mock::context::MockContext;
 use ibc::mock::header::MockHeader;
@@ -131,7 +131,7 @@ impl IbcTestRunner {
     }
 
     pub fn client_id(client_id: u64) -> ClientId {
-        ClientId::new(ClientType::new(MOCK_CLIENT_TYPE), client_id)
+        ClientId::new(mock_client_type(), client_id)
             .expect("it should be possible to create the client identifier")
     }
 


### PR DESCRIPTION

Closes: #188

## Description

While implementing ADR 4, we forgot to make this change. This allows `ClientType` to be more than just Tendermint.



______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
