### PR TITLE
Fix `old_*` naming in `ClientState`

### DIFF
--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -570,7 +570,7 @@ impl Ics2ClientState for ClientState {
         })
     }
 
-    fn old_check_misbehaviour_and_update_state(
+    fn check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ClientReader,
         client_id: ClientId,
@@ -629,7 +629,7 @@ impl Ics2ClientState for ClientState {
             .into_box())
     }
 
-    fn check_misbehaviour_and_update_state(
+    fn new_check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
         client_id: ClientId,

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -406,7 +406,7 @@ impl Ics2ClientState for ClientState {
         TmConsensusState::try_from(consensus_state).map(TmConsensusState::into_box)
     }
 
-    fn old_check_header_and_update_state(
+    fn check_header_and_update_state(
         &self,
         ctx: &dyn ClientReader,
         client_id: ClientId,
@@ -694,7 +694,7 @@ impl Ics2ClientState for ClientState {
             .into_box())
     }
 
-    fn check_header_and_update_state(
+    fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
         client_id: ClientId,

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -79,14 +79,14 @@ pub trait ClientState:
     fn initialise(&self, consensus_state: Any) -> Result<Box<dyn ConsensusState>, ClientError>;
 
     /// XXX: temporary solution until we get rid of `ClientReader`
-    fn old_check_header_and_update_state(
+    fn check_header_and_update_state(
         &self,
         ctx: &dyn ClientReader,
         client_id: ClientId,
         header: Any,
     ) -> Result<UpdatedState, ClientError>;
 
-    fn check_header_and_update_state(
+    fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
         client_id: ClientId,

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -78,7 +78,6 @@ pub trait ClientState:
 
     fn initialise(&self, consensus_state: Any) -> Result<Box<dyn ConsensusState>, ClientError>;
 
-    /// XXX: temporary solution until we get rid of `ClientReader`
     fn check_header_and_update_state(
         &self,
         ctx: &dyn ClientReader,
@@ -86,6 +85,7 @@ pub trait ClientState:
         header: Any,
     ) -> Result<UpdatedState, ClientError>;
 
+    /// XXX: temporary solution until we get rid of `ClientReader`
     fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
@@ -93,15 +93,15 @@ pub trait ClientState:
         header: Any,
     ) -> Result<UpdatedState, ClientError>;
 
-    /// XXX: temporary solution until we get rid of `ClientReader`
-    fn old_check_misbehaviour_and_update_state(
+    fn check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ClientReader,
         client_id: ClientId,
         misbehaviour: Any,
     ) -> Result<Box<dyn ClientState>, ClientError>;
 
-    fn check_misbehaviour_and_update_state(
+    /// XXX: temporary solution until we get rid of `ClientReader`
+    fn new_check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
         client_id: ClientId,

--- a/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
@@ -38,7 +38,7 @@ where
     }
 
     let _ = client_state
-        .check_misbehaviour_and_update_state(ctx, client_id.clone(), misbehaviour)
+        .new_check_misbehaviour_and_update_state(ctx, client_id.clone(), misbehaviour)
         .map_err(|e| ClientError::MisbehaviourHandlingFailure {
             reason: e.to_string(),
         })?;
@@ -64,7 +64,7 @@ where
     }
 
     let client_state = client_state
-        .check_misbehaviour_and_update_state(ctx, client_id.clone(), misbehaviour)
+        .new_check_misbehaviour_and_update_state(ctx, client_id.clone(), misbehaviour)
         .map_err(|e| ClientError::MisbehaviourHandlingFailure {
             reason: e.to_string(),
         })?;
@@ -97,7 +97,7 @@ pub fn process(
     }
 
     let client_state = client_state
-        .old_check_misbehaviour_and_update_state(ctx, client_id.clone(), misbehaviour)
+        .check_misbehaviour_and_update_state(ctx, client_id.clone(), misbehaviour)
         .map_err(|e| ClientError::MisbehaviourHandlingFailure {
             reason: e.to_string(),
         })?;

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -74,7 +74,7 @@ where
     }
 
     let _ = client_state
-        .check_header_and_update_state(ctx, client_id.clone(), header)
+        .new_check_header_and_update_state(ctx, client_id.clone(), header)
         .map_err(|e| ClientError::HeaderVerificationFailure {
             reason: e.to_string(),
         })?;
@@ -100,7 +100,7 @@ where
         client_state,
         consensus_state,
     } = client_state
-        .check_header_and_update_state(ctx, client_id.clone(), header.clone())
+        .new_check_header_and_update_state(ctx, client_id.clone(), header.clone())
         .map_err(|e| ClientError::HeaderVerificationFailure {
             reason: e.to_string(),
         })?;
@@ -189,7 +189,7 @@ pub fn process<Ctx: ClientReader>(
         client_state,
         consensus_state,
     } = client_state
-        .old_check_header_and_update_state(ctx, client_id.clone(), header.clone())
+        .check_header_and_update_state(ctx, client_id.clone(), header.clone())
         .map_err(|e| ClientError::HeaderVerificationFailure {
             reason: e.to_string(),
         })?;

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -180,7 +180,7 @@ impl ClientState for MockClientState {
         MockConsensusState::try_from(consensus_state).map(MockConsensusState::into_box)
     }
 
-    fn old_check_header_and_update_state(
+    fn check_header_and_update_state(
         &self,
         _ctx: &dyn ClientReader,
         _client_id: ClientId,
@@ -201,7 +201,7 @@ impl ClientState for MockClientState {
         })
     }
 
-    fn check_header_and_update_state(
+    fn new_check_header_and_update_state(
         &self,
         _ctx: &dyn ValidationContext,
         _client_id: ClientId,

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -222,7 +222,7 @@ impl ClientState for MockClientState {
         })
     }
 
-    fn old_check_misbehaviour_and_update_state(
+    fn check_misbehaviour_and_update_state(
         &self,
         _ctx: &dyn ClientReader,
         _client_id: ClientId,
@@ -249,7 +249,7 @@ impl ClientState for MockClientState {
         Ok(new_state.into_box())
     }
 
-    fn check_misbehaviour_and_update_state(
+    fn new_check_misbehaviour_and_update_state(
         &self,
         _ctx: &dyn ValidationContext,
         _client_id: ClientId,


### PR DESCRIPTION
Only renames `old_check_header_and_update_state`, and `old_check_misbehaviour_and_update_state` that we added in recent PRs. This is better as users will need to *add* a method only (`new_*`) as opposed to rewriting a method that changed signature (`check_*`) *and* add a new method.