### PR TITLE
Fix codecov's flakiness

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,4 +49,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,4 +49,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
- Don't fail the CI when the coverage job fails
- Specify the `CODECOV_TOKEN` secret to avoid using the global Codecov app token which might often hit the rate limit, as per https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469