### PR TITLE
Cleanup method parameters in `ValidationContext` and `ExecutionContext`

### DIFF
--- a/.changelog/unreleased/breaking-changes/304-reader-function-use-reference-modifier.md
+++ b/.changelog/unreleased/breaking-changes/304-reader-function-use-reference-modifier.md
@@ -1,0 +1,3 @@
+- The function parameters in the Reader traits now references,
+  while the functions in the Keeper traits take ownership directly.
+  ([#304](https://github.com/cosmos/ibc-rs/issues/304))

--- a/.changelog/unreleased/breaking-changes/319-val-ctx-use-reference-modifier.md
+++ b/.changelog/unreleased/breaking-changes/319-val-ctx-use-reference-modifier.md
@@ -1,0 +1,3 @@
+- The function parameters in the `ValidationContext` trait now use references,
+  while the functions in the `ExecutionContext` trait take ownership directly.
+  ([#319](https://github.com/cosmos/ibc-rs/issues/319))

--- a/.changelog/unreleased/feature/304-reader-function-use-reference-modifier.md
+++ b/.changelog/unreleased/feature/304-reader-function-use-reference-modifier.md
@@ -1,3 +1,0 @@
-- The function parameters in the Reader trait should be used with the reference
-  modifier, while the functions in the Keeper trait take ownership directly.
-  ([#304](https://github.com/cosmos/ibc-rs/issues/304))

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -48,9 +48,9 @@ use crate::Height;
 
 use super::client_type as tm_client_type;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ValidationContext;
 
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
@@ -631,7 +631,7 @@ impl Ics2ClientState for ClientState {
             .into_box())
     }
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     fn new_check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
@@ -697,7 +697,7 @@ impl Ics2ClientState for ClientState {
             .into_box())
     }
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -661,11 +661,11 @@ impl Ics2ClientState for ClientState {
         }
 
         let consensus_state_1 = {
-            let cs = ctx.consensus_state(&client_id, header_1.trusted_height)?;
+            let cs = ctx.consensus_state(&client_id, &header_1.trusted_height)?;
             downcast_tm_consensus_state(cs.as_ref())
         }?;
         let consensus_state_2 = {
-            let cs = ctx.consensus_state(&client_id, header_2.trusted_height)?;
+            let cs = ctx.consensus_state(&client_id, &header_2.trusted_height)?;
             downcast_tm_consensus_state(cs.as_ref())
         }?;
 
@@ -709,7 +709,7 @@ impl Ics2ClientState for ClientState {
             client_id: &ClientId,
             height: Height,
         ) -> Result<Option<Box<dyn ConsensusState>>, ClientError> {
-            match ctx.consensus_state(client_id, height) {
+            match ctx.consensus_state(client_id, &height) {
                 Ok(cs) => Ok(Some(cs)),
                 Err(e) => match e {
                     ContextError::ClientError(e) => Err(e),
@@ -754,7 +754,7 @@ impl Ics2ClientState for ClientState {
             };
 
         let trusted_consensus_state = downcast_tm_consensus_state(
-            ctx.consensus_state(&client_id, header.trusted_height)
+            ctx.consensus_state(&client_id, &header.trusted_height)
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => todo!(),
@@ -817,7 +817,7 @@ impl Ics2ClientState for ClientState {
         // (cs-new, cs-next, cs-latest)
         if header.height() < client_state.latest_height() {
             let maybe_next_cs = ctx
-                .next_consensus_state(&client_id, header.height())
+                .next_consensus_state(&client_id, &header.height())
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => todo!(),
@@ -844,7 +844,7 @@ impl Ics2ClientState for ClientState {
         // (cs-trusted, cs-prev, cs-new)
         if header.trusted_height < header.height() {
             let maybe_prev_cs = ctx
-                .prev_consensus_state(&client_id, header.height())
+                .prev_consensus_state(&client_id, &header.height())
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => todo!(),

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -153,21 +153,21 @@ mod val_exec_ctx {
         fn consensus_state(
             &self,
             client_id: &ClientId,
-            height: Height,
+            height: &Height,
         ) -> Result<Box<dyn ConsensusState>, ContextError>;
 
         /// Search for the lowest consensus state higher than `height`.
         fn next_consensus_state(
             &self,
             client_id: &ClientId,
-            height: Height,
+            height: &Height,
         ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
 
         /// Search for the highest consensus state lower than `height`.
         fn prev_consensus_state(
             &self,
             client_id: &ClientId,
-            height: Height,
+            height: &Height,
         ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
 
         /// Returns the current height of the local chain.
@@ -187,7 +187,7 @@ mod val_exec_ctx {
         /// Returns the `ConsensusState` of the host (local) chain at a specific height.
         fn host_consensus_state(
             &self,
-            height: Height,
+            height: &Height,
         ) -> Result<Box<dyn ConsensusState>, ContextError>;
 
         /// Returns a natural number, counting how many clients have been created thus far.
@@ -219,8 +219,8 @@ mod val_exec_ctx {
         /// connection handshake protocol prefers.
         fn pick_version(
             &self,
-            supported_versions: Vec<ConnectionVersion>,
-            counterparty_candidate_versions: Vec<ConnectionVersion>,
+            supported_versions: &[ConnectionVersion],
+            counterparty_candidate_versions: &[ConnectionVersion],
         ) -> Result<ConnectionVersion, ContextError> {
             pick_version(supported_versions, counterparty_candidate_versions)
                 .map_err(ContextError::ConnectionError)
@@ -274,7 +274,7 @@ mod val_exec_ctx {
         /// <https://github.com/cosmos/ibc-go/blob/04791984b3d6c83f704c4f058e6ca0038d155d91/modules/core/04-channel/keeper/packet.go#L206>
         fn packet_commitment(
             &self,
-            packet_data: Vec<u8>,
+            packet_data: &[u8],
             timeout_height: TimeoutHeight,
             timeout_timestamp: Timestamp,
         ) -> PacketCommitment {
@@ -289,28 +289,29 @@ mod val_exec_ctx {
             let packet_data_hash = self.hash(packet_data);
             hash_input.append(&mut packet_data_hash.to_vec());
 
-            self.hash(hash_input).into()
+            self.hash(&hash_input).into()
         }
 
         fn ack_commitment(&self, ack: Acknowledgement) -> AcknowledgementCommitment {
-            self.hash(ack.into()).into()
+            let ack: Vec<u8> = ack.into();
+            self.hash(&ack).into()
         }
 
         /// A hashing function for packet commitments
-        fn hash(&self, value: Vec<u8>) -> Vec<u8>;
+        fn hash(&self, value: &[u8]) -> Vec<u8>;
 
         /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
         fn client_update_time(
             &self,
             client_id: &ClientId,
-            height: Height,
+            height: &Height,
         ) -> Result<Timestamp, ContextError>;
 
         /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
         fn client_update_height(
             &self,
             client_id: &ClientId,
-            height: Height,
+            height: &Height,
         ) -> Result<Height, ContextError>;
 
         /// Returns a counter on the number of channel ids have been created thus far.
@@ -323,8 +324,8 @@ mod val_exec_ctx {
 
         /// Calculates the block delay period using the connection's delay period and the maximum
         /// expected time per block.
-        fn block_delay(&self, delay_period_time: Duration) -> u64 {
-            calculate_block_delay(delay_period_time, self.max_expected_time_per_block())
+        fn block_delay(&self, delay_period_time: &Duration) -> u64 {
+            calculate_block_delay(delay_period_time, &self.max_expected_time_per_block())
         }
     }
 

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -275,8 +275,8 @@ mod val_exec_ctx {
         fn packet_commitment(
             &self,
             packet_data: &[u8],
-            timeout_height: TimeoutHeight,
-            timeout_timestamp: Timestamp,
+            timeout_height: &TimeoutHeight,
+            timeout_timestamp: &Timestamp,
         ) -> PacketCommitment {
             let mut hash_input = timeout_timestamp.nanoseconds().to_be_bytes().to_vec();
 
@@ -292,9 +292,8 @@ mod val_exec_ctx {
             self.hash(&hash_input).into()
         }
 
-        fn ack_commitment(&self, ack: Acknowledgement) -> AcknowledgementCommitment {
-            let ack: Vec<u8> = ack.into();
-            self.hash(&ack).into()
+        fn ack_commitment(&self, ack: &Acknowledgement) -> AcknowledgementCommitment {
+            self.hash(ack.as_ref()).into()
         }
 
         /// A hashing function for packet commitments
@@ -413,7 +412,7 @@ mod val_exec_ctx {
         fn store_connection(
             &mut self,
             connections_path: ConnectionsPath,
-            connection_end: &ConnectionEnd,
+            connection_end: ConnectionEnd,
         ) -> Result<(), ContextError>;
 
         /// Stores the given connection_id at a path associated with the client_id.
@@ -456,7 +455,7 @@ mod val_exec_ctx {
         fn store_connection_channels(
             &mut self,
             conn_id: ConnectionId,
-            port_channel_id: &(PortId, ChannelId),
+            port_channel_id: (PortId, ChannelId),
         ) -> Result<(), ContextError>;
 
         /// Stores the given channel_end at a path associated with the port_id and channel_id.

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -56,10 +56,10 @@ impl std::error::Error for ContextError {
     }
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub use val_exec_ctx::*;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 mod val_exec_ctx {
     use core::time::Duration;
 

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -419,7 +419,7 @@ mod val_exec_ctx {
         fn store_connection_to_client(
             &mut self,
             client_connections_path: ClientConnectionsPath,
-            conn_id: &ConnectionId,
+            conn_id: ConnectionId,
         ) -> Result<(), ContextError>;
 
         /// Called upon connection identifier creation (Init or Try process).
@@ -462,7 +462,7 @@ mod val_exec_ctx {
         fn store_channel(
             &mut self,
             port_channel_id: (PortId, ChannelId),
-            channel_end: &ChannelEnd,
+            channel_end: ChannelEnd,
         ) -> Result<(), ContextError>;
 
         fn store_next_sequence_send(

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -25,7 +25,7 @@ use crate::Height;
 use super::consensus_state::ConsensusState;
 use super::context::ClientReader;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ContextError, ValidationContext};
 
 pub trait ClientState:
@@ -88,7 +88,7 @@ pub trait ClientState:
     ) -> Result<UpdatedState, ClientError>;
 
     /// XXX: temporary solution until we get rid of `ClientReader`
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     fn new_check_header_and_update_state(
         &self,
         ctx: &dyn ValidationContext,
@@ -104,7 +104,7 @@ pub trait ClientState:
     ) -> Result<Box<dyn ClientState>, ClientError>;
 
     /// XXX: temporary solution until we get rid of `ClientReader`
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     fn new_check_misbehaviour_and_update_state(
         &self,
         ctx: &dyn ValidationContext,

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -2,18 +2,18 @@
 
 use crate::prelude::*;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::ClientConsensusStatePath;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::ClientStatePath;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::ClientTypePath;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ExecutionContext;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ValidationContext;
 
 use crate::core::ics02_client::client_state::ClientState;
@@ -41,7 +41,7 @@ pub struct CreateClientResult {
     pub processed_height: Height,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgCreateClient) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -70,7 +70,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgCreateClient) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
@@ -12,9 +12,9 @@ use crate::core::ics24_host::identifier::ClientId;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::ClientStatePath;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ContextError, ExecutionContext, ValidationContext};
 
 /// The result following the successful processing of a `MsgSubmitMisbehaviour` message.
@@ -24,7 +24,7 @@ pub struct MisbehaviourResult {
     pub client_state: Box<dyn ClientState>,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgSubmitMisbehaviour) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -51,7 +51,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgSubmitMisbehaviour) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -17,11 +17,11 @@ use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::timestamp::Timestamp;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ExecutionContext, ValidationContext};
 
 /// The result following the successful processing of a `MsgUpdateAnyClient` message.
@@ -34,7 +34,7 @@ pub struct UpdateClientResult {
     pub processed_height: Height,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgUpdateClient) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -88,7 +88,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgUpdateClient) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -55,7 +55,7 @@ where
 
     // Read consensus state from the host chain store.
     let latest_consensus_state = ctx
-        .consensus_state(&client_id, client_state.latest_height())
+        .consensus_state(&client_id, &client_state.latest_height())
         .map_err(|_| ClientError::ConsensusStateNotFound {
             client_id: client_id.clone(),
             height: client_state.latest_height(),

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -13,11 +13,11 @@ use crate::core::ics24_host::identifier::ClientId;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ExecutionContext, ValidationContext};
 
 /// The result following the successful processing of a `MsgUpgradeAnyClient` message.
@@ -28,7 +28,7 @@ pub struct UpgradeClientResult {
     pub consensus_state: Box<dyn ConsensusState>,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgUpgradeClient) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -55,7 +55,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgUpgradeClient) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -10,18 +10,18 @@ use crate::core::ics03_connection::msgs::conn_open_ack::MsgConnectionOpenAck;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::identifier::ClientId;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::ConnectionsPath;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ExecutionContext, ValidationContext};
 
 use super::ConnectionIdState;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx_a: &Ctx, msg: MsgConnectionOpenAck) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -30,7 +30,7 @@ where
     validate_impl(ctx_a, &msg, &vars)
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 fn validate_impl<Ctx>(
     ctx_a: &Ctx,
     msg: &MsgConnectionOpenAck,
@@ -142,7 +142,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx_a: &mut Ctx, msg: MsgConnectionOpenAck) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,
@@ -151,7 +151,7 @@ where
     execute_impl(ctx_a, msg, vars)
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 fn execute_impl<Ctx>(
     ctx_a: &mut Ctx,
     msg: MsgConnectionOpenAck,
@@ -187,12 +187,12 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 struct LocalVars {
     conn_end_on_a: ConnectionEnd,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 impl LocalVars {
     fn new<Ctx>(ctx_a: &Ctx, msg: &MsgConnectionOpenAck) -> Result<Self, ContextError>
     where
@@ -357,9 +357,9 @@ mod tests {
     use crate::mock::host::HostType;
     use crate::timestamp::ZERO_DURATION;
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ics26_routing::msgs::MsgEnvelope;
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ValidationContext;
 
     #[test]
@@ -472,7 +472,7 @@ mod tests {
         ];
 
         for test in tests {
-            #[cfg(val_exec_ctx)]
+            #[cfg(feature = "val_exec_ctx")]
             {
                 let res = ValidationContext::validate(
                     &test.ctx,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -70,7 +70,7 @@ where
                     description: "failed to fetch client state".to_string(),
                 })?;
         let consensus_state_of_b_on_a = ctx_a
-            .consensus_state(vars.client_id_on_a(), msg.proofs_height_on_b)
+            .consensus_state(vars.client_id_on_a(), &msg.proofs_height_on_b)
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch client consensus state".to_string(),
             })?;
@@ -118,7 +118,7 @@ where
             })?;
 
         let expected_consensus_state_of_a_on_b = ctx_a
-            .host_consensus_state(msg.consensus_height_of_a_on_b)
+            .host_consensus_state(&msg.consensus_height_of_a_on_b)
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch host consensus state".to_string(),
             })?;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -181,7 +181,7 @@ where
             new_conn_end_on_a
         };
 
-        ctx_a.store_connection(ConnectionsPath(msg.conn_id_on_a), &new_conn_end_on_a)?;
+        ctx_a.store_connection(ConnectionsPath(msg.conn_id_on_a), new_conn_end_on_a)?;
     }
 
     Ok(())

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -136,7 +136,7 @@ where
 
         ctx_b.store_connection(
             ConnectionsPath(msg.conn_id_on_b.clone()),
-            &new_conn_end_on_b,
+            new_conn_end_on_b,
         )?;
     }
 

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -58,7 +58,7 @@ where
                     description: "failed to fetch client state".to_string(),
                 })?;
         let consensus_state_of_a_on_b = ctx_b
-            .consensus_state(client_id_on_b, msg.proof_height_on_a)
+            .consensus_state(client_id_on_b, &msg.proof_height_on_a)
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch client consensus state".to_string(),
             })?;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -134,10 +134,7 @@ where
             new_conn_end_on_b
         };
 
-        ctx_b.store_connection(
-            ConnectionsPath(msg.conn_id_on_b.clone()),
-            new_conn_end_on_b,
-        )?;
+        ctx_b.store_connection(ConnectionsPath(msg.conn_id_on_b.clone()), new_conn_end_on_b)?;
     }
 
     Ok(())

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -10,16 +10,16 @@ use crate::core::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenCon
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::ConnectionsPath;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ExecutionContext, ValidationContext};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgConnectionOpenConfirm) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -28,7 +28,7 @@ where
     validate_impl(ctx_b, msg, &vars)
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 fn validate_impl<Ctx>(
     ctx_b: &Ctx,
     msg: &MsgConnectionOpenConfirm,
@@ -93,7 +93,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(
     ctx_b: &mut Ctx,
     msg: &MsgConnectionOpenConfirm,
@@ -105,7 +105,7 @@ where
     execute_impl(ctx_b, msg, vars)
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 fn execute_impl<Ctx>(
     ctx_b: &mut Ctx,
     msg: &MsgConnectionOpenConfirm,
@@ -143,12 +143,12 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 struct LocalVars {
     conn_end_on_b: ConnectionEnd,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 impl LocalVars {
     fn new<Ctx>(ctx_b: &Ctx, msg: &MsgConnectionOpenConfirm) -> Result<Self, ContextError>
     where
@@ -279,9 +279,9 @@ mod tests {
     use crate::timestamp::ZERO_DURATION;
     use crate::Height;
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ics26_routing::msgs::MsgEnvelope;
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ValidationContext;
 
     #[test]
@@ -344,7 +344,7 @@ mod tests {
         .collect();
 
         for test in tests {
-            #[cfg(val_exec_ctx)]
+            #[cfg(feature = "val_exec_ctx")]
             {
                 let res = ValidationContext::validate(
                     &test.ctx,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -84,7 +84,10 @@ where
     }
 
     ctx_a.increase_connection_counter();
-    ctx_a.store_connection_to_client(ClientConnectionsPath(msg.client_id_on_a), &conn_id_on_a)?;
+    ctx_a.store_connection_to_client(
+        ClientConnectionsPath(msg.client_id_on_a),
+        conn_id_on_a.clone(),
+    )?;
     ctx_a.store_connection(ConnectionsPath(conn_id_on_a), conn_end_on_a)?;
 
     Ok(())

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -85,7 +85,7 @@ where
 
     ctx_a.increase_connection_counter();
     ctx_a.store_connection_to_client(ClientConnectionsPath(msg.client_id_on_a), &conn_id_on_a)?;
-    ctx_a.store_connection(ConnectionsPath(conn_id_on_a), &conn_end_on_a)?;
+    ctx_a.store_connection(ConnectionsPath(conn_id_on_a), conn_end_on_a)?;
 
     Ok(())
 }

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -11,16 +11,16 @@ use crate::core::ics24_host::identifier::ConnectionId;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::{ClientConnectionsPath, ConnectionsPath};
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ExecutionContext, ValidationContext};
 
 use super::ConnectionIdState;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx_a: &Ctx, msg: MsgConnectionOpenInit) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -37,7 +37,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx_a: &mut Ctx, msg: MsgConnectionOpenInit) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,
@@ -166,9 +166,9 @@ mod tests {
     use crate::mock::context::MockContext;
     use crate::Height;
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ics26_routing::msgs::MsgEnvelope;
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ValidationContext;
 
     use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
@@ -238,7 +238,7 @@ mod tests {
         .collect();
 
         for test in tests {
-            #[cfg(val_exec_ctx)]
+            #[cfg(feature = "val_exec_ctx")]
             {
                 let res = ValidationContext::validate(
                     &test.ctx,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -166,7 +166,7 @@ where
     ctx_b.increase_connection_counter();
     ctx_b.store_connection_to_client(
         ClientConnectionsPath(msg.client_id_on_b),
-        &vars.conn_id_on_b,
+        vars.conn_id_on_b.clone(),
     )?;
     ctx_b.store_connection(ConnectionsPath(vars.conn_id_on_b), vars.conn_end_on_b)?;
 

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -168,7 +168,7 @@ where
         ClientConnectionsPath(msg.client_id_on_b),
         &vars.conn_id_on_b,
     )?;
-    ctx_b.store_connection(ConnectionsPath(vars.conn_id_on_b), &vars.conn_end_on_b)?;
+    ctx_b.store_connection(ConnectionsPath(vars.conn_id_on_b), vars.conn_end_on_b)?;
 
     Ok(())
 }

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -13,16 +13,16 @@ use crate::handler::{HandlerOutput, HandlerResult};
 
 use super::ConnectionIdState;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::identifier::ClientId;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ics24_host::path::{ClientConnectionsPath, ConnectionsPath};
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ExecutionContext, ValidationContext};
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn validate<Ctx>(ctx_b: &Ctx, msg: MsgConnectionOpenTry) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
@@ -31,7 +31,7 @@ where
     validate_impl(ctx_b, &msg, &vars)
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 fn validate_impl<Ctx>(
     ctx_b: &Ctx,
     msg: &MsgConnectionOpenTry,
@@ -132,7 +132,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub(crate) fn execute<Ctx>(ctx_b: &mut Ctx, msg: MsgConnectionOpenTry) -> Result<(), ContextError>
 where
     Ctx: ExecutionContext,
@@ -141,7 +141,7 @@ where
     execute_impl(ctx_b, msg, vars)
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 fn execute_impl<Ctx>(
     ctx_b: &mut Ctx,
     msg: MsgConnectionOpenTry,
@@ -173,7 +173,7 @@ where
     Ok(())
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 struct LocalVars {
     conn_id_on_b: ConnectionId,
     conn_end_on_b: ConnectionEnd,
@@ -181,7 +181,7 @@ struct LocalVars {
     conn_id_on_a: ConnectionId,
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 impl LocalVars {
     fn new<Ctx>(ctx_b: &Ctx, msg: &MsgConnectionOpenTry) -> Result<Self, ContextError>
     where
@@ -342,9 +342,9 @@ mod tests {
     use crate::mock::host::HostType;
     use crate::Height;
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ics26_routing::msgs::MsgEnvelope;
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     use crate::core::ValidationContext;
 
     #[test]
@@ -439,7 +439,7 @@ mod tests {
         .collect();
 
         for test in tests {
-            #[cfg(val_exec_ctx)]
+            #[cfg(feature = "val_exec_ctx")]
             {
                 let res = ValidationContext::validate(
                     &test.ctx,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -65,7 +65,7 @@ where
                     description: "failed to fetch client state".to_string(),
                 })?;
         let consensus_state_of_a_on_b = ctx_b
-            .consensus_state(&msg.client_id_on_b, msg.proofs_height_on_a)
+            .consensus_state(&msg.client_id_on_b, &msg.proofs_height_on_a)
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch client consensus state".to_string(),
             })?;
@@ -109,7 +109,7 @@ where
             })?;
 
         let expected_consensus_state_of_b_on_a = ctx_b
-            .host_consensus_state(msg.consensus_height_of_b_on_a)
+            .host_consensus_state(&msg.consensus_height_of_b_on_a)
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch host consensus state".to_string(),
             })?;
@@ -188,7 +188,7 @@ impl LocalVars {
         Ctx: ValidationContext,
     {
         let version_on_b =
-            ctx_b.pick_version(ctx_b.get_compatible_versions(), msg.versions_on_a.clone())?;
+            ctx_b.pick_version(&ctx_b.get_compatible_versions(), &msg.versions_on_a)?;
 
         Ok(Self {
             conn_id_on_b: ConnectionId::new(ctx_b.connection_counter()?),

--- a/crates/ibc/src/core/mod.rs
+++ b/crates/ibc/src/core/mod.rs
@@ -29,16 +29,16 @@ pub mod ics26_routing;
 
 pub mod context;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub mod handler;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub use handler::execute;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub use handler::validate;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub use context::ExecutionContext;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 pub use context::ValidationContext;
 
 pub use context::ContextError;

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -34,7 +34,7 @@ use crate::mock::misbehaviour::Misbehaviour;
 
 use crate::Height;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::{ContextError, ValidationContext};
 
 pub const MOCK_CLIENT_STATE_TYPE_URL: &str = "/ibc.mock.ClientState";
@@ -204,7 +204,7 @@ impl ClientState for MockClientState {
         })
     }
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     fn new_check_header_and_update_state(
         &self,
         _ctx: &dyn ValidationContext,
@@ -253,7 +253,7 @@ impl ClientState for MockClientState {
         Ok(new_state.into_box())
     }
 
-    #[cfg(val_exec_ctx)]
+    #[cfg(feature = "val_exec_ctx")]
     fn new_check_misbehaviour_and_update_state(
         &self,
         _ctx: &dyn ValidationContext,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -54,9 +54,9 @@ use crate::Height;
 
 use super::client_state::MOCK_CLIENT_TYPE;
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::context::ContextError;
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 use crate::core::ValidationContext;
 
 pub const DEFAULT_BLOCK_TIME_SECS: u64 = 3;
@@ -1503,7 +1503,7 @@ impl RelayerContext for MockContext {
     }
 }
 
-#[cfg(val_exec_ctx)]
+#[cfg(feature = "val_exec_ctx")]
 impl ValidationContext for MockContext {
     fn client_state(&self, client_id: &ClientId) -> Result<Box<dyn ClientState>, ContextError> {
         ClientReader::client_state(self, client_id).map_err(ContextError::ClientError)

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1516,7 +1516,7 @@ impl ValidationContext for MockContext {
     fn consensus_state(
         &self,
         client_id: &ClientId,
-        height: Height,
+        height: &Height,
     ) -> Result<Box<dyn ConsensusState>, ContextError> {
         ClientReader::consensus_state(self, client_id, height).map_err(ContextError::ClientError)
     }
@@ -1524,7 +1524,7 @@ impl ValidationContext for MockContext {
     fn next_consensus_state(
         &self,
         client_id: &ClientId,
-        height: Height,
+        height: &Height,
     ) -> Result<Option<Box<dyn ConsensusState>>, ContextError> {
         ClientReader::next_consensus_state(self, client_id, height)
             .map_err(ContextError::ClientError)
@@ -1533,7 +1533,7 @@ impl ValidationContext for MockContext {
     fn prev_consensus_state(
         &self,
         client_id: &ClientId,
-        height: Height,
+        height: &Height,
     ) -> Result<Option<Box<dyn ConsensusState>>, ContextError> {
         ClientReader::prev_consensus_state(self, client_id, height)
             .map_err(ContextError::ClientError)
@@ -1549,7 +1549,7 @@ impl ValidationContext for MockContext {
 
     fn host_consensus_state(
         &self,
-        height: Height,
+        height: &Height,
     ) -> Result<Box<dyn ConsensusState>, ContextError> {
         ConnectionReader::host_consensus_state(self, height).map_err(ContextError::ConnectionError)
     }
@@ -1617,7 +1617,7 @@ impl ValidationContext for MockContext {
         &self,
         key: &(PortId, ChannelId, Sequence),
     ) -> Result<PacketCommitment, ContextError> {
-        ChannelReader::get_packet_commitment(self, &key.0, &key.1, key.2)
+        ChannelReader::get_packet_commitment(self, &key.0, &key.1, &key.2)
             .map_err(ContextError::PacketError)
     }
 
@@ -1625,7 +1625,7 @@ impl ValidationContext for MockContext {
         &self,
         key: &(PortId, ChannelId, Sequence),
     ) -> Result<Receipt, ContextError> {
-        ChannelReader::get_packet_receipt(self, &key.0, &key.1, key.2)
+        ChannelReader::get_packet_receipt(self, &key.0, &key.1, &key.2)
             .map_err(ContextError::PacketError)
     }
 
@@ -1633,18 +1633,18 @@ impl ValidationContext for MockContext {
         &self,
         key: &(PortId, ChannelId, Sequence),
     ) -> Result<AcknowledgementCommitment, ContextError> {
-        ChannelReader::get_packet_acknowledgement(self, &key.0, &key.1, key.2)
+        ChannelReader::get_packet_acknowledgement(self, &key.0, &key.1, &key.2)
             .map_err(ContextError::PacketError)
     }
 
-    fn hash(&self, value: Vec<u8>) -> Vec<u8> {
+    fn hash(&self, value: &[u8]) -> Vec<u8> {
         sha2::Sha256::digest(value).to_vec()
     }
 
     fn client_update_time(
         &self,
         client_id: &ClientId,
-        height: Height,
+        height: &Height,
     ) -> Result<Timestamp, ContextError> {
         ChannelReader::client_update_time(self, client_id, height)
             .map_err(ContextError::ChannelError)
@@ -1653,7 +1653,7 @@ impl ValidationContext for MockContext {
     fn client_update_height(
         &self,
         client_id: &ClientId,
-        height: Height,
+        height: &Height,
     ) -> Result<Height, ContextError> {
         ChannelReader::client_update_height(self, client_id, height)
             .map_err(ContextError::ChannelError)


### PR DESCRIPTION
Closes: #319

## Description

Also fixes the feature flags typo for `val_exec_ctx` throughout the codebase.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
