### PR TITLE
Simplify `Msg` trait by removing unnecessary interfaces

### DIFF
--- a/.changelog/unreleased/breaking-changes/218-prune-msg-interface.md
+++ b/.changelog/unreleased/breaking-changes/218-prune-msg-interface.md
@@ -1,0 +1,2 @@
+- Simplify Msg trait by removing unnecessary interfaces.
+  ([#218](https://github.com/cosmos/ibc-rs/issues/218))

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -95,7 +95,6 @@ default-features = false
 env_logger = "0.10.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-modelator = "0.4.2"
 sha2 = { version = "0.10.6" }
 tendermint-rpc = { version = "0.28", features = ["http-client", "websocket-client"] }
 tendermint-testgen = { version = "0.28" } # Needed for generating (synthetic) light blocks.

--- a/crates/ibc/src/applications/transfer/msgs/transfer.rs
+++ b/crates/ibc/src/applications/transfer/msgs/transfer.rs
@@ -44,12 +44,7 @@ pub struct MsgTransfer<C = Coin> {
 }
 
 impl Msg for MsgTransfer {
-    type ValidationError = TokenTransferError;
     type Raw = RawMsgTransfer;
-
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
 
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
@@ -125,17 +120,6 @@ impl TryFrom<Any> for MsgTransfer {
             _ => Err(TokenTransferError::UnknownMsgType {
                 msg_type: raw.type_url,
             }),
-        }
-    }
-}
-
-impl From<MsgTransfer> for Any {
-    fn from(msg: MsgTransfer) -> Self {
-        Self {
-            type_url: TYPE_URL.to_string(),
-            value: msg
-                .encode_vec()
-                .expect("encoding to `Any` from `MsgTranfer`"),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
@@ -9,12 +9,9 @@ use tendermint_proto::google::protobuf as tpb;
 
 use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header;
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
 use crate::timestamp::Timestamp;
-
-use super::client_type as tm_client_type;
 
 pub const TENDERMINT_CONSENSUS_STATE_TYPE_URL: &str =
     "/ibc.lightclients.tendermint.v1.ConsensusState";
@@ -37,10 +34,6 @@ impl ConsensusState {
 }
 
 impl crate::core::ics02_client::consensus_state::ConsensusState for ConsensusState {
-    fn client_type(&self) -> ClientType {
-        tm_client_type()
-    }
-
     fn root(&self) -> &CommitmentRoot {
         &self.root
     }

--- a/crates/ibc/src/clients/ics07_tendermint/header.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/header.rs
@@ -15,14 +15,11 @@ use tendermint_light_client_verifier::types::{TrustedBlockState, UntrustedBlockS
 
 use crate::clients::ics07_tendermint::consensus_state::ConsensusState;
 use crate::clients::ics07_tendermint::error::Error;
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics24_host::identifier::ChainId;
 use crate::timestamp::Timestamp;
 use crate::utils::pretty::{PrettySignedHeader, PrettyValidatorSet};
 use crate::Height;
-
-use super::client_type as tm_client_type;
 
 pub const TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.Header";
 
@@ -111,10 +108,6 @@ pub fn headers_compatible(header: &SignedHeader, other: &SignedHeader) -> bool {
 }
 
 impl crate::core::ics02_client::header::Header for Header {
-    fn client_type(&self) -> ClientType {
-        tm_client_type()
-    }
-
     fn height(&self) -> Height {
         self.height()
     }

--- a/crates/ibc/src/core/ics02_client/consensus_state.rs
+++ b/crates/ibc/src/core/ics02_client/consensus_state.rs
@@ -7,7 +7,6 @@ use erased_serde::Serialize as ErasedSerialize;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::protobuf::Protobuf as ErasedProtobuf;
 
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
 use crate::dynamic_typing::AsAny;
@@ -30,9 +29,6 @@ pub trait ConsensusState:
     + Send
     + Sync
 {
-    /// Type of client associated with this consensus state (eg. Tendermint)
-    fn client_type(&self) -> ClientType;
-
     /// Commitment root of the consensus state, which is used for key-value pair verification.
     fn root(&self) -> &CommitmentRoot;
 

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -219,8 +219,7 @@ mod tests {
             MockClientState::new(MockHeader::new(height)).into(),
             MockConsensusState::new(MockHeader::new(height)).into(),
             signer,
-        )
-        .unwrap();
+        );
 
         let output = dispatch(&ctx, ClientMsg::CreateClient(msg.clone()));
 
@@ -266,20 +265,17 @@ mod tests {
                 MockClientState::new(MockHeader::new(height_2)).into(),
                 MockConsensusState::new(MockHeader::new(height_2)).into(),
                 signer.clone(),
-            )
-            .unwrap(),
+            ),
             MsgCreateClient::new(
                 MockClientState::new(MockHeader::new(height_2)).into(),
                 MockConsensusState::new(MockHeader::new(height_2)).into(),
                 signer.clone(),
-            )
-            .unwrap(),
+            ),
             MsgCreateClient::new(
                 MockClientState::new(MockHeader::new(height_3)).into(),
                 MockConsensusState::new(MockHeader::new(height_3)).into(),
                 signer,
-            )
-            .unwrap(),
+            ),
         ]
         .into_iter()
         .collect();
@@ -350,8 +346,7 @@ mod tests {
             tm_client_state,
             TmConsensusState::try_from(tm_header).unwrap().into(),
             signer,
-        )
-        .unwrap();
+        );
 
         let output = dispatch(&ctx, ClientMsg::CreateClient(msg.clone()));
 

--- a/crates/ibc/src/core/ics02_client/header.rs
+++ b/crates/ibc/src/core/ics02_client/header.rs
@@ -5,7 +5,6 @@ use erased_serde::Serialize as ErasedSerialize;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::protobuf::Protobuf as ErasedProtobuf;
 
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::ClientError;
 use crate::dynamic_typing::AsAny;
 use crate::timestamp::Timestamp;
@@ -27,9 +26,6 @@ pub trait Header:
     + Send
     + Sync
 {
-    /// The type of client (eg. Tendermint)
-    fn client_type(&self) -> ClientType;
-
     /// The height of the consensus state
     fn height(&self) -> Height;
 

--- a/crates/ibc/src/core/ics02_client/msgs/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/create_client.rs
@@ -31,7 +31,6 @@ impl MsgCreateClient {
 }
 
 impl Msg for MsgCreateClient {
-    type ValidationError = crate::core::ics24_host::error::ValidationError;
     type Raw = RawMsgCreateClient;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics02_client/msgs/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/create_client.rs
@@ -21,26 +21,18 @@ pub struct MsgCreateClient {
 }
 
 impl MsgCreateClient {
-    pub fn new(
-        client_state: Any,
-        consensus_state: Any,
-        signer: Signer,
-    ) -> Result<Self, ClientError> {
-        Ok(MsgCreateClient {
+    pub fn new(client_state: Any, consensus_state: Any, signer: Signer) -> Self {
+        MsgCreateClient {
             client_state,
             consensus_state,
             signer,
-        })
+        }
     }
 }
 
 impl Msg for MsgCreateClient {
     type ValidationError = crate::core::ics24_host::error::ValidationError;
     type Raw = RawMsgCreateClient;
-
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
 
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
@@ -59,11 +51,11 @@ impl TryFrom<RawMsgCreateClient> for MsgCreateClient {
             .consensus_state
             .ok_or(ClientError::MissingRawConsensusState)?;
 
-        MsgCreateClient::new(
+        Ok(MsgCreateClient::new(
             raw_client_state,
             raw_consensus_state,
             raw.signer.parse().map_err(ClientError::Signer)?,
-        )
+        ))
     }
 }
 
@@ -101,8 +93,7 @@ mod tests {
             tm_client_state,
             TmConsensusState::try_from(tm_header).unwrap().into(),
             signer,
-        )
-        .unwrap();
+        );
 
         let raw = RawMsgCreateClient::from(msg.clone());
         let msg_back = MsgCreateClient::try_from(raw.clone()).unwrap();

--- a/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
@@ -23,7 +23,6 @@ pub struct MsgSubmitMisbehaviour {
 }
 
 impl Msg for MsgSubmitMisbehaviour {
-    type ValidationError = crate::core::ics24_host::error::ValidationError;
     type Raw = RawMsgSubmitMisbehaviour;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
@@ -26,10 +26,6 @@ impl Msg for MsgSubmitMisbehaviour {
     type ValidationError = crate::core::ics24_host::error::ValidationError;
     type Raw = RawMsgSubmitMisbehaviour;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -7,7 +7,6 @@ use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
 use ibc_proto::protobuf::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
-use crate::core::ics24_host::error::ValidationError;
 use crate::core::ics24_host::identifier::ClientId;
 use crate::signer::Signer;
 use crate::tx_msg::Msg;
@@ -33,7 +32,6 @@ impl MsgUpdateClient {
 }
 
 impl Msg for MsgUpdateClient {
-    type ValidationError = ValidationError;
     type Raw = RawMsgUpdateClient;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -36,10 +36,6 @@ impl Msg for MsgUpdateClient {
     type ValidationError = ValidationError;
     type Raw = RawMsgUpdateClient;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics02_client/msgs/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/upgrade_client.rs
@@ -50,7 +50,6 @@ impl MsgUpgradeClient {
 }
 
 impl Msg for MsgUpgradeClient {
-    type ValidationError = crate::core::ics24_host::error::ValidationError;
     type Raw = RawMsgUpgradeClient;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics02_client/msgs/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/upgrade_client.rs
@@ -53,10 +53,6 @@ impl Msg for MsgUpgradeClient {
     type ValidationError = crate::core::ics24_host::error::ValidationError;
     type Raw = RawMsgUpgradeClient;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -39,7 +39,6 @@ pub struct MsgConnectionOpenAck {
 }
 
 impl Msg for MsgConnectionOpenAck {
-    type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenAck;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -42,10 +42,6 @@ impl Msg for MsgConnectionOpenAck {
     type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenAck;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_confirm.rs
@@ -29,10 +29,6 @@ impl Msg for MsgConnectionOpenConfirm {
     type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenConfirm;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_confirm.rs
@@ -26,7 +26,6 @@ pub struct MsgConnectionOpenConfirm {
 }
 
 impl Msg for MsgConnectionOpenConfirm {
-    type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenConfirm;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_init.rs
@@ -27,7 +27,6 @@ pub struct MsgConnectionOpenInit {
 }
 
 impl Msg for MsgConnectionOpenInit {
-    type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenInit;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_init.rs
@@ -30,10 +30,6 @@ impl Msg for MsgConnectionOpenInit {
     type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenInit;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -51,7 +51,6 @@ pub struct MsgConnectionOpenTry {
 }
 
 impl Msg for MsgConnectionOpenTry {
-    type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenTry;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -54,10 +54,6 @@ impl Msg for MsgConnectionOpenTry {
     type ValidationError = ConnectionError;
     type Raw = RawMsgConnectionOpenTry;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/handler.rs
+++ b/crates/ibc/src/core/ics04_channel/handler.rs
@@ -226,21 +226,7 @@ pub fn get_module_for_packet_msg<Ctx>(ctx: &Ctx, msg: &PacketMsg) -> Result<Modu
 where
     Ctx: RouterContext,
 {
-    let module_id = match msg {
-        PacketMsg::RecvPacket(msg) => ctx
-            .lookup_module_by_port(&msg.packet.destination_port)
-            .map_err(ChannelError::Port)?,
-        PacketMsg::AckPacket(msg) => ctx
-            .lookup_module_by_port(&msg.packet.source_port)
-            .map_err(ChannelError::Port)?,
-        PacketMsg::TimeoutPacket(msg) => ctx
-            .lookup_module_by_port(&msg.packet.source_port)
-            .map_err(ChannelError::Port)?,
-        PacketMsg::TimeoutOnClosePacket(msg) => ctx
-            .lookup_module_by_port(&msg.packet.source_port)
-            .map_err(ChannelError::Port)?,
-    };
-
+    let module_id = msg.lookup_module(ctx)?;
     if ctx.router().has_route(&module_id) {
         Ok(module_id)
     } else {

--- a/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -69,7 +69,6 @@ impl MsgAcknowledgement {
 }
 
 impl Msg for MsgAcknowledgement {
-    type ValidationError = PacketError;
     type Raw = RawMsgAcknowledgement;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -72,10 +72,6 @@ impl Msg for MsgAcknowledgement {
     type ValidationError = PacketError;
     type Raw = RawMsgAcknowledgement;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_close_confirm.rs
@@ -48,10 +48,6 @@ impl Msg for MsgChannelCloseConfirm {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelCloseConfirm;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_close_confirm.rs
@@ -45,7 +45,6 @@ impl MsgChannelCloseConfirm {
 }
 
 impl Msg for MsgChannelCloseConfirm {
-    type ValidationError = ChannelError;
     type Raw = RawMsgChannelCloseConfirm;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_close_init.rs
@@ -36,10 +36,6 @@ impl Msg for MsgChannelCloseInit {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelCloseInit;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_close_init.rs
@@ -33,7 +33,6 @@ impl MsgChannelCloseInit {
 }
 
 impl Msg for MsgChannelCloseInit {
-    type ValidationError = ChannelError;
     type Raw = RawMsgChannelCloseInit;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_ack.rs
@@ -49,7 +49,6 @@ impl MsgChannelOpenAck {
 }
 
 impl Msg for MsgChannelOpenAck {
-    type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenAck;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_ack.rs
@@ -52,10 +52,6 @@ impl Msg for MsgChannelOpenAck {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenAck;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_confirm.rs
@@ -46,10 +46,6 @@ impl Msg for MsgChannelOpenConfirm {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenConfirm;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_confirm.rs
@@ -43,7 +43,6 @@ impl MsgChannelOpenConfirm {
 }
 
 impl Msg for MsgChannelOpenConfirm {
-    type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenConfirm;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_init.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_init.rs
@@ -35,10 +35,6 @@ impl Msg for MsgChannelOpenInit {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenInit;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_init.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_init.rs
@@ -32,7 +32,6 @@ impl MsgChannelOpenInit {
 }
 
 impl Msg for MsgChannelOpenInit {
-    type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenInit;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
@@ -57,10 +57,6 @@ impl Msg for MsgChannelOpenTry {
     type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenTry;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
@@ -54,18 +54,10 @@ impl MsgChannelOpenTry {
 }
 
 impl Msg for MsgChannelOpenTry {
-    type ValidationError = ChannelError;
     type Raw = RawMsgChannelOpenTry;
 
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
-    }
-
-    fn validate_basic(&self) -> Result<(), ValidationError> {
-        match self.chan_end_on_b.counterparty().channel_id() {
-            None => Err(ValidationError::InvalidCounterpartyChannelId),
-            Some(_c) => Ok(()),
-        }
     }
 }
 
@@ -95,8 +87,11 @@ impl TryFrom<RawMsgChannelOpenTry> for MsgChannelOpenTry {
             signer: raw_msg.signer.parse().map_err(ChannelError::Signer)?,
         };
 
-        msg.validate_basic()
-            .map_err(|_| ChannelError::InvalidCounterpartyChannelId)?;
+        match msg.chan_end_on_b.counterparty().channel_id() {
+            None => Err(ValidationError::InvalidCounterpartyChannelId),
+            Some(_c) => Ok(()),
+        }
+        .map_err(|_| ChannelError::InvalidCounterpartyChannelId)?;
 
         Ok(msg)
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/recv_packet.rs
@@ -36,10 +36,6 @@ impl Msg for MsgRecvPacket {
     type ValidationError = PacketError;
     type Raw = RawMsgRecvPacket;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/recv_packet.rs
@@ -33,7 +33,6 @@ impl MsgRecvPacket {
 }
 
 impl Msg for MsgRecvPacket {
-    type ValidationError = PacketError;
     type Raw = RawMsgRecvPacket;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/timeout.rs
@@ -43,10 +43,6 @@ impl Msg for MsgTimeout {
     type ValidationError = PacketError;
     type Raw = RawMsgTimeout;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics04_channel/msgs/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/timeout.rs
@@ -40,7 +40,6 @@ impl MsgTimeout {
 }
 
 impl Msg for MsgTimeout {
-    type ValidationError = PacketError;
     type Raw = RawMsgTimeout;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -39,7 +39,6 @@ impl MsgTimeoutOnClose {
 }
 
 impl Msg for MsgTimeoutOnClose {
-    type ValidationError = PacketError;
     type Raw = RawMsgTimeoutOnClose;
 
     fn type_url(&self) -> String {

--- a/crates/ibc/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -42,10 +42,6 @@ impl Msg for MsgTimeoutOnClose {
     type ValidationError = PacketError;
     type Raw = RawMsgTimeoutOnClose;
 
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
-
     fn type_url(&self) -> String {
         TYPE_URL.to_string()
     }

--- a/crates/ibc/src/core/ics23_commitment/mod.rs
+++ b/crates/ibc/src/core/ics23_commitment/mod.rs
@@ -4,5 +4,4 @@
 pub mod commitment;
 pub mod error;
 pub mod merkle;
-pub mod mock;
 pub mod specs;

--- a/crates/ibc/src/core/ics26_routing/handler.rs
+++ b/crates/ibc/src/core/ics26_routing/handler.rs
@@ -283,8 +283,7 @@ mod tests {
             MockClientState::new(MockHeader::new(start_client_height)).into(),
             MockConsensusState::new(MockHeader::new(start_client_height)).into(),
             default_signer.clone(),
-        )
-        .unwrap();
+        );
 
         //
         // Connection handshake messages.

--- a/crates/ibc/src/keys.rs
+++ b/crates/ibc/src/keys.rs
@@ -1,4 +1,0 @@
-pub const MODULE_NAME: &str = "ibc";
-pub const STORE_KEY: &str = MODULE_NAME;
-pub const QUERIER_ROUTE: &str = MODULE_NAME;
-pub const ROUTER_KEY: &str = MODULE_NAME;

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -56,7 +56,6 @@ pub mod core;
 pub mod dynamic_typing;
 pub mod events;
 pub mod handler;
-pub mod keys;
 pub mod macros;
 pub mod proofs;
 pub mod relayer;

--- a/crates/ibc/src/mock/consensus_state.rs
+++ b/crates/ibc/src/mock/consensus_state.rs
@@ -5,11 +5,9 @@ use ibc_proto::ibc::mock::ConsensusState as RawMockConsensusState;
 use ibc_proto::protobuf::Protobuf;
 use serde::{Deserialize, Serialize};
 
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics23_commitment::commitment::CommitmentRoot;
-use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::header::MockHeader;
 use crate::timestamp::Timestamp;
 
@@ -98,10 +96,6 @@ impl From<MockConsensusState> for Any {
 }
 
 impl ConsensusState for MockConsensusState {
-    fn client_type(&self) -> ClientType {
-        mock_client_type()
-    }
-
     fn root(&self) -> &CommitmentRoot {
         &self.root
     }

--- a/crates/ibc/src/mock/header.rs
+++ b/crates/ibc/src/mock/header.rs
@@ -6,10 +6,8 @@ use ibc_proto::ibc::mock::Header as RawMockHeader;
 use ibc_proto::protobuf::Protobuf;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics02_client::header::Header;
-use crate::mock::client_state::client_type as mock_client_type;
 use crate::timestamp::Timestamp;
 use crate::Height;
 
@@ -85,10 +83,6 @@ impl MockHeader {
 }
 
 impl Header for MockHeader {
-    fn client_type(&self) -> ClientType {
-        mock_client_type()
-    }
-
     fn height(&self) -> Height {
         self.height
     }

--- a/crates/ibc/src/mock/host.rs
+++ b/crates/ibc/src/mock/host.rs
@@ -8,15 +8,12 @@ use tendermint::block::Header as TmHeader;
 use tendermint_testgen::light_block::TmLightBlock;
 use tendermint_testgen::{Generator, LightBlock as TestgenLightBlock};
 
-use crate::clients::ics07_tendermint::client_type as tm_client_type;
 use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TMConsensusState;
 use crate::clients::ics07_tendermint::header::TENDERMINT_HEADER_TYPE_URL;
-use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics02_client::header::Header;
 use crate::core::ics24_host::identifier::ChainId;
-use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::consensus_state::MockConsensusState;
 use crate::mock::header::MockHeader;
 use crate::prelude::*;
@@ -184,13 +181,6 @@ impl From<HostBlock> for Any {
 }
 
 impl Header for HostBlock {
-    fn client_type(&self) -> ClientType {
-        match self {
-            HostBlock::Mock(_) => mock_client_type(),
-            HostBlock::SyntheticTendermint(_) => tm_client_type(),
-        }
-    }
-
     fn height(&self) -> Height {
         HostBlock::height(self)
     }

--- a/crates/ibc/src/prelude.rs
+++ b/crates/ibc/src/prelude.rs
@@ -9,7 +9,3 @@ pub use alloc::vec::Vec;
 
 pub use alloc::format;
 pub use alloc::vec;
-
-// Those are exported by default in the std prelude in Rust 2021
-pub use core::convert::{TryFrom, TryInto};
-pub use core::iter::FromIterator;

--- a/crates/ibc/src/relayer/ics18_relayer/utils.rs
+++ b/crates/ibc/src/relayer/ics18_relayer/utils.rs
@@ -111,14 +111,6 @@ mod tests {
             // Update client on chain B to latest height of A.
             // - create the client update message with the latest header from A
             let a_latest_header = ctx_a.query_latest_header().unwrap();
-            assert_eq!(
-                a_latest_header.client_type(),
-                mock_client_type(),
-                "Client type verification in header failed for context A (Mock); got {:?} but expected {:?}",
-                a_latest_header.client_type(),
-                mock_client_type()
-            );
-
             let client_msg_b_res =
                 build_client_update_datagram(&ctx_b, &client_on_b_for_a, a_latest_header.as_ref());
 
@@ -158,14 +150,6 @@ mod tests {
 
             let th = b_latest_header.height();
             b_latest_header.set_trusted_height(th.decrement().unwrap());
-
-            assert_eq!(
-                b_latest_header.client_type(),
-                tm_client_type(),
-                "Client type verification in header failed for context B (TM); got {:?} but expected {:?}",
-                b_latest_header.client_type(),
-                tm_client_type(),
-            );
 
             let client_msg_a_res = build_client_update_datagram(
                 &ctx_a,

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -20,10 +20,8 @@ use crate::core::ics04_channel::error::{ChannelError, PacketError};
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics04_channel::Version;
-use crate::core::ics05_port::context::PortReader;
-use crate::core::ics05_port::error::PortError;
 use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-use crate::core::ics26_routing::context::{Module, ModuleId};
+use crate::core::ics26_routing::context::Module;
 use crate::mock::context::MockIbcStore;
 use crate::prelude::*;
 use crate::signer::Signer;
@@ -150,12 +148,6 @@ impl TokenTransferKeeper for DummyTransferModule {
             .or_default()
             .insert(channel_id, seq);
         Ok(())
-    }
-}
-
-impl PortReader for DummyTransferModule {
-    fn lookup_module_by_port(&self, _port_id: &PortId) -> Result<ModuleId, PortError> {
-        unimplemented!()
     }
 }
 

--- a/crates/ibc/src/tx_msg.rs
+++ b/crates/ibc/src/tx_msg.rs
@@ -7,7 +7,9 @@ pub trait Msg: Clone {
     type Raw: From<Self> + prost::Message;
 
     // TODO: Clarify what is this function supposed to do & its connection to ICS26 routing mod.
-    fn route(&self) -> String;
+    fn route(&self) -> String {
+        crate::keys::ROUTER_KEY.to_string()
+    }
 
     /// Unique type identifier for this message, to support encoding to/from `prost_types::Any`.
     fn type_url(&self) -> String;

--- a/crates/ibc/src/tx_msg.rs
+++ b/crates/ibc/src/tx_msg.rs
@@ -1,25 +1,11 @@
-use crate::core::ics24_host::error::ValidationError;
 use crate::prelude::*;
 use ibc_proto::google::protobuf::Any;
 
 pub trait Msg: Clone {
-    type ValidationError;
     type Raw: From<Self> + prost::Message;
-
-    // TODO: Clarify what is this function supposed to do & its connection to ICS26 routing mod.
-    fn route(&self) -> String {
-        crate::keys::ROUTER_KEY.to_string()
-    }
 
     /// Unique type identifier for this message, to support encoding to/from `prost_types::Any`.
     fn type_url(&self) -> String;
-
-    fn to_any(self) -> Any {
-        Any {
-            type_url: self.type_url(),
-            value: self.get_sign_bytes(),
-        }
-    }
 
     fn get_sign_bytes(self) -> Vec<u8> {
         let mut buf = Vec::new();
@@ -34,7 +20,10 @@ pub trait Msg: Clone {
         }
     }
 
-    fn validate_basic(&self) -> Result<(), ValidationError> {
-        Ok(())
+    fn to_any(self) -> Any {
+        Any {
+            type_url: self.type_url(),
+            value: self.get_sign_bytes(),
+        }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #218 

## Definition

Examine the usage of **`Msg`** APIs in both internal and external contexts (dependent Repos) and implement the best approach. The `Msg` is mainly employed to convert different messages to `Any` type but through various practices.

## Use Cases
- Internally, It is implemented on all message types but only operated [once](https://github.com/cosmos/ibc-rs/blob/10566298229c63e05c5ec9bf2af1dcf6dd92e8f4/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs#L102) the `validate_basic()` method, which could be ported and coded locally. It is not used for converting to `Any` type.
- Inside `ComposableFi/Centauri` repo, the `type_url` is called to build `Any` messages, like [here](https://github.com/ComposableFi/centauri/blob/9d233782725943db8e992107cbd1edb0a4e0133e/hyperspace/primitives/src/utils.rs#L57).
This part can be delegated to the respective `const TYPE_URL`
- Looking at `Penumbra-zene/penumbra` repo, `Msg` trait was recently implemented on the `IbcAction` type [here](https://github.com/penumbra-zone/penumbra/blob/df753caa0315b5d431b2b5ac3d133ae17902dddd/proto/src/protobuf.rs#L177-L191), 
but not utilized yet.
- `Anoma/Namad` uses the `to_any()` method, like [here](https://github.com/anoma/namada/blob/7ed315a96cd5bfc8e0e2bef37e065746eada6622/tests/src/vm_host_env/mod.rs#L562)
- `nomic-io/orga` build the needed `Any` message locally

## Approaches
1. Remove `Msg` trait and leave it to be implemented outside the `ibc-rs` boundary. You could do it by importing `TYPE_URL` and using `raw_msg.encode_vec()` 
2. Remove `Msg` trait, but implement `From<Msg* types> for Any` for each of the message types to expose `Any` conversion, similar to [here](https://github.com/cosmos/ibc-rs/blob/4c16095a73ccb188b3d4659c1313368b8cb90a7f/crates/ibc/src/applications/transfer/msgs/transfer.rs#L132-L141)
3. Simplify the current `Msg` trait by cleaning `route()`, `validate_basic()` and `Error` type


I chose the 3rd one. 1st may not be developer-friendly. Also, the 3rd offer the min required methods with fewer lines of code than the 2nd approach, except it exposes excessive `type_url()` and `get_sign_bytes()` 

Btw, Please lmk your thoughts on this to pick the best one.

______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [X] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
