### PR TITLE
Set counterparty_connection_id to None in conn_open_init

### DIFF
--- a/.changelog/unreleased/bug-fixes/174-fix-conn-open-cpty.md
+++ b/.changelog/unreleased/bug-fixes/174-fix-conn-open-cpty.md
@@ -1,0 +1,1 @@
+- Set counterparty connection ID to None in `conn_open_init` ([#174](https://github.com/cosmos/ibc-rs/issues/174))

--- a/.changelog/unreleased/bug-fixes/274-fix-conn-open-ack-conn-id.md
+++ b/.changelog/unreleased/bug-fixes/274-fix-conn-open-ack-conn-id.md
@@ -1,0 +1,2 @@
+- Verify the message's counterparty connection ID in `conn_open_ack`
+  instead of the store's ([#274](https://github.com/cosmos/ibc-rs/issues/274))

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -40,11 +40,6 @@ pub(crate) fn process(
     let client_id_on_a = conn_end_on_a.client_id();
     let client_id_on_b = conn_end_on_a.counterparty().client_id();
 
-    let conn_id_on_b = conn_end_on_a
-        .counterparty()
-        .connection_id()
-        .ok_or(ConnectionError::InvalidCounterparty)?;
-
     // Proof verification.
     {
         let client_state_of_b_on_a = ctx_a.client_state(client_id_on_a)?;
@@ -73,7 +68,7 @@ pub(crate) fn process(
                     prefix_on_b,
                     &msg.proof_conn_end_on_b,
                     consensus_state_of_b_on_a.root(),
-                    conn_id_on_b,
+                    &msg.conn_id_on_b,
                     &expected_conn_end_on_b,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
@@ -115,7 +110,7 @@ pub(crate) fn process(
     output.emit(IbcEvent::OpenAckConnection(OpenAck::new(
         msg.conn_id_on_a.clone(),
         client_id_on_a.clone(),
-        conn_id_on_b.clone(),
+        msg.conn_id_on_b.clone(),
         client_id_on_b.clone(),
     )));
     output.log("success: conn_open_ack verification passed");

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to ICS3 messages of type `MsgConnectionOpenInit`.
 
-use crate::core::ics03_connection::connection::{ConnectionEnd, State};
+use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::context::ConnectionReader;
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::events::OpenInit;
@@ -37,7 +37,11 @@ pub(crate) fn process(
     let conn_end_on_a = ConnectionEnd::new(
         State::Init,
         msg.client_id_on_a.clone(),
-        msg.counterparty.clone(),
+        Counterparty::new(
+            msg.counterparty.client_id().clone(),
+            None,
+            msg.counterparty.prefix().clone(),
+        ),
         versions,
         msg.delay_period,
     );


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #174
Closes: #274

## Description

In addition to setting the connection ID to `None` in `conn_open_init`, this PR also fixes a check in `conn_open_ack` that expected the counterparty's `connection_id` to be `Some(_)` before the Ack message is processed.

______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [X] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
