### PR TITLE
Don't require ICS20 module to implement Channel{Reader,Keeper}

### DIFF
--- a/.changelog/unreleased/breaking-changes/182-ics20-channel-reader-keeper.md
+++ b/.changelog/unreleased/breaking-changes/182-ics20-channel-reader-keeper.md
@@ -1,0 +1,4 @@
+- `Ics20Context` no longer requires types implementing it to implement `ChannelReader` and `ChannelKeeper`, and instead depends on the `Ics20ChannelKeeper`
+  and `SendPacketReader` traits. Additionally, the `send_packet` handler now requires the calling context to implement `SendPacketReader` and returns
+  a `SendPacketResult`.
+  ([#182](https://github.com/cosmos/ibc-rs/issues/182))

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -22,7 +22,7 @@ use crate::core::ics26_routing::context::{ModuleOutputBuilder, OnRecvPacketAck};
 use crate::prelude::*;
 use crate::signer::Signer;
 
-pub trait Ics20Keeper: BankKeeper {
+pub trait TokenTransferKeeper: BankKeeper {
     fn store_send_packet_result(&mut self, result: SendPacketResult) -> Result<(), Ics04Error> {
         self.store_next_sequence_send(
             result.port_id.clone(),
@@ -81,7 +81,7 @@ pub trait Ics20Reader: SendPacketReader {
     }
 }
 
-impl<T> Ics20Keeper for T
+impl<T> TokenTransferKeeper for T
 where
     T: ChannelKeeper + BankKeeper,
 {
@@ -148,7 +148,7 @@ pub trait BankKeeper {
 /// Captures all the dependencies which the ICS20 module requires to be able to dispatch and
 /// process IBC messages.
 pub trait Ics20Context:
-    Ics20Keeper<AccountId = <Self as Ics20Context>::AccountId>
+    TokenTransferKeeper<AccountId = <Self as Ics20Context>::AccountId>
     + Ics20Reader<AccountId = <Self as Ics20Context>::AccountId>
 {
     type AccountId: TryFrom<Signer>;

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -9,10 +9,13 @@ use crate::applications::transfer::relay::on_recv_packet::process_recv_packet;
 use crate::applications::transfer::relay::on_timeout_packet::process_timeout_packet;
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader};
+use crate::core::ics04_channel::commitment::PacketCommitment;
+use crate::core::ics04_channel::context::SendPacketReader;
+use crate::core::ics04_channel::error::Error as Ics04Error;
+use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
-use crate::core::ics04_channel::packet::Packet;
+use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 use crate::core::ics26_routing::context::{ModuleOutputBuilder, OnRecvPacketAck};
@@ -20,12 +23,12 @@ use crate::prelude::*;
 use crate::signer::Signer;
 
 pub trait Ics20Keeper:
-    ChannelKeeper + BankKeeper<AccountId = <Self as Ics20Keeper>::AccountId>
+    Ics20ChannelKeeper + BankKeeper<AccountId = <Self as Ics20Keeper>::AccountId>
 {
     type AccountId;
 }
 
-pub trait Ics20Reader: ChannelReader {
+pub trait Ics20Reader: SendPacketReader {
     type AccountId: TryFrom<Signer>;
 
     /// get_port returns the portID for the transfer module.
@@ -49,6 +52,39 @@ pub trait Ics20Reader: ChannelReader {
     fn denom_hash_string(&self, _denom: &PrefixedDenom) -> Option<String> {
         None
     }
+}
+
+pub trait Ics20ChannelKeeper {
+    fn store_send_packet_result(&mut self, result: SendPacketResult) -> Result<(), Ics04Error> {
+        self.store_next_sequence_send(
+            result.port_id.clone(),
+            result.channel_id.clone(),
+            result.seq_number,
+        )?;
+
+        self.store_packet_commitment(
+            result.port_id,
+            result.channel_id,
+            result.seq,
+            result.commitment,
+        )?;
+        Ok(())
+    }
+
+    fn store_packet_commitment(
+        &mut self,
+        port_id: PortId,
+        channel_id: ChannelId,
+        sequence: Sequence,
+        commitment: PacketCommitment,
+    ) -> Result<(), Ics04Error>;
+
+    fn store_next_sequence_send(
+        &mut self,
+        port_id: PortId,
+        channel_id: ChannelId,
+        seq: Sequence,
+    ) -> Result<(), Ics04Error>;
 }
 
 // https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-028-public-key-addresses.md
@@ -197,7 +233,7 @@ pub fn on_recv_packet<Ctx: 'static + Ics20Context>(
         Err(_) => {
             return OnRecvPacketAck::Failed(Box::new(Acknowledgement::Error(
                 Ics20Error::packet_data_deserialization().to_string(),
-            )))
+            )));
         }
     };
 

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -87,7 +87,10 @@ pub trait Ics20ChannelKeeper {
     ) -> Result<(), Ics04Error>;
 }
 
-impl<T: ChannelKeeper> Ics20ChannelKeeper for T {
+impl<T> Ics20ChannelKeeper for T
+where
+    T: ChannelKeeper,
+{
     fn store_packet_commitment(
         &mut self,
         port_id: PortId,

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -10,7 +10,7 @@ use crate::applications::transfer::relay::on_timeout_packet::process_timeout_pac
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
 use crate::core::ics04_channel::commitment::PacketCommitment;
-use crate::core::ics04_channel::context::SendPacketReader;
+use crate::core::ics04_channel::context::{ChannelKeeper, SendPacketReader};
 use crate::core::ics04_channel::error::Error as Ics04Error;
 use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
@@ -85,6 +85,27 @@ pub trait Ics20ChannelKeeper {
         channel_id: ChannelId,
         seq: Sequence,
     ) -> Result<(), Ics04Error>;
+}
+
+impl<T: ChannelKeeper> Ics20ChannelKeeper for T {
+    fn store_packet_commitment(
+        &mut self,
+        port_id: PortId,
+        channel_id: ChannelId,
+        sequence: Sequence,
+        commitment: PacketCommitment,
+    ) -> Result<(), Ics04Error> {
+        ChannelKeeper::store_packet_commitment(self, port_id, channel_id, sequence, commitment)
+    }
+
+    fn store_next_sequence_send(
+        &mut self,
+        port_id: PortId,
+        channel_id: ChannelId,
+        seq: Sequence,
+    ) -> Result<(), Ics04Error> {
+        ChannelKeeper::store_next_sequence_send(self, port_id, channel_id, seq)
+    }
 }
 
 // https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-028-public-key-addresses.md

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -55,7 +55,7 @@ pub trait TokenTransferKeeper: BankKeeper {
     ) -> Result<(), Ics04Error>;
 }
 
-pub trait Ics20Reader: SendPacketReader {
+pub trait TokenTransferReader: SendPacketReader {
     type AccountId: TryFrom<Signer>;
 
     /// get_port returns the portID for the transfer module.
@@ -66,7 +66,7 @@ pub trait Ics20Reader: SendPacketReader {
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
-    ) -> Result<<Self as Ics20Reader>::AccountId, Ics20Error>;
+    ) -> Result<<Self as TokenTransferReader>::AccountId, Ics20Error>;
 
     /// Returns true iff send is enabled.
     fn is_send_enabled(&self) -> bool;
@@ -149,7 +149,7 @@ pub trait BankKeeper {
 /// process IBC messages.
 pub trait Ics20Context:
     TokenTransferKeeper<AccountId = <Self as Ics20Context>::AccountId>
-    + Ics20Reader<AccountId = <Self as Ics20Context>::AccountId>
+    + TokenTransferReader<AccountId = <Self as Ics20Context>::AccountId>
 {
     type AccountId: TryFrom<Signer>;
 }

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -94,7 +94,7 @@ where
         events,
     } = send_packet(ctx, packet).map_err(Error::ics04_channel)?;
 
-    ctx.store_packet_result(result)
+    ctx.store_send_packet_result(result)
         .map_err(Error::ics04_channel)?;
 
     output.merge_output(

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -150,6 +150,86 @@ pub trait ChannelReader {
     }
 }
 
+pub trait SendPacketReader {
+    /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
+    fn channel_end(&self, port_id: &PortId, channel_id: &ChannelId) -> Result<ChannelEnd, Error>;
+
+    /// Returns the ConnectionState for the given identifier `connection_id`.
+    fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, Error>;
+
+    /// Returns the ClientState for the given identifier `client_id`. Necessary dependency towards
+    /// proof verification.
+    fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, Error>;
+
+    fn client_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Box<dyn ConsensusState>, Error>;
+
+    fn get_next_sequence_send(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<Sequence, Error>;
+
+    fn hash(&self, value: Vec<u8>) -> Vec<u8>;
+
+    fn packet_commitment(
+        &self,
+        packet_data: Vec<u8>,
+        timeout_height: TimeoutHeight,
+        timeout_timestamp: Timestamp,
+    ) -> PacketCommitment {
+        let mut hash_input = timeout_timestamp.nanoseconds().to_be_bytes().to_vec();
+
+        let revision_number = timeout_height.commitment_revision_number().to_be_bytes();
+        hash_input.append(&mut revision_number.to_vec());
+
+        let revision_height = timeout_height.commitment_revision_height().to_be_bytes();
+        hash_input.append(&mut revision_height.to_vec());
+
+        let packet_data_hash = self.hash(packet_data);
+        hash_input.append(&mut packet_data_hash.to_vec());
+
+        self.hash(hash_input).into()
+    }
+}
+
+impl<T: ChannelReader> SendPacketReader for T {
+    fn channel_end(&self, port_id: &PortId, channel_id: &ChannelId) -> Result<ChannelEnd, Error> {
+        ChannelReader::channel_end(self, port_id, channel_id)
+    }
+
+    fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, Error> {
+        ChannelReader::connection_end(self, connection_id)
+    }
+
+    fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, Error> {
+        ChannelReader::client_state(self, client_id)
+    }
+
+    fn client_consensus_state(
+        &self,
+        client_id: &ClientId,
+        height: Height,
+    ) -> Result<Box<dyn ConsensusState>, Error> {
+        ChannelReader::client_consensus_state(self, client_id, height)
+    }
+
+    fn get_next_sequence_send(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<Sequence, Error> {
+        ChannelReader::get_next_sequence_send(self, port_id, channel_id)
+    }
+
+    fn hash(&self, value: Vec<u8>) -> Vec<u8> {
+        ChannelReader::hash(self, value)
+    }
+}
+
 /// A context supplying all the necessary write-only dependencies (i.e., storage writing facility)
 /// for processing any `ChannelMsg`.
 pub trait ChannelKeeper {

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -196,7 +196,10 @@ pub trait SendPacketReader {
     }
 }
 
-impl<T: ChannelReader> SendPacketReader for T {
+impl<T> SendPacketReader for T
+where
+    T: ChannelReader,
+{
     fn channel_end(&self, port_id: &PortId, channel_id: &ChannelId) -> Result<ChannelEnd, Error> {
         ChannelReader::channel_end(self, port_id, channel_id)
     }

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -20,7 +20,7 @@ pub struct SendPacketResult {
 }
 
 pub fn send_packet(
-    ctx: &dyn SendPacketReader,
+    ctx: &impl SendPacketReader,
     packet: Packet,
 ) -> HandlerResult<SendPacketResult, Error> {
     let mut output = HandlerOutput::builder();

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -4,8 +4,7 @@ use subtle_encoding::bech32;
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
 use crate::applications::transfer::context::{
-    cosmos_adr028_escrow_address, BankKeeper, Ics20ChannelKeeper, Ics20Context, Ics20Keeper,
-    Ics20Reader,
+    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, Ics20Keeper, Ics20Reader,
 };
 use crate::applications::transfer::{error::Error as Ics20Error, PrefixedCoin};
 use crate::core::ics02_client::client_state::ClientState;
@@ -117,10 +116,6 @@ impl Module for DummyTransferModule {
 }
 
 impl Ics20Keeper for DummyTransferModule {
-    type AccountId = Signer;
-}
-
-impl Ics20ChannelKeeper for DummyTransferModule {
     fn store_packet_commitment(
         &mut self,
         port_id: PortId,

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -4,7 +4,7 @@ use subtle_encoding::bech32;
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
 use crate::applications::transfer::context::{
-    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, Ics20Keeper, Ics20Reader,
+    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, Ics20Reader, TokenTransferKeeper,
 };
 use crate::applications::transfer::{error::Error as Ics20Error, PrefixedCoin};
 use crate::core::ics02_client::client_state::ClientState;
@@ -115,7 +115,7 @@ impl Module for DummyTransferModule {
     }
 }
 
-impl Ics20Keeper for DummyTransferModule {
+impl TokenTransferKeeper for DummyTransferModule {
     fn store_packet_commitment(
         &mut self,
         port_id: PortId,

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -4,7 +4,8 @@ use subtle_encoding::bech32;
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
 use crate::applications::transfer::context::{
-    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, Ics20Reader, TokenTransferKeeper,
+    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, TokenTransferKeeper,
+    TokenTransferReader,
 };
 use crate::applications::transfer::{error::Error as Ics20Error, PrefixedCoin};
 use crate::core::ics02_client::client_state::ClientState;
@@ -187,7 +188,7 @@ impl BankKeeper for DummyTransferModule {
     }
 }
 
-impl Ics20Reader for DummyTransferModule {
+impl TokenTransferReader for DummyTransferModule {
     type AccountId = Signer;
 
     fn get_port(&self) -> Result<PortId, Ics20Error> {
@@ -198,7 +199,7 @@ impl Ics20Reader for DummyTransferModule {
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
-    ) -> Result<<Self as Ics20Reader>::AccountId, Ics20Error> {
+    ) -> Result<<Self as TokenTransferReader>::AccountId, Ics20Error> {
         let addr = cosmos_adr028_escrow_address(port_id, channel_id);
         Ok(bech32::encode("cosmos", addr).parse().unwrap())
     }

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use subtle_encoding::bech32;
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
 use crate::applications::transfer::context::{
-    cosmos_adr028_escrow_address, BankKeeper, Ics20Context, Ics20Keeper, Ics20Reader,
+    cosmos_adr028_escrow_address, BankKeeper, Ics20ChannelKeeper, Ics20Context, Ics20Keeper,
+    Ics20Reader,
 };
 use crate::applications::transfer::{error::Error as Ics20Error, PrefixedCoin};
 use crate::core::ics02_client::client_state::ClientState;
@@ -14,11 +14,11 @@ use crate::core::ics02_client::error::Error as Ics02Error;
 use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics03_connection::error::Error as Ics03Error;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
-use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
-use crate::core::ics04_channel::context::{ChannelKeeper, ChannelReader};
+use crate::core::ics04_channel::commitment::PacketCommitment;
+use crate::core::ics04_channel::context::SendPacketReader;
 use crate::core::ics04_channel::error::Error;
 use crate::core::ics04_channel::handler::ModuleExtras;
-use crate::core::ics04_channel::packet::{Receipt, Sequence};
+use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics04_channel::Version;
 use crate::core::ics05_port::context::PortReader;
 use crate::core::ics05_port::error::Error as PortError;
@@ -27,7 +27,6 @@ use crate::core::ics26_routing::context::{Module, ModuleId};
 use crate::mock::context::MockIbcStore;
 use crate::prelude::*;
 use crate::signer::Signer;
-use crate::timestamp::Timestamp;
 use crate::Height;
 
 // Needed in mocks.
@@ -121,7 +120,7 @@ impl Ics20Keeper for DummyTransferModule {
     type AccountId = Signer;
 }
 
-impl ChannelKeeper for DummyTransferModule {
+impl Ics20ChannelKeeper for DummyTransferModule {
     fn store_packet_commitment(
         &mut self,
         port_id: PortId,
@@ -141,62 +140,6 @@ impl ChannelKeeper for DummyTransferModule {
         Ok(())
     }
 
-    fn delete_packet_commitment(
-        &mut self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _seq: Sequence,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn store_packet_receipt(
-        &mut self,
-        _port_id: PortId,
-        _channel_id: ChannelId,
-        _seq: Sequence,
-        _receipt: Receipt,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn store_packet_acknowledgement(
-        &mut self,
-        _port_id: PortId,
-        _channel_id: ChannelId,
-        _seq: Sequence,
-        _ack: AcknowledgementCommitment,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn delete_packet_acknowledgement(
-        &mut self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _seq: Sequence,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn store_connection_channels(
-        &mut self,
-        _conn_id: ConnectionId,
-        _port_id: PortId,
-        _channel_id: ChannelId,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn store_channel(
-        &mut self,
-        _port_id: PortId,
-        _channel_id: ChannelId,
-        _channel_end: ChannelEnd,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
     fn store_next_sequence_send(
         &mut self,
         port_id: PortId,
@@ -211,28 +154,6 @@ impl ChannelKeeper for DummyTransferModule {
             .or_default()
             .insert(channel_id, seq);
         Ok(())
-    }
-
-    fn store_next_sequence_recv(
-        &mut self,
-        _port_id: PortId,
-        _channel_id: ChannelId,
-        _seq: Sequence,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn store_next_sequence_ack(
-        &mut self,
-        _port_id: PortId,
-        _channel_id: ChannelId,
-        _seq: Sequence,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
-    fn increase_channel_counter(&mut self) {
-        unimplemented!()
     }
 }
 
@@ -296,7 +217,7 @@ impl Ics20Reader for DummyTransferModule {
     }
 }
 
-impl ChannelReader for DummyTransferModule {
+impl SendPacketReader for DummyTransferModule {
     fn channel_end(&self, port_id: &PortId, channel_id: &ChannelId) -> Result<ChannelEnd, Error> {
         match self
             .ibc_store
@@ -320,10 +241,6 @@ impl ChannelReader for DummyTransferModule {
             None => Err(Ics03Error::connection_not_found(cid.clone())),
         }
         .map_err(Error::ics03_connection)
-    }
-
-    fn connection_channels(&self, _cid: &ConnectionId) -> Result<Vec<(PortId, ChannelId)>, Error> {
-        unimplemented!()
     }
 
     fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, Error> {
@@ -379,89 +296,10 @@ impl ChannelReader for DummyTransferModule {
         }
     }
 
-    fn get_next_sequence_recv(
-        &self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-    ) -> Result<Sequence, Error> {
-        unimplemented!()
-    }
-
-    fn get_next_sequence_ack(
-        &self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-    ) -> Result<Sequence, Error> {
-        unimplemented!()
-    }
-
-    fn get_packet_commitment(
-        &self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _seq: Sequence,
-    ) -> Result<PacketCommitment, Error> {
-        unimplemented!()
-    }
-
-    fn get_packet_receipt(
-        &self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _seq: Sequence,
-    ) -> Result<Receipt, Error> {
-        unimplemented!()
-    }
-
-    fn get_packet_acknowledgement(
-        &self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _seq: Sequence,
-    ) -> Result<AcknowledgementCommitment, Error> {
-        unimplemented!()
-    }
-
     fn hash(&self, value: Vec<u8>) -> Vec<u8> {
         use sha2::Digest;
 
         sha2::Sha256::digest(value).to_vec()
-    }
-
-    fn host_height(&self) -> Height {
-        Height::new(0, 1).unwrap()
-    }
-
-    fn host_consensus_state(&self, _height: Height) -> Result<Box<dyn ConsensusState>, Error> {
-        unimplemented!()
-    }
-
-    fn pending_host_consensus_state(&self) -> Result<Box<dyn ConsensusState>, Error> {
-        unimplemented!()
-    }
-
-    fn client_update_time(
-        &self,
-        _client_id: &ClientId,
-        _height: Height,
-    ) -> Result<Timestamp, Error> {
-        unimplemented!()
-    }
-
-    fn client_update_height(
-        &self,
-        _client_id: &ClientId,
-        _height: Height,
-    ) -> Result<Height, Error> {
-        unimplemented!()
-    }
-
-    fn channel_counter(&self) -> Result<u64, Error> {
-        unimplemented!()
-    }
-
-    fn max_expected_time_per_block(&self) -> Duration {
-        unimplemented!()
     }
 }
 


### PR DESCRIPTION
Closes: #182 (potential solution)

With these changes, we no longer require an ICS20 module (i.e. the type implementing `Ics20Context`) to implement the complete `ChannelReader` and `ChannelKeeper` traits. We only require them to implement the `Ics20ChannelKeeper` and the `SendPacketReader` traits ->
https://github.com/cosmos/ibc-rs/blob/42ff93ff1d996b5b049db8a90f46dc23987109b0/crates/ibc/src/applications/transfer/context.rs#L25-L26

Moreover, we also provide blanket impls for both these traits (i.e. `Ics20ChannelKeeper` and `SendPacketReader`) if the type implements `ChannelReader` and `ChannelKeeper` respectively.
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
