### PR TITLE
Put `ValidationContext` and `ExecutionContext` behind a feature flag

### DIFF
--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -38,6 +38,7 @@ std = [
 ]
 clock = ["tendermint/clock", "time/std"]
 
+# This feature guards the unfinished implementation of ADR 5.
 val_exec_ctx = []
 
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -38,6 +38,8 @@ std = [
 ]
 clock = ["tendermint/clock", "time/std"]
 
+val_exec_ctx = []
+
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
 mocks = ["tendermint-testgen", "clock", "std"]
@@ -89,4 +91,3 @@ modelator = "0.4.2"
 sha2 = { version = "0.10.6" }
 tendermint-rpc = { version = "0.28", features = ["http-client", "websocket-client"] }
 tendermint-testgen = { version = "0.28" } # Needed for generating (synthetic) light blocks.
-

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -20,7 +20,6 @@ use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConse
 use crate::clients::ics07_tendermint::error::{Error, IntoResult};
 use crate::clients::ics07_tendermint::header::{Header as TmHeader, Header};
 use crate::clients::ics07_tendermint::misbehaviour::Misbehaviour as TmMisbehaviour;
-use crate::core::context::ContextError;
 use crate::core::ics02_client::client_state::{
     ClientState as Ics2ClientState, UpdatedState, UpgradeOptions as CoreUpgradeOptions,
 };
@@ -44,11 +43,15 @@ use crate::core::ics24_host::path::{
     ConnectionsPath, ReceiptsPath, SeqRecvsPath,
 };
 use crate::core::ics24_host::Path;
-use crate::core::ValidationContext;
 use crate::timestamp::{Timestamp, ZERO_DURATION};
 use crate::Height;
 
 use super::client_type as tm_client_type;
+
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ValidationContext;
 
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 
@@ -632,6 +635,7 @@ impl Ics2ClientState for ClientState {
             .into_box())
     }
 
+    #[cfg(val_exec_ctx)]
     fn new_check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
@@ -697,6 +701,7 @@ impl Ics2ClientState for ClientState {
             .into_box())
     }
 
+    #[cfg(val_exec_ctx)]
     fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -1,45 +1,11 @@
-use core::time::Duration;
+use crate::prelude::*;
 
-use crate::events::IbcEvent;
-use crate::{prelude::*, timestamp::Timestamp, Height};
-
-use crate::core::ics26_routing::error::RouterError;
-
-use ibc_proto::google::protobuf::Any;
-
-use super::ics02_client::client_type::ClientType;
-use super::ics02_client::handler::{create_client, misbehaviour, update_client, upgrade_client};
-use super::ics02_client::msgs::ClientMsg;
-use super::ics03_connection::handler::{
-    conn_open_ack, conn_open_confirm, conn_open_init, conn_open_try,
-};
-use super::ics03_connection::msgs::ConnectionMsg;
-use super::ics24_host::path::{
-    ClientConnectionsPath, ClientConsensusStatePath, ClientStatePath, ClientTypePath,
-    CommitmentsPath, ConnectionsPath, ReceiptsPath,
-};
-use super::ics26_routing::msgs::MsgEnvelope;
 use super::{
-    ics02_client::{
-        client_state::ClientState, consensus_state::ConsensusState, error::ClientError,
-    },
-    ics03_connection::{
-        connection::ConnectionEnd,
-        error::ConnectionError,
-        version::{get_compatible_versions, pick_version, Version as ConnectionVersion},
-    },
-    ics04_channel::{
-        channel::ChannelEnd,
-        commitment::{AcknowledgementCommitment, PacketCommitment},
-        context::calculate_block_delay,
-        error::{ChannelError, PacketError},
-        msgs::acknowledgement::Acknowledgement,
-        packet::{Receipt, Sequence},
-        timeout::TimeoutHeight,
-    },
-    ics23_commitment::commitment::CommitmentPrefix,
-    ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
+    ics02_client::error::ClientError,
+    ics03_connection::error::ConnectionError,
+    ics04_channel::error::{ChannelError, PacketError},
 };
+
 use displaydoc::Display;
 
 #[derive(Debug, Display)]
@@ -90,378 +56,442 @@ impl std::error::Error for ContextError {
     }
 }
 
-pub trait ValidationContext {
-    /// Validation entrypoint.
-    fn validate(&self, message: MsgEnvelope) -> Result<(), RouterError>
-    where
-        Self: Sized,
-    {
-        match message {
-            MsgEnvelope::ClientMsg(message) => match message {
-                ClientMsg::CreateClient(message) => create_client::validate(self, message),
-                ClientMsg::UpdateClient(message) => update_client::validate(self, message),
-                ClientMsg::Misbehaviour(message) => misbehaviour::validate(self, message),
-                ClientMsg::UpgradeClient(message) => upgrade_client::validate(self, message),
-            }
-            .map_err(RouterError::ContextError),
-            MsgEnvelope::ConnectionMsg(message) => match message {
-                ConnectionMsg::ConnectionOpenInit(message) => {
-                    conn_open_init::validate(self, message)
+#[cfg(val_exec_ctx)]
+pub use val_exec_ctx::*;
+
+#[cfg(val_exec_ctx)]
+mod val_exec_ctx {
+    use core::time::Duration;
+
+    use ibc_proto::google::protobuf::Any;
+
+    use crate::core::ics02_client::client_state::ClientState;
+    use crate::core::ics02_client::client_type::ClientType;
+    use crate::core::ics02_client::consensus_state::ConsensusState;
+    use crate::core::ics03_connection::connection::ConnectionEnd;
+    use crate::core::ics03_connection::error::ConnectionError;
+    use crate::core::ics03_connection::version::{
+        get_compatible_versions, pick_version, Version as ConnectionVersion,
+    };
+    use crate::core::ics04_channel::channel::ChannelEnd;
+    use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
+    use crate::core::ics04_channel::context::calculate_block_delay;
+    use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
+    use crate::core::ics04_channel::packet::{Receipt, Sequence};
+    use crate::core::ics04_channel::timeout::TimeoutHeight;
+    use crate::core::ics23_commitment::commitment::CommitmentPrefix;
+    use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
+    use crate::core::ics24_host::path::{
+        ClientConnectionsPath, ClientConsensusStatePath, ClientStatePath, ClientTypePath,
+        CommitmentsPath, ConnectionsPath, ReceiptsPath,
+    };
+    use crate::core::{
+        ics02_client::{
+            handler::{create_client, misbehaviour, update_client, upgrade_client},
+            msgs::ClientMsg,
+        },
+        ics03_connection::{
+            handler::{conn_open_ack, conn_open_confirm, conn_open_init, conn_open_try},
+            msgs::ConnectionMsg,
+        },
+        ics24_host::identifier::ClientId,
+        ics26_routing::{error::RouterError, msgs::MsgEnvelope},
+    };
+    use crate::events::IbcEvent;
+    use crate::timestamp::Timestamp;
+    use crate::{prelude::*, Height};
+
+    use super::ContextError;
+
+    pub trait ValidationContext {
+        /// Validation entrypoint.
+        fn validate(&self, message: MsgEnvelope) -> Result<(), RouterError>
+        where
+            Self: Sized,
+        {
+            match message {
+                MsgEnvelope::ClientMsg(message) => match message {
+                    ClientMsg::CreateClient(message) => create_client::validate(self, message),
+                    ClientMsg::UpdateClient(message) => update_client::validate(self, message),
+                    ClientMsg::Misbehaviour(message) => misbehaviour::validate(self, message),
+                    ClientMsg::UpgradeClient(message) => upgrade_client::validate(self, message),
                 }
-                ConnectionMsg::ConnectionOpenTry(message) => conn_open_try::validate(self, message),
-                ConnectionMsg::ConnectionOpenAck(message) => conn_open_ack::validate(self, message),
-                ConnectionMsg::ConnectionOpenConfirm(ref message) => {
-                    conn_open_confirm::validate(self, message)
+                .map_err(RouterError::ContextError),
+                MsgEnvelope::ConnectionMsg(message) => match message {
+                    ConnectionMsg::ConnectionOpenInit(message) => {
+                        conn_open_init::validate(self, message)
+                    }
+                    ConnectionMsg::ConnectionOpenTry(message) => {
+                        conn_open_try::validate(self, message)
+                    }
+                    ConnectionMsg::ConnectionOpenAck(message) => {
+                        conn_open_ack::validate(self, message)
+                    }
+                    ConnectionMsg::ConnectionOpenConfirm(ref message) => {
+                        conn_open_confirm::validate(self, message)
+                    }
                 }
+                .map_err(RouterError::ContextError),
+                MsgEnvelope::ChannelMsg(_message) => todo!(),
+                MsgEnvelope::PacketMsg(_message) => todo!(),
             }
-            .map_err(RouterError::ContextError),
-            MsgEnvelope::ChannelMsg(_message) => todo!(),
-            MsgEnvelope::PacketMsg(_message) => todo!(),
+        }
+
+        /// Returns the ClientState for the given identifier `client_id`.
+        fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, ContextError>;
+
+        /// Tries to decode the given `client_state` into a concrete light client state.
+        fn decode_client_state(
+            &self,
+            client_state: Any,
+        ) -> Result<Box<dyn ClientState>, ContextError>;
+
+        /// Retrieve the consensus state for the given client ID at the specified
+        /// height.
+        ///
+        /// Returns an error if no such state exists.
+        fn consensus_state(
+            &self,
+            client_id: &ClientId,
+            height: Height,
+        ) -> Result<Box<dyn ConsensusState>, ContextError>;
+
+        /// Search for the lowest consensus state higher than `height`.
+        fn next_consensus_state(
+            &self,
+            client_id: &ClientId,
+            height: Height,
+        ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
+
+        /// Search for the highest consensus state lower than `height`.
+        fn prev_consensus_state(
+            &self,
+            client_id: &ClientId,
+            height: Height,
+        ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
+
+        /// Returns the current height of the local chain.
+        fn host_height(&self) -> Result<Height, ContextError>;
+
+        /// Returns the current timestamp of the local chain.
+        fn host_timestamp(&self) -> Result<Timestamp, ContextError> {
+            let pending_consensus_state = self
+                .pending_host_consensus_state()
+                .expect("host must have pending consensus state");
+            Ok(pending_consensus_state.timestamp())
+        }
+
+        /// Returns the pending `ConsensusState` of the host (local) chain.
+        fn pending_host_consensus_state(&self) -> Result<Box<dyn ConsensusState>, ContextError>;
+
+        /// Returns the `ConsensusState` of the host (local) chain at a specific height.
+        fn host_consensus_state(
+            &self,
+            height: Height,
+        ) -> Result<Box<dyn ConsensusState>, ContextError>;
+
+        /// Returns a natural number, counting how many clients have been created thus far.
+        /// The value of this counter should increase only via method `ClientKeeper::increase_client_counter`.
+        fn client_counter(&self) -> Result<u64, ContextError>;
+
+        /// Returns the ConnectionEnd for the given identifier `conn_id`.
+        fn connection_end(&self, conn_id: &ConnectionId) -> Result<ConnectionEnd, ContextError>;
+
+        /// Validates the `ClientState` of the client on the counterparty chain.
+        fn validate_self_client(
+            &self,
+            counterparty_client_state: Any,
+        ) -> Result<(), ConnectionError>;
+
+        /// Returns the prefix that the local chain uses in the KV store.
+        fn commitment_prefix(&self) -> CommitmentPrefix;
+
+        /// Returns a counter on how many connections have been created thus far.
+        fn connection_counter(&self) -> Result<u64, ContextError>;
+
+        /// Function required by ICS 03. Returns the list of all possible versions that the connection
+        /// handshake protocol supports.
+        fn get_compatible_versions(&self) -> Vec<ConnectionVersion> {
+            get_compatible_versions()
+        }
+
+        /// Function required by ICS 03. Returns one version out of the supplied list of versions, which the
+        /// connection handshake protocol prefers.
+        fn pick_version(
+            &self,
+            supported_versions: Vec<ConnectionVersion>,
+            counterparty_candidate_versions: Vec<ConnectionVersion>,
+        ) -> Result<ConnectionVersion, ContextError> {
+            pick_version(supported_versions, counterparty_candidate_versions)
+                .map_err(ContextError::ConnectionError)
+        }
+
+        /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
+        fn channel_end(
+            &self,
+            port_channel_id: &(PortId, ChannelId),
+        ) -> Result<ChannelEnd, ContextError>;
+
+        fn connection_channels(
+            &self,
+            cid: &ConnectionId,
+        ) -> Result<Vec<(PortId, ChannelId)>, ContextError>;
+
+        fn get_next_sequence_send(
+            &self,
+            port_channel_id: &(PortId, ChannelId),
+        ) -> Result<Sequence, ContextError>;
+
+        fn get_next_sequence_recv(
+            &self,
+            port_channel_id: &(PortId, ChannelId),
+        ) -> Result<Sequence, ContextError>;
+
+        fn get_next_sequence_ack(
+            &self,
+            port_channel_id: &(PortId, ChannelId),
+        ) -> Result<Sequence, ContextError>;
+
+        fn get_packet_commitment(
+            &self,
+            key: &(PortId, ChannelId, Sequence),
+        ) -> Result<PacketCommitment, ContextError>;
+
+        fn get_packet_receipt(
+            &self,
+            key: &(PortId, ChannelId, Sequence),
+        ) -> Result<Receipt, ContextError>;
+
+        fn get_packet_acknowledgement(
+            &self,
+            key: &(PortId, ChannelId, Sequence),
+        ) -> Result<AcknowledgementCommitment, ContextError>;
+
+        /// Compute the commitment for a packet.
+        /// Note that the absence of `timeout_height` is treated as
+        /// `{revision_number: 0, revision_height: 0}` to be consistent with ibc-go,
+        /// where this value is used to mean "no timeout height":
+        /// <https://github.com/cosmos/ibc-go/blob/04791984b3d6c83f704c4f058e6ca0038d155d91/modules/core/04-channel/keeper/packet.go#L206>
+        fn packet_commitment(
+            &self,
+            packet_data: Vec<u8>,
+            timeout_height: TimeoutHeight,
+            timeout_timestamp: Timestamp,
+        ) -> PacketCommitment {
+            let mut hash_input = timeout_timestamp.nanoseconds().to_be_bytes().to_vec();
+
+            let revision_number = timeout_height.commitment_revision_number().to_be_bytes();
+            hash_input.append(&mut revision_number.to_vec());
+
+            let revision_height = timeout_height.commitment_revision_height().to_be_bytes();
+            hash_input.append(&mut revision_height.to_vec());
+
+            let packet_data_hash = self.hash(packet_data);
+            hash_input.append(&mut packet_data_hash.to_vec());
+
+            self.hash(hash_input).into()
+        }
+
+        fn ack_commitment(&self, ack: Acknowledgement) -> AcknowledgementCommitment {
+            self.hash(ack.into()).into()
+        }
+
+        /// A hashing function for packet commitments
+        fn hash(&self, value: Vec<u8>) -> Vec<u8>;
+
+        /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
+        fn client_update_time(
+            &self,
+            client_id: &ClientId,
+            height: Height,
+        ) -> Result<Timestamp, ContextError>;
+
+        /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
+        fn client_update_height(
+            &self,
+            client_id: &ClientId,
+            height: Height,
+        ) -> Result<Height, ContextError>;
+
+        /// Returns a counter on the number of channel ids have been created thus far.
+        /// The value of this counter should increase only via method
+        /// `ChannelKeeper::increase_channel_counter`.
+        fn channel_counter(&self) -> Result<u64, ContextError>;
+
+        /// Returns the maximum expected time per block
+        fn max_expected_time_per_block(&self) -> Duration;
+
+        /// Calculates the block delay period using the connection's delay period and the maximum
+        /// expected time per block.
+        fn block_delay(&self, delay_period_time: Duration) -> u64 {
+            calculate_block_delay(delay_period_time, self.max_expected_time_per_block())
         }
     }
 
-    /// Returns the ClientState for the given identifier `client_id`.
-    fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, ContextError>;
-
-    /// Tries to decode the given `client_state` into a concrete light client state.
-    fn decode_client_state(&self, client_state: Any) -> Result<Box<dyn ClientState>, ContextError>;
-
-    /// Retrieve the consensus state for the given client ID at the specified
-    /// height.
-    ///
-    /// Returns an error if no such state exists.
-    fn consensus_state(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Box<dyn ConsensusState>, ContextError>;
-
-    /// Search for the lowest consensus state higher than `height`.
-    fn next_consensus_state(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
-
-    /// Search for the highest consensus state lower than `height`.
-    fn prev_consensus_state(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
-
-    /// Returns the current height of the local chain.
-    fn host_height(&self) -> Result<Height, ContextError>;
-
-    /// Returns the current timestamp of the local chain.
-    fn host_timestamp(&self) -> Result<Timestamp, ContextError> {
-        let pending_consensus_state = self
-            .pending_host_consensus_state()
-            .expect("host must have pending consensus state");
-        Ok(pending_consensus_state.timestamp())
-    }
-
-    /// Returns the pending `ConsensusState` of the host (local) chain.
-    fn pending_host_consensus_state(&self) -> Result<Box<dyn ConsensusState>, ContextError>;
-
-    /// Returns the `ConsensusState` of the host (local) chain at a specific height.
-    fn host_consensus_state(&self, height: Height)
-        -> Result<Box<dyn ConsensusState>, ContextError>;
-
-    /// Returns a natural number, counting how many clients have been created thus far.
-    /// The value of this counter should increase only via method `ClientKeeper::increase_client_counter`.
-    fn client_counter(&self) -> Result<u64, ContextError>;
-
-    /// Returns the ConnectionEnd for the given identifier `conn_id`.
-    fn connection_end(&self, conn_id: &ConnectionId) -> Result<ConnectionEnd, ContextError>;
-
-    /// Validates the `ClientState` of the client on the counterparty chain.
-    fn validate_self_client(&self, counterparty_client_state: Any) -> Result<(), ConnectionError>;
-
-    /// Returns the prefix that the local chain uses in the KV store.
-    fn commitment_prefix(&self) -> CommitmentPrefix;
-
-    /// Returns a counter on how many connections have been created thus far.
-    fn connection_counter(&self) -> Result<u64, ContextError>;
-
-    /// Function required by ICS 03. Returns the list of all possible versions that the connection
-    /// handshake protocol supports.
-    fn get_compatible_versions(&self) -> Vec<ConnectionVersion> {
-        get_compatible_versions()
-    }
-
-    /// Function required by ICS 03. Returns one version out of the supplied list of versions, which the
-    /// connection handshake protocol prefers.
-    fn pick_version(
-        &self,
-        supported_versions: Vec<ConnectionVersion>,
-        counterparty_candidate_versions: Vec<ConnectionVersion>,
-    ) -> Result<ConnectionVersion, ContextError> {
-        pick_version(supported_versions, counterparty_candidate_versions)
-            .map_err(ContextError::ConnectionError)
-    }
-
-    /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
-    fn channel_end(
-        &self,
-        port_channel_id: &(PortId, ChannelId),
-    ) -> Result<ChannelEnd, ContextError>;
-
-    fn connection_channels(
-        &self,
-        cid: &ConnectionId,
-    ) -> Result<Vec<(PortId, ChannelId)>, ContextError>;
-
-    fn get_next_sequence_send(
-        &self,
-        port_channel_id: &(PortId, ChannelId),
-    ) -> Result<Sequence, ContextError>;
-
-    fn get_next_sequence_recv(
-        &self,
-        port_channel_id: &(PortId, ChannelId),
-    ) -> Result<Sequence, ContextError>;
-
-    fn get_next_sequence_ack(
-        &self,
-        port_channel_id: &(PortId, ChannelId),
-    ) -> Result<Sequence, ContextError>;
-
-    fn get_packet_commitment(
-        &self,
-        key: &(PortId, ChannelId, Sequence),
-    ) -> Result<PacketCommitment, ContextError>;
-
-    fn get_packet_receipt(
-        &self,
-        key: &(PortId, ChannelId, Sequence),
-    ) -> Result<Receipt, ContextError>;
-
-    fn get_packet_acknowledgement(
-        &self,
-        key: &(PortId, ChannelId, Sequence),
-    ) -> Result<AcknowledgementCommitment, ContextError>;
-
-    /// Compute the commitment for a packet.
-    /// Note that the absence of `timeout_height` is treated as
-    /// `{revision_number: 0, revision_height: 0}` to be consistent with ibc-go,
-    /// where this value is used to mean "no timeout height":
-    /// <https://github.com/cosmos/ibc-go/blob/04791984b3d6c83f704c4f058e6ca0038d155d91/modules/core/04-channel/keeper/packet.go#L206>
-    fn packet_commitment(
-        &self,
-        packet_data: Vec<u8>,
-        timeout_height: TimeoutHeight,
-        timeout_timestamp: Timestamp,
-    ) -> PacketCommitment {
-        let mut hash_input = timeout_timestamp.nanoseconds().to_be_bytes().to_vec();
-
-        let revision_number = timeout_height.commitment_revision_number().to_be_bytes();
-        hash_input.append(&mut revision_number.to_vec());
-
-        let revision_height = timeout_height.commitment_revision_height().to_be_bytes();
-        hash_input.append(&mut revision_height.to_vec());
-
-        let packet_data_hash = self.hash(packet_data);
-        hash_input.append(&mut packet_data_hash.to_vec());
-
-        self.hash(hash_input).into()
-    }
-
-    fn ack_commitment(&self, ack: Acknowledgement) -> AcknowledgementCommitment {
-        self.hash(ack.into()).into()
-    }
-
-    /// A hashing function for packet commitments
-    fn hash(&self, value: Vec<u8>) -> Vec<u8>;
-
-    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_time(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Timestamp, ContextError>;
-
-    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_height(
-        &self,
-        client_id: &ClientId,
-        height: Height,
-    ) -> Result<Height, ContextError>;
-
-    /// Returns a counter on the number of channel ids have been created thus far.
-    /// The value of this counter should increase only via method
-    /// `ChannelKeeper::increase_channel_counter`.
-    fn channel_counter(&self) -> Result<u64, ContextError>;
-
-    /// Returns the maximum expected time per block
-    fn max_expected_time_per_block(&self) -> Duration;
-
-    /// Calculates the block delay period using the connection's delay period and the maximum
-    /// expected time per block.
-    fn block_delay(&self, delay_period_time: Duration) -> u64 {
-        calculate_block_delay(delay_period_time, self.max_expected_time_per_block())
-    }
-}
-
-pub trait ExecutionContext: ValidationContext {
-    /// Execution entrypoint
-    fn execute(&mut self, message: MsgEnvelope) -> Result<(), RouterError>
-    where
-        Self: Sized,
-    {
-        match message {
-            MsgEnvelope::ClientMsg(message) => match message {
-                ClientMsg::CreateClient(message) => create_client::execute(self, message),
-                ClientMsg::UpdateClient(message) => update_client::execute(self, message),
-                ClientMsg::Misbehaviour(message) => misbehaviour::execute(self, message),
-                ClientMsg::UpgradeClient(message) => upgrade_client::execute(self, message),
-            }
-            .map_err(RouterError::ContextError),
-            MsgEnvelope::ConnectionMsg(message) => match message {
-                ConnectionMsg::ConnectionOpenInit(message) => {
-                    conn_open_init::execute(self, message)
+    pub trait ExecutionContext: ValidationContext {
+        /// Execution entrypoint
+        fn execute(&mut self, message: MsgEnvelope) -> Result<(), RouterError>
+        where
+            Self: Sized,
+        {
+            match message {
+                MsgEnvelope::ClientMsg(message) => match message {
+                    ClientMsg::CreateClient(message) => create_client::execute(self, message),
+                    ClientMsg::UpdateClient(message) => update_client::execute(self, message),
+                    ClientMsg::Misbehaviour(message) => misbehaviour::execute(self, message),
+                    ClientMsg::UpgradeClient(message) => upgrade_client::execute(self, message),
                 }
-                ConnectionMsg::ConnectionOpenTry(message) => conn_open_try::execute(self, message),
-                ConnectionMsg::ConnectionOpenAck(message) => conn_open_ack::execute(self, message),
-                ConnectionMsg::ConnectionOpenConfirm(ref message) => {
-                    conn_open_confirm::execute(self, message)
+                .map_err(RouterError::ContextError),
+                MsgEnvelope::ConnectionMsg(message) => match message {
+                    ConnectionMsg::ConnectionOpenInit(message) => {
+                        conn_open_init::execute(self, message)
+                    }
+                    ConnectionMsg::ConnectionOpenTry(message) => {
+                        conn_open_try::execute(self, message)
+                    }
+                    ConnectionMsg::ConnectionOpenAck(message) => {
+                        conn_open_ack::execute(self, message)
+                    }
+                    ConnectionMsg::ConnectionOpenConfirm(ref message) => {
+                        conn_open_confirm::execute(self, message)
+                    }
                 }
+                .map_err(RouterError::ContextError),
+                MsgEnvelope::ChannelMsg(_message) => todo!(),
+                MsgEnvelope::PacketMsg(_message) => todo!(),
             }
-            .map_err(RouterError::ContextError),
-            MsgEnvelope::ChannelMsg(_message) => todo!(),
-            MsgEnvelope::PacketMsg(_message) => todo!(),
         }
+
+        /// Called upon successful client creation
+        fn store_client_type(
+            &mut self,
+            client_type_path: ClientTypePath,
+            client_type: ClientType,
+        ) -> Result<(), ContextError>;
+
+        /// Called upon successful client creation and update
+        fn store_client_state(
+            &mut self,
+            client_state_path: ClientStatePath,
+            client_state: Box<dyn ClientState>,
+        ) -> Result<(), ContextError>;
+
+        /// Called upon successful client creation and update
+        fn store_consensus_state(
+            &mut self,
+            consensus_state_path: ClientConsensusStatePath,
+            consensus_state: Box<dyn ConsensusState>,
+        ) -> Result<(), ContextError>;
+
+        /// Called upon client creation.
+        /// Increases the counter which keeps track of how many clients have been created.
+        /// Should never fail.
+        fn increase_client_counter(&mut self);
+
+        /// Called upon successful client update.
+        /// Implementations are expected to use this to record the specified time as the time at which
+        /// this update (or header) was processed.
+        fn store_update_time(
+            &mut self,
+            client_id: ClientId,
+            height: Height,
+            timestamp: Timestamp,
+        ) -> Result<(), ContextError>;
+
+        /// Called upon successful client update.
+        /// Implementations are expected to use this to record the specified height as the height at
+        /// at which this update (or header) was processed.
+        fn store_update_height(
+            &mut self,
+            client_id: ClientId,
+            height: Height,
+            host_height: Height,
+        ) -> Result<(), ContextError>;
+
+        /// Stores the given connection_end at path
+        fn store_connection(
+            &mut self,
+            connections_path: ConnectionsPath,
+            connection_end: &ConnectionEnd,
+        ) -> Result<(), ContextError>;
+
+        /// Stores the given connection_id at a path associated with the client_id.
+        fn store_connection_to_client(
+            &mut self,
+            client_connections_path: ClientConnectionsPath,
+            conn_id: &ConnectionId,
+        ) -> Result<(), ContextError>;
+
+        /// Called upon connection identifier creation (Init or Try process).
+        /// Increases the counter which keeps track of how many connections have been created.
+        /// Should never fail.
+        fn increase_connection_counter(&mut self);
+
+        fn store_packet_commitment(
+            &mut self,
+            commitments_path: CommitmentsPath,
+            commitment: PacketCommitment,
+        ) -> Result<(), ContextError>;
+
+        fn delete_packet_commitment(&mut self, key: CommitmentsPath) -> Result<(), ContextError>;
+
+        fn store_packet_receipt(
+            &mut self,
+            path: ReceiptsPath,
+            receipt: Receipt,
+        ) -> Result<(), ContextError>;
+
+        fn store_packet_acknowledgement(
+            &mut self,
+            key: (PortId, ChannelId, Sequence),
+            ack_commitment: AcknowledgementCommitment,
+        ) -> Result<(), ContextError>;
+
+        fn delete_packet_acknowledgement(
+            &mut self,
+            key: (PortId, ChannelId, Sequence),
+        ) -> Result<(), ContextError>;
+
+        fn store_connection_channels(
+            &mut self,
+            conn_id: ConnectionId,
+            port_channel_id: &(PortId, ChannelId),
+        ) -> Result<(), ContextError>;
+
+        /// Stores the given channel_end at a path associated with the port_id and channel_id.
+        fn store_channel(
+            &mut self,
+            port_channel_id: (PortId, ChannelId),
+            channel_end: &ChannelEnd,
+        ) -> Result<(), ContextError>;
+
+        fn store_next_sequence_send(
+            &mut self,
+            port_channel_id: (PortId, ChannelId),
+            seq: Sequence,
+        ) -> Result<(), ContextError>;
+
+        fn store_next_sequence_recv(
+            &mut self,
+            port_channel_id: (PortId, ChannelId),
+            seq: Sequence,
+        ) -> Result<(), ContextError>;
+
+        fn store_next_sequence_ack(
+            &mut self,
+            port_channel_id: (PortId, ChannelId),
+            seq: Sequence,
+        ) -> Result<(), ContextError>;
+
+        /// Called upon channel identifier creation (Init or Try message processing).
+        /// Increases the counter which keeps track of how many channels have been created.
+        /// Should never fail.
+        fn increase_channel_counter(&mut self);
+
+        /// Ibc events
+        fn emit_ibc_event(&mut self, event: IbcEvent);
+
+        /// Logging facility
+        fn log_message(&mut self, message: String);
     }
-
-    /// Called upon successful client creation
-    fn store_client_type(
-        &mut self,
-        client_type_path: ClientTypePath,
-        client_type: ClientType,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon successful client creation and update
-    fn store_client_state(
-        &mut self,
-        client_state_path: ClientStatePath,
-        client_state: Box<dyn ClientState>,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon successful client creation and update
-    fn store_consensus_state(
-        &mut self,
-        consensus_state_path: ClientConsensusStatePath,
-        consensus_state: Box<dyn ConsensusState>,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon client creation.
-    /// Increases the counter which keeps track of how many clients have been created.
-    /// Should never fail.
-    fn increase_client_counter(&mut self);
-
-    /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified time as the time at which
-    /// this update (or header) was processed.
-    fn store_update_time(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        timestamp: Timestamp,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified height as the height at
-    /// at which this update (or header) was processed.
-    fn store_update_height(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        host_height: Height,
-    ) -> Result<(), ContextError>;
-
-    /// Stores the given connection_end at path
-    fn store_connection(
-        &mut self,
-        connections_path: ConnectionsPath,
-        connection_end: &ConnectionEnd,
-    ) -> Result<(), ContextError>;
-
-    /// Stores the given connection_id at a path associated with the client_id.
-    fn store_connection_to_client(
-        &mut self,
-        client_connections_path: ClientConnectionsPath,
-        conn_id: &ConnectionId,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon connection identifier creation (Init or Try process).
-    /// Increases the counter which keeps track of how many connections have been created.
-    /// Should never fail.
-    fn increase_connection_counter(&mut self);
-
-    fn store_packet_commitment(
-        &mut self,
-        commitments_path: CommitmentsPath,
-        commitment: PacketCommitment,
-    ) -> Result<(), ContextError>;
-
-    fn delete_packet_commitment(&mut self, key: CommitmentsPath) -> Result<(), ContextError>;
-
-    fn store_packet_receipt(
-        &mut self,
-        path: ReceiptsPath,
-        receipt: Receipt,
-    ) -> Result<(), ContextError>;
-
-    fn store_packet_acknowledgement(
-        &mut self,
-        key: (PortId, ChannelId, Sequence),
-        ack_commitment: AcknowledgementCommitment,
-    ) -> Result<(), ContextError>;
-
-    fn delete_packet_acknowledgement(
-        &mut self,
-        key: (PortId, ChannelId, Sequence),
-    ) -> Result<(), ContextError>;
-
-    fn store_connection_channels(
-        &mut self,
-        conn_id: ConnectionId,
-        port_channel_id: &(PortId, ChannelId),
-    ) -> Result<(), ContextError>;
-
-    /// Stores the given channel_end at a path associated with the port_id and channel_id.
-    fn store_channel(
-        &mut self,
-        port_channel_id: (PortId, ChannelId),
-        channel_end: &ChannelEnd,
-    ) -> Result<(), ContextError>;
-
-    fn store_next_sequence_send(
-        &mut self,
-        port_channel_id: (PortId, ChannelId),
-        seq: Sequence,
-    ) -> Result<(), ContextError>;
-
-    fn store_next_sequence_recv(
-        &mut self,
-        port_channel_id: (PortId, ChannelId),
-        seq: Sequence,
-    ) -> Result<(), ContextError>;
-
-    fn store_next_sequence_ack(
-        &mut self,
-        port_channel_id: (PortId, ChannelId),
-        seq: Sequence,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon channel identifier creation (Init or Try message processing).
-    /// Increases the counter which keeps track of how many channels have been created.
-    /// Should never fail.
-    fn increase_channel_counter(&mut self);
-
-    /// Ibc events
-    fn emit_ibc_event(&mut self, event: IbcEvent);
-
-    /// Logging facility
-    fn log_message(&mut self, message: String);
 }

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -18,13 +18,15 @@ use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
 };
 use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
-use crate::core::{ContextError, ValidationContext};
 use crate::dynamic_typing::AsAny;
 use crate::prelude::*;
 use crate::Height;
 
 use super::consensus_state::ConsensusState;
 use super::context::ClientReader;
+
+#[cfg(val_exec_ctx)]
+use crate::core::{ContextError, ValidationContext};
 
 pub trait ClientState:
     AsAny
@@ -86,6 +88,7 @@ pub trait ClientState:
     ) -> Result<UpdatedState, ClientError>;
 
     /// XXX: temporary solution until we get rid of `ClientReader`
+    #[cfg(val_exec_ctx)]
     fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
@@ -101,6 +104,7 @@ pub trait ClientState:
     ) -> Result<Box<dyn ClientState>, ClientError>;
 
     /// XXX: temporary solution until we get rid of `ClientReader`
+    #[cfg(val_exec_ctx)]
     fn new_check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ValidationContext,

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -1,12 +1,19 @@
 //! Protocol logic specific to processing ICS2 messages of type `MsgCreateClient`.
 
-use crate::core::context::ContextError;
-use crate::core::ics24_host::path::ClientConsensusStatePath;
-use crate::core::ics24_host::path::ClientStatePath;
-use crate::core::ics24_host::path::ClientTypePath;
 use crate::prelude::*;
 
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::ClientConsensusStatePath;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::ClientStatePath;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::ClientTypePath;
+
+#[cfg(val_exec_ctx)]
 use crate::core::ExecutionContext;
+#[cfg(val_exec_ctx)]
 use crate::core::ValidationContext;
 
 use crate::core::ics02_client::client_state::ClientState;
@@ -34,6 +41,7 @@ pub struct CreateClientResult {
     pub processed_height: Height,
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgCreateClient) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -62,6 +70,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgCreateClient) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
@@ -1,5 +1,7 @@
 //! Protocol logic specific to processing ICS2 messages of type `MsgSubmitMisbehaviour`.
 //!
+use crate::prelude::*;
+
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics02_client::error::ClientError;
@@ -7,11 +9,13 @@ use crate::core::ics02_client::events::ClientMisbehaviour;
 use crate::core::ics02_client::handler::ClientResult;
 use crate::core::ics02_client::msgs::misbehaviour::MsgSubmitMisbehaviour;
 use crate::core::ics24_host::identifier::ClientId;
-use crate::core::ics24_host::path::ClientStatePath;
-use crate::core::{ContextError, ExecutionContext, ValidationContext};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::prelude::*;
+
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::ClientStatePath;
+#[cfg(val_exec_ctx)]
+use crate::core::{ContextError, ExecutionContext, ValidationContext};
 
 /// The result following the successful processing of a `MsgSubmitMisbehaviour` message.
 #[derive(Clone, Debug, PartialEq)]
@@ -20,6 +24,7 @@ pub struct MisbehaviourResult {
     pub client_state: Box<dyn ClientState>,
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgSubmitMisbehaviour) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -46,6 +51,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgSubmitMisbehaviour) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -2,7 +2,8 @@
 
 use tracing::debug;
 
-use crate::core::context::ContextError;
+use crate::prelude::*;
+
 use crate::core::ics02_client::client_state::{ClientState, UpdatedState};
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::context::ClientReader;
@@ -12,12 +13,16 @@ use crate::core::ics02_client::handler::ClientResult;
 use crate::core::ics02_client::height::Height;
 use crate::core::ics02_client::msgs::update_client::MsgUpdateClient;
 use crate::core::ics24_host::identifier::ClientId;
-use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
-use crate::core::{ExecutionContext, ValidationContext};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::prelude::*;
 use crate::timestamp::Timestamp;
+
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
+#[cfg(val_exec_ctx)]
+use crate::core::{ExecutionContext, ValidationContext};
 
 /// The result following the successful processing of a `MsgUpdateAnyClient` message.
 #[derive(Clone, Debug, PartialEq)]
@@ -29,6 +34,7 @@ pub struct UpdateClientResult {
     pub processed_height: Height,
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgUpdateClient) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -82,6 +88,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgUpdateClient) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -1,6 +1,7 @@
 //! Protocol logic specific to processing ICS2 messages of type `MsgUpgradeAnyClient`.
 //!
-use crate::core::context::ContextError;
+use crate::prelude::*;
+
 use crate::core::ics02_client::client_state::{ClientState, UpdatedState};
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::context::ClientReader;
@@ -9,11 +10,15 @@ use crate::core::ics02_client::events::UpgradeClient;
 use crate::core::ics02_client::handler::ClientResult;
 use crate::core::ics02_client::msgs::upgrade_client::MsgUpgradeClient;
 use crate::core::ics24_host::identifier::ClientId;
-use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
-use crate::core::{ExecutionContext, ValidationContext};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::prelude::*;
+
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
+#[cfg(val_exec_ctx)]
+use crate::core::{ExecutionContext, ValidationContext};
 
 /// The result following the successful processing of a `MsgUpgradeAnyClient` message.
 #[derive(Clone, Debug, PartialEq)]
@@ -23,6 +28,7 @@ pub struct UpgradeClientResult {
     pub consensus_state: Box<dyn ConsensusState>,
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgUpgradeClient) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -49,6 +55,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgUpgradeClient) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -1,21 +1,27 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenAck`.
+use crate::prelude::*;
 
-use crate::core::context::ContextError;
 use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::context::ConnectionReader;
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::events::OpenAck;
 use crate::core::ics03_connection::handler::ConnectionResult;
 use crate::core::ics03_connection::msgs::conn_open_ack::MsgConnectionOpenAck;
-use crate::core::ics24_host::identifier::ClientId;
-use crate::core::ics24_host::path::ConnectionsPath;
-use crate::core::{ExecutionContext, ValidationContext};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::prelude::*;
+
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::identifier::ClientId;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::ConnectionsPath;
+#[cfg(val_exec_ctx)]
+use crate::core::{ExecutionContext, ValidationContext};
 
 use super::ConnectionIdState;
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx_a: &Ctx, msg: MsgConnectionOpenAck) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -24,6 +30,7 @@ where
     validate_impl(ctx_a, &msg, &vars)
 }
 
+#[cfg(val_exec_ctx)]
 fn validate_impl<Ctx>(
     ctx_a: &Ctx,
     msg: &MsgConnectionOpenAck,
@@ -135,6 +142,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(ctx_a: &mut Ctx, msg: MsgConnectionOpenAck) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,
@@ -143,6 +151,7 @@ where
     execute_impl(ctx_a, msg, vars)
 }
 
+#[cfg(val_exec_ctx)]
 fn execute_impl<Ctx>(
     ctx_a: &mut Ctx,
     msg: MsgConnectionOpenAck,
@@ -178,10 +187,12 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 struct LocalVars {
     conn_end_on_a: ConnectionEnd,
 }
 
+#[cfg(val_exec_ctx)]
 impl LocalVars {
     fn new<Ctx>(ctx_a: &Ctx, msg: &MsgConnectionOpenAck) -> Result<Self, ContextError>
     where
@@ -328,8 +339,6 @@ pub(crate) fn process(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ics26_routing::msgs::MsgEnvelope;
-    use crate::core::ValidationContext;
     use crate::prelude::*;
 
     use core::str::FromStr;
@@ -347,6 +356,11 @@ mod tests {
     use crate::mock::context::MockContext;
     use crate::mock::host::HostType;
     use crate::timestamp::ZERO_DURATION;
+
+    #[cfg(val_exec_ctx)]
+    use crate::core::ics26_routing::msgs::MsgEnvelope;
+    #[cfg(val_exec_ctx)]
+    use crate::core::ValidationContext;
 
     #[test]
     fn conn_open_ack_msg_processing() {
@@ -458,30 +472,33 @@ mod tests {
         ];
 
         for test in tests {
-            let res = ValidationContext::validate(
-                &test.ctx,
-                MsgEnvelope::ConnectionMsg(test.msg.clone()),
-            );
+            #[cfg(val_exec_ctx)]
+            {
+                let res = ValidationContext::validate(
+                    &test.ctx,
+                    MsgEnvelope::ConnectionMsg(test.msg.clone()),
+                );
 
-            match res {
-                Ok(_) => {
-                    assert!(
+                match res {
+                    Ok(_) => {
+                        assert!(
                         test.want_pass,
                         "conn_open_ack: test passed but was supposed to fail for test: {}, \nparams {:?} {:?}",
                         test.name,
                         test.msg.clone(),
                         test.ctx.clone()
                     )
-                }
-                Err(e) => {
-                    assert!(
-                        !test.want_pass,
-                        "conn_open_ack: did not pass test: {}, \nparams {:?} {:?} error: {:?}",
-                        test.name,
-                        test.msg,
-                        test.ctx.clone(),
-                        e,
-                    );
+                    }
+                    Err(e) => {
+                        assert!(
+                            !test.want_pass,
+                            "conn_open_ack: did not pass test: {}, \nparams {:?} {:?} error: {:?}",
+                            test.name,
+                            test.msg,
+                            test.ctx.clone(),
+                            e,
+                        );
+                    }
                 }
             }
 

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -1,19 +1,25 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenConfirm`.
+use crate::prelude::*;
 
-use crate::core::context::ContextError;
 use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::context::ConnectionReader;
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::events::OpenConfirm;
 use crate::core::ics03_connection::handler::{ConnectionIdState, ConnectionResult};
 use crate::core::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenConfirm;
-use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
-use crate::core::ics24_host::path::ConnectionsPath;
-use crate::core::{ExecutionContext, ValidationContext};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::prelude::*;
 
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::ConnectionsPath;
+#[cfg(val_exec_ctx)]
+use crate::core::{ExecutionContext, ValidationContext};
+
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgConnectionOpenConfirm) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -22,6 +28,7 @@ where
     validate_impl(ctx_b, msg, &vars)
 }
 
+#[cfg(val_exec_ctx)]
 fn validate_impl<Ctx>(
     ctx_b: &Ctx,
     msg: &MsgConnectionOpenConfirm,
@@ -86,6 +93,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(
     ctx_b: &mut Ctx,
     msg: &MsgConnectionOpenConfirm,
@@ -97,6 +105,7 @@ where
     execute_impl(ctx_b, msg, vars)
 }
 
+#[cfg(val_exec_ctx)]
 fn execute_impl<Ctx>(
     ctx_b: &mut Ctx,
     msg: &MsgConnectionOpenConfirm,
@@ -134,10 +143,12 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 struct LocalVars {
     conn_end_on_b: ConnectionEnd,
 }
 
+#[cfg(val_exec_ctx)]
 impl LocalVars {
     fn new<Ctx>(ctx_b: &Ctx, msg: &MsgConnectionOpenConfirm) -> Result<Self, ContextError>
     where
@@ -250,8 +261,6 @@ pub(crate) fn process(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ics26_routing::msgs::MsgEnvelope;
-    use crate::core::ValidationContext;
     use crate::prelude::*;
 
     use core::str::FromStr;
@@ -269,6 +278,11 @@ mod tests {
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
     use crate::Height;
+
+    #[cfg(val_exec_ctx)]
+    use crate::core::ics26_routing::msgs::MsgEnvelope;
+    #[cfg(val_exec_ctx)]
+    use crate::core::ValidationContext;
 
     #[test]
     fn conn_open_confirm_msg_processing() {
@@ -330,23 +344,25 @@ mod tests {
         .collect();
 
         for test in tests {
-            let res = ValidationContext::validate(
-                &test.ctx,
-                MsgEnvelope::ConnectionMsg(test.msg.clone()),
-            );
+            #[cfg(val_exec_ctx)]
+            {
+                let res = ValidationContext::validate(
+                    &test.ctx,
+                    MsgEnvelope::ConnectionMsg(test.msg.clone()),
+                );
 
-            match res {
-                Ok(_) => {
-                    assert!(
+                match res {
+                    Ok(_) => {
+                        assert!(
                         test.want_pass,
                         "conn_open_confirm: test passed but was supposed to fail for test: {}, \nparams {:?} {:?}",
                         test.name,
                         test.msg.clone(),
                         test.ctx.clone()
                     )
-                }
-                Err(e) => {
-                    assert!(
+                    }
+                    Err(e) => {
+                        assert!(
                         !test.want_pass,
                         "conn_open_confirm: did not pass test: {}, \nparams {:?} {:?} error: {:?}",
                         test.name,
@@ -354,6 +370,7 @@ mod tests {
                         test.ctx.clone(),
                         e,
                     );
+                    }
                 }
             }
 

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -1,21 +1,28 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenTry`.
+use crate::prelude::*;
 
-use crate::core::context::ContextError;
 use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::context::ConnectionReader;
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::events::OpenTry;
 use crate::core::ics03_connection::handler::ConnectionResult;
 use crate::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
-use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
-use crate::core::ics24_host::path::{ClientConnectionsPath, ConnectionsPath};
-use crate::core::{ExecutionContext, ValidationContext};
+use crate::core::ics24_host::identifier::ConnectionId;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
-use crate::prelude::*;
 
 use super::ConnectionIdState;
 
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::identifier::ClientId;
+#[cfg(val_exec_ctx)]
+use crate::core::ics24_host::path::{ClientConnectionsPath, ConnectionsPath};
+#[cfg(val_exec_ctx)]
+use crate::core::{ExecutionContext, ValidationContext};
+
+#[cfg(val_exec_ctx)]
 pub(crate) fn validate<Ctx>(ctx_b: &Ctx, msg: MsgConnectionOpenTry) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -24,6 +31,7 @@ where
     validate_impl(ctx_b, &msg, &vars)
 }
 
+#[cfg(val_exec_ctx)]
 fn validate_impl<Ctx>(
     ctx_b: &Ctx,
     msg: &MsgConnectionOpenTry,
@@ -124,6 +132,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 pub(crate) fn execute<Ctx>(ctx_b: &mut Ctx, msg: MsgConnectionOpenTry) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,
@@ -132,6 +141,7 @@ where
     execute_impl(ctx_b, msg, vars)
 }
 
+#[cfg(val_exec_ctx)]
 fn execute_impl<Ctx>(
     ctx_b: &mut Ctx,
     msg: MsgConnectionOpenTry,
@@ -163,6 +173,7 @@ where
     Ok(())
 }
 
+#[cfg(val_exec_ctx)]
 struct LocalVars {
     conn_id_on_b: ConnectionId,
     conn_end_on_b: ConnectionEnd,
@@ -170,6 +181,7 @@ struct LocalVars {
     conn_id_on_a: ConnectionId,
 }
 
+#[cfg(val_exec_ctx)]
 impl LocalVars {
     fn new<Ctx>(ctx_b: &Ctx, msg: &MsgConnectionOpenTry) -> Result<Self, ContextError>
     where
@@ -316,8 +328,6 @@ pub(crate) fn process(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ics26_routing::msgs::MsgEnvelope;
-    use crate::core::ValidationContext;
     use crate::prelude::*;
 
     use test_log::test;
@@ -332,6 +342,11 @@ mod tests {
     use crate::mock::context::MockContext;
     use crate::mock::host::HostType;
     use crate::Height;
+
+    #[cfg(val_exec_ctx)]
+    use crate::core::ics26_routing::msgs::MsgEnvelope;
+    #[cfg(val_exec_ctx)]
+    use crate::core::ValidationContext;
 
     #[test]
     fn conn_open_try_msg_processing() {
@@ -425,33 +440,35 @@ mod tests {
         .collect();
 
         for test in tests {
-            let res = ValidationContext::validate(
-                &test.ctx,
-                MsgEnvelope::ConnectionMsg(test.msg.clone()),
-            );
+            #[cfg(val_exec_ctx)]
+            {
+                let res = ValidationContext::validate(
+                    &test.ctx,
+                    MsgEnvelope::ConnectionMsg(test.msg.clone()),
+                );
 
-            match res {
-                Ok(_) => {
-                    assert!(
+                match res {
+                    Ok(_) => {
+                        assert!(
                         test.want_pass,
                         "conn_open_try: test passed but was supposed to fail for test: {}, \nparams {:?} {:?}",
                         test.name,
                         test.msg.clone(),
                         test.ctx.clone()
                     )
-                }
-                Err(e) => {
-                    assert!(
-                        !test.want_pass,
-                        "conn_open_try: did not pass test: {}, \nparams {:?} {:?} error: {:?}",
-                        test.name,
-                        test.msg,
-                        test.ctx.clone(),
-                        e,
-                    );
+                    }
+                    Err(e) => {
+                        assert!(
+                            !test.want_pass,
+                            "conn_open_try: did not pass test: {}, \nparams {:?} {:?} error: {:?}",
+                            test.name,
+                            test.msg,
+                            test.ctx.clone(),
+                            e,
+                        );
+                    }
                 }
             }
-
             let res = dispatch(&test.ctx, test.msg.clone());
             // Additionally check the events and the output objects in the result.
             match res {

--- a/crates/ibc/src/core/mod.rs
+++ b/crates/ibc/src/core/mod.rs
@@ -28,12 +28,17 @@ pub mod ics24_host;
 pub mod ics26_routing;
 
 pub mod context;
+
+#[cfg(val_exec_ctx)]
 pub mod handler;
-
-pub use context::ExecutionContext;
-pub use context::ValidationContext;
-
+#[cfg(val_exec_ctx)]
 pub use handler::execute;
+#[cfg(val_exec_ctx)]
 pub use handler::validate;
+
+#[cfg(val_exec_ctx)]
+pub use context::ExecutionContext;
+#[cfg(val_exec_ctx)]
+pub use context::ValidationContext;
 
 pub use context::ContextError;

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -1,4 +1,3 @@
-use crate::core::{ContextError, ValidationContext};
 use crate::prelude::*;
 
 use alloc::collections::btree_map::BTreeMap as HashMap;
@@ -32,7 +31,11 @@ use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::consensus_state::MockConsensusState;
 use crate::mock::header::MockHeader;
 use crate::mock::misbehaviour::Misbehaviour;
+
 use crate::Height;
+
+#[cfg(val_exec_ctx)]
+use crate::core::{ContextError, ValidationContext};
 
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
 
@@ -201,6 +204,7 @@ impl ClientState for MockClientState {
         })
     }
 
+    #[cfg(val_exec_ctx)]
     fn new_check_header_and_update_state(
         &self,
         _ctx: &dyn ValidationContext,
@@ -249,6 +253,7 @@ impl ClientState for MockClientState {
         Ok(new_state.into_box())
     }
 
+    #[cfg(val_exec_ctx)]
     fn new_check_misbehaviour_and_update_state(
         &self,
         _ctx: &dyn ValidationContext,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1,8 +1,6 @@
 //! Implementation of a global context mock. Used in testing handlers of all IBC modules.
 
 use crate::clients::ics07_tendermint::TENDERMINT_CLIENT_TYPE;
-use crate::core::context::ContextError;
-use crate::core::ValidationContext;
 use crate::prelude::*;
 
 use alloc::collections::btree_map::BTreeMap;
@@ -55,6 +53,11 @@ use crate::timestamp::Timestamp;
 use crate::Height;
 
 use super::client_state::MOCK_CLIENT_TYPE;
+
+#[cfg(val_exec_ctx)]
+use crate::core::context::ContextError;
+#[cfg(val_exec_ctx)]
+use crate::core::ValidationContext;
 
 pub const DEFAULT_BLOCK_TIME_SECS: u64 = 3;
 
@@ -1497,6 +1500,7 @@ impl RelayerContext for MockContext {
     }
 }
 
+#[cfg(val_exec_ctx)]
 impl ValidationContext for MockContext {
     fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, ContextError> {
         ClientReader::client_state(self, client_id).map_err(ContextError::ClientError)


### PR DESCRIPTION
Allows us to release v0.25.0 without being blocked by the unfinished ADR 5 implementation.

