### PR TITLE
Make `dispatch()` and `decode()` `pub` again

### DIFF
--- a/crates/ibc/src/core/ics26_routing/handler.rs
+++ b/crates/ibc/src/core/ics26_routing/handler.rs
@@ -42,7 +42,7 @@ where
 }
 
 /// Attempts to convert a message into a [MsgEnvelope] message
-pub(crate) fn decode(message: Any) -> Result<MsgEnvelope, RouterError> {
+pub fn decode(message: Any) -> Result<MsgEnvelope, RouterError> {
     message.try_into()
 }
 
@@ -51,10 +51,7 @@ pub(crate) fn decode(message: Any) -> Result<MsgEnvelope, RouterError> {
 /// and events produced after processing the input `msg`.
 /// If this method returns an error, the runtime is expected to rollback all state modifications to
 /// the `Ctx` caused by all messages from the transaction that this `msg` is a part of.
-pub(crate) fn dispatch<Ctx>(
-    ctx: &mut Ctx,
-    msg: MsgEnvelope,
-) -> Result<HandlerOutput<()>, RouterError>
+pub fn dispatch<Ctx>(ctx: &mut Ctx, msg: MsgEnvelope) -> Result<HandlerOutput<()>, RouterError>
 where
     Ctx: RouterContext,
 {


### PR DESCRIPTION
Makes `dispatch()` and `decode()` `pub` again since we're not yet ready to make our domain `Msg` types private (#324).

Reverts these changes which were recently made in #328.