### PR TITLE
ClientType: Change from &'static str to String

### DIFF
--- a/.changelog/unreleased/breaking-changes/206-change-clienttype-string.md
+++ b/.changelog/unreleased/breaking-changes/206-change-clienttype-string.md
@@ -1,0 +1,2 @@
+- Change ClientType to contain a String instead of &'static str
+  ([#206](https://github.com/cosmos/ibc-rs/issues/206))

--- a/crates/ibc/src/clients/ics07_tendermint/mod.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/mod.rs
@@ -1,6 +1,8 @@
 //! ICS 07: Tendermint Client implements a client verification algorithm for blockchains which use
 //! the Tendermint consensus algorithm.
 
+use alloc::string::ToString;
+
 use crate::core::ics02_client::client_type::ClientType;
 
 pub mod client_state;
@@ -12,5 +14,5 @@ pub mod misbehaviour;
 pub(crate) const TENDERMINT_CLIENT_TYPE: &str = "07-tendermint";
 
 pub fn client_type() -> ClientType {
-    ClientType::new(TENDERMINT_CLIENT_TYPE)
+    ClientType::new(TENDERMINT_CLIENT_TYPE.to_string())
 }

--- a/crates/ibc/src/core/ics02_client/client_type.rs
+++ b/crates/ibc/src/core/ics02_client/client_type.rs
@@ -3,21 +3,22 @@ use core::fmt::{Display, Error as FmtError, Formatter};
 use serde_derive::{Deserialize, Serialize};
 
 /// Type of the client, depending on the specific consensus algorithm.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct ClientType(&'static str);
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ClientType(String);
 
 impl ClientType {
-    pub fn new(s: &'static str) -> Self {
+    pub fn new(s: String) -> Self {
         Self(s)
     }
-    /// Yields the identifier of this client type as a string
-    pub fn as_str(&self) -> &'static str {
-        self.0
+
+    /// Yields this identifier as a borrowed `&str`
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
 impl Display for ClientType {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(f, "ClientType({})", self.as_str())
+        write!(f, "ClientType({})", self.0)
     }
 }

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -44,7 +44,7 @@ pub fn process(ctx: &dyn ClientReader, msg: MsgCreateClient) -> HandlerResult<Cl
 
     let client_type = client_state.client_type();
 
-    let client_id = ClientId::new(client_type, id_counter).map_err(|e| {
+    let client_id = ClientId::new(client_type.clone(), id_counter).map_err(|e| {
         Error::client_identifier_constructor(client_state.client_type(), id_counter, e)
     })?;
 
@@ -54,7 +54,7 @@ pub fn process(ctx: &dyn ClientReader, msg: MsgCreateClient) -> HandlerResult<Cl
 
     let result = ClientResult::Create(Result {
         client_id: client_id.clone(),
-        client_type,
+        client_type: client_type.clone(),
         client_state,
         consensus_state,
         processed_time: ctx.host_timestamp(),

--- a/crates/ibc/src/core/ics24_host/identifier.rs
+++ b/crates/ibc/src/core/ics24_host/identifier.rs
@@ -151,7 +151,7 @@ impl ClientId {
     /// ```
     /// # use ibc::core::ics24_host::identifier::ClientId;
     /// # use ibc::core::ics02_client::client_type::ClientType;
-    /// let tm_client_id = ClientId::new(ClientType::new("07-tendermint"), 0);
+    /// let tm_client_id = ClientId::new(ClientType::new("07-tendermint".to_string()), 0);
     /// assert!(tm_client_id.is_ok());
     /// tm_client_id.map(|id| { assert_eq!(&id, "07-tendermint-0") });
     /// ```

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -37,7 +37,7 @@ pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 pub const MOCK_CLIENT_TYPE: &str = "9999-mock";
 
 pub fn client_type() -> ClientType {
-    ClientType::new(MOCK_CLIENT_TYPE)
+    ClientType::new(MOCK_CLIENT_TYPE.to_string())
 }
 
 /// A mock of an IBC client record as it is stored in a mock context.

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1170,7 +1170,7 @@ impl ConnectionKeeper for MockContext {
 impl ClientReader for MockContext {
     fn client_type(&self, client_id: &ClientId) -> Result<ClientType, Ics02Error> {
         match self.ibc_store.lock().unwrap().clients.get(client_id) {
-            Some(client_record) => Ok(client_record.client_type),
+            Some(client_record) => Ok(client_record.client_type.clone()),
             None => Err(Ics02Error::client_not_found(client_id.clone())),
         }
     }
@@ -1311,7 +1311,7 @@ impl ClientKeeper for MockContext {
             .clients
             .entry(client_id)
             .or_insert(MockClientRecord {
-                client_type,
+                client_type: client_type.clone(),
                 consensus_states: Default::default(),
                 client_state: Default::default(),
             });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Fixes #206.

## Description

`&'static str` makes it impossible to deserialize ClientType and affects any structs including ClientType as well, so change it to use `String` instead.

______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [X] Linked to GitHub issue.
- [X] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
