### PR TITLE
Remove global `allow_deprecated`

### DIFF
--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -292,8 +292,6 @@ impl Ics2ClientState for ClientState {
         // Reset custom fields to zero values
         self.trusting_period = ZERO_DURATION;
         self.trust_level = TrustThreshold::ZERO;
-        self.allow_update.after_expiry = false;
-        self.allow_update.after_misbehaviour = false;
         self.frozen_height = None;
         self.max_clock_drift = ZERO_DURATION;
 
@@ -830,6 +828,9 @@ impl TryFrom<RawTmClientState> for ClientState {
             .frozen_height
             .and_then(|raw_height| raw_height.try_into().ok());
 
+        // We use set this deprecated field just so that we can properly convert
+        // it back in its raw form
+        #[allow(deprecated)]
         let allow_update = AllowUpdate {
             after_expiry: raw.allow_update_after_expiry,
             after_misbehaviour: raw.allow_update_after_misbehaviour,

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -292,6 +292,8 @@ impl Ics2ClientState for ClientState {
         // Reset custom fields to zero values
         self.trusting_period = ZERO_DURATION;
         self.trust_level = TrustThreshold::ZERO;
+        self.allow_update.after_expiry = false;
+        self.allow_update.after_misbehaviour = false;
         self.frozen_height = None;
         self.max_clock_drift = ZERO_DURATION;
 

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -79,6 +79,9 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
             return Err(Error::empty_versions());
         }
 
+        // We set the deprecated `previous_connection_id` field so that we can
+        // properly convert `MsgConnectionOpenTry` into its raw form
+        #[allow(deprecated)]
         Ok(Self {
             previous_connection_id: msg.previous_connection_id,
             client_id_on_b: msg.client_id.parse().map_err(Error::invalid_identifier)?,
@@ -113,6 +116,7 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
 
 impl From<MsgConnectionOpenTry> for RawMsgConnectionOpenTry {
     fn from(msg: MsgConnectionOpenTry) -> Self {
+        #[allow(deprecated)]
         RawMsgConnectionOpenTry {
             client_id: msg.client_id_on_b.as_str().to_string(),
             previous_connection_id: msg.previous_connection_id,
@@ -169,6 +173,8 @@ pub mod test_util {
         consensus_height: u64,
     ) -> RawMsgConnectionOpenTry {
         let client_state_height = Height::new(0, consensus_height).unwrap();
+
+        #[allow(deprecated)]
         RawMsgConnectionOpenTry {
             client_id: ClientId::default().to_string(),
             previous_connection_id: ConnectionId::default().to_string(),

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
@@ -37,6 +37,7 @@ impl MsgChannelOpenTry {
         proofs: Proofs,
         signer: Signer,
     ) -> Self {
+        #[allow(deprecated)]
         Self {
             port_id,
             channel,
@@ -89,6 +90,7 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
         )
         .map_err(ChannelError::invalid_proof)?;
 
+        #[allow(deprecated)]
         let msg = MsgChannelOpenTry {
             port_id: raw_msg.port_id.parse().map_err(ChannelError::identifier)?,
             previous_channel_id: raw_msg.previous_channel_id,
@@ -110,6 +112,7 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
 
 impl From<MsgChannelOpenTry> for RawMsgChannelOpenTry {
     fn from(domain_msg: MsgChannelOpenTry) -> Self {
+        #[allow(deprecated)]
         RawMsgChannelOpenTry {
             port_id: domain_msg.port_id.to_string(),
             previous_channel_id: domain_msg.previous_channel_id,
@@ -134,6 +137,7 @@ pub mod test_util {
 
     /// Returns a dummy `RawMsgChannelOpenTry`, for testing only!
     pub fn get_dummy_raw_msg_chan_open_try(proof_height: u64) -> RawMsgChannelOpenTry {
+        #[allow(deprecated)]
         RawMsgChannelOpenTry {
             port_id: PortId::default().to_string(),
             previous_channel_id: ChannelId::default().to_string(),

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -4,9 +4,6 @@
 
 #![no_std]
 #![allow(clippy::large_enum_variant)]
-// We currently still have the crossing-hellos logic, which requires using
-// deprecated fields. See issue #143.
-#![allow(deprecated)]
 #![deny(
     warnings,
     trivial_casts,


### PR DESCRIPTION
Closes: #143

## Description

Removes the global `#![allow(deprecated)]`. However we still need to use some deprecated fields sometimes for trivial reasons (added comments).

I didn't add a changelog entry as this is more a small internal clean up. 


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
