### PR TITLE
Don't fail CI because of code coverage job

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: Coverage
 on:
   pull_request:
     paths:
+      - .codecov.yml
       - .github/workflows/rust.yml
       - .github/workflows/coverage.yml
       - Cargo.toml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,4 +49,3 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
-


### PR DESCRIPTION
As discussed with @plafer, we might change this back in Q1 when focus will be on correctness and QA.