### PR TITLE
Refactor `RecvPacket` handler and `Acknowledgement` types

### DIFF
--- a/.changelog/unreleased/breaking-changes/361-remove-async-acks.md
+++ b/.changelog/unreleased/breaking-changes/361-remove-async-acks.md
@@ -1,0 +1,2 @@
+- Remove support for asynchronous acknowledgements
+  ([#361](https://github.com/cosmos/ibc-rs/issues/361))

--- a/.changelog/unreleased/bug-fixes/369-fix-token-transfer-acks.md
+++ b/.changelog/unreleased/bug-fixes/369-fix-token-transfer-acks.md
@@ -1,0 +1,2 @@
+- Fix acknowledgement returned by the token transfer's onRecvPacket callback
+  ([#369](https://github.com/cosmos/ibc-rs/issues/369))

--- a/crates/ibc/README.md
+++ b/crates/ibc/README.md
@@ -42,6 +42,13 @@ ICS 5 (Port Allocation) requires the IBC handler to permit [transferring ownersh
 
 We currently support neither.
 
+### Asynchronous acknowledgements
+The standard gives the ability for modules to [acknowledge packets asynchronously](https://github.com/cosmos/ibc/tree/main/spec/core/ics-004-channel-and-packet-semantics#writing-acknowledgements). This allows modules to receive the packet, but only applying the changes at a later time (after which they would write the acknowledgement).
+
+We currently force applications to process the packets as part of `onRecvPacket()`. If you need asynchronous acknowledgements for your application, please open an issue.
+
+Note that this still makes us 100% compatible with ibc-go.
+
 ## License
 
 Copyright © 2021 Informal Systems Inc. and ibc-rs authors.

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -95,13 +95,10 @@ mod test {
 
     #[test]
     fn test_ack_success_to_vec() {
-        let ack_success = TokenTransferAcknowledgement::success();
+        let ack_success: Vec<u8> = TokenTransferAcknowledgement::success().into();
 
         // Check that it's the same output as ibc-go
-        assert_eq!(
-            Vec::<u8>::from(ack_success),
-            r#"{"result":"AQ=="}"#.as_bytes()
-        );
+        assert_eq!(ack_success, r#"{"result":"AQ=="}"#.as_bytes());
     }
 
     #[test]

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -105,6 +105,19 @@ mod test {
     }
 
     #[test]
+    fn test_ack_error_to_vec() {
+        let ack_error = TokenTransferAcknowledgement::Error(
+            "cannot unmarshal ICS-20 transfer packet data".to_string(),
+        );
+
+        // Check that it's the same output as ibc-go
+        assert_eq!(
+            Vec::<u8>::from(ack_error),
+            r#"{"error":"cannot unmarshal ICS-20 transfer packet data"}"#.as_bytes()
+        );
+    }
+
+    #[test]
     fn test_ack_de() {
         fn de_json_assert_eq(json_str: &str, ack: TokenTransferAcknowledgement) {
             let de = serde_json::from_str::<TokenTransferAcknowledgement>(json_str).unwrap();

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -87,6 +87,14 @@ mod test {
     }
 
     #[test]
+    fn test_ack_success_asref() {
+        let ack_success = Acknowledgement::success();
+
+        // Check that it's the same output as ibc-go
+        assert_eq!(ack_success.as_ref(), r#"{"result":"AQ=="}"#.as_bytes());
+    }
+
+    #[test]
     fn test_ack_de() {
         fn de_json_assert_eq(json_str: &str, ack: Acknowledgement) {
             let de = serde_json::from_str::<Acknowledgement>(json_str).unwrap();

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -39,6 +39,10 @@ impl Acknowledgement {
     pub fn from_error(err: TokenTransferError) -> Self {
         Self::Error(format!("{ACK_ERR_STR}: {err}"))
     }
+
+    pub fn is_successful(&self) -> bool {
+        matches!(self, Acknowledgement::Success(_))
+    }
 }
 
 impl AsRef<[u8]> for Acknowledgement {

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -45,10 +45,7 @@ impl AsRef<[u8]> for Acknowledgement {
     fn as_ref(&self) -> &[u8] {
         match self {
             Acknowledgement::Success(_) => r#"{"result":"AQ=="}"#.as_bytes(),
-            Acknowledgement::Error(_) => {
-                r#"{"error":"error handling packet on destination chain: see events for details"}"#
-                    .as_bytes()
-            }
+            Acknowledgement::Error(s) => s.as_bytes(),
         }
     }
 }

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -45,15 +45,6 @@ impl TokenTransferAcknowledgement {
     }
 }
 
-impl AsRef<[u8]> for TokenTransferAcknowledgement {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            TokenTransferAcknowledgement::Success(_) => r#"{"result":"AQ=="}"#.as_bytes(),
-            TokenTransferAcknowledgement::Error(s) => s.as_bytes(),
-        }
-    }
-}
-
 impl Display for TokenTransferAcknowledgement {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         match self {
@@ -63,9 +54,19 @@ impl Display for TokenTransferAcknowledgement {
     }
 }
 
+impl From<TokenTransferAcknowledgement> for Vec<u8> {
+    fn from(ack: TokenTransferAcknowledgement) -> Self {
+        match ack {
+            TokenTransferAcknowledgement::Success(_) => r#"{"result":"AQ=="}"#.as_bytes().into(),
+            // TokenTransferAcknowledgement::Error(s) => s.as_bytes(),
+            TokenTransferAcknowledgement::Error(s) => alloc::format!(r#"{{"error":"{s}"}}"#).into(),
+        }
+    }
+}
+
 impl From<TokenTransferAcknowledgement> for Acknowledgement {
     fn from(ack: TokenTransferAcknowledgement) -> Self {
-        ack.as_ref().into()
+        ack.into()
     }
 }
 
@@ -93,11 +94,14 @@ mod test {
     }
 
     #[test]
-    fn test_ack_success_asref() {
+    fn test_ack_success_to_vec() {
         let ack_success = TokenTransferAcknowledgement::success();
 
         // Check that it's the same output as ibc-go
-        assert_eq!(ack_success.as_ref(), r#"{"result":"AQ=="}"#.as_bytes());
+        assert_eq!(
+            Vec::<u8>::from(ack_success),
+            r#"{"result":"AQ=="}"#.as_bytes()
+        );
     }
 
     #[test]

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -1,7 +1,7 @@
 use core::fmt::{Display, Error as FmtError, Formatter};
 
 use super::error::TokenTransferError;
-use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
+use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as AcknowledgementBytes;
 use crate::prelude::*;
 
 /// A string constant included in error acknowledgements.
@@ -59,7 +59,7 @@ impl Display for Acknowledgement {
     }
 }
 
-impl From<Acknowledgement> for GenericAcknowledgement {
+impl From<Acknowledgement> for AcknowledgementBytes {
     fn from(ack: Acknowledgement) -> Self {
         ack.as_ref().into()
     }

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -1,7 +1,7 @@
 use core::fmt::{Display, Error as FmtError, Formatter};
 
 use super::error::TokenTransferError;
-use crate::core::ics26_routing::context::Acknowledgement as AckTrait;
+use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
 use crate::prelude::*;
 
 /// A string constant included in error acknowledgements.
@@ -59,7 +59,11 @@ impl Display for Acknowledgement {
     }
 }
 
-impl AckTrait for Acknowledgement {}
+impl From<Acknowledgement> for GenericAcknowledgement {
+    fn from(ack: Acknowledgement) -> Self {
+        ack.as_ref().into()
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/crates/ibc/src/applications/transfer/acknowledgement.rs
+++ b/crates/ibc/src/applications/transfer/acknowledgement.rs
@@ -44,8 +44,11 @@ impl Acknowledgement {
 impl AsRef<[u8]> for Acknowledgement {
     fn as_ref(&self) -> &[u8] {
         match self {
-            Acknowledgement::Success(_) => ACK_SUCCESS_B64.as_bytes(),
-            Acknowledgement::Error(s) => s.as_bytes(),
+            Acknowledgement::Success(_) => r#"{"result":"AQ=="}"#.as_bytes(),
+            Acknowledgement::Error(_) => {
+                r#"{"error":"error handling packet on destination chain: see events for details"}"#
+                    .as_bytes()
+            }
         }
     }
 }

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -264,7 +264,6 @@ pub fn on_recv_packet<Ctx: 'static + TokenTransferContext>(
         Err(_) => {
             let ack =
                 Acknowledgement::Error(TokenTransferError::PacketDataDeserialization.to_string());
-            // TODO: Make sure that this is the right way to serialize (vs using serde)
             return ack.into();
         }
     };

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest, Sha256};
 
 use super::error::TokenTransferError;
-use crate::applications::transfer::acknowledgement::Acknowledgement;
+use crate::applications::transfer::acknowledgement::TokenTransferAcknowledgement;
 use crate::applications::transfer::events::{AckEvent, AckStatusEvent, RecvEvent, TimeoutEvent};
 use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::relay::on_ack_packet::process_ack_packet;
@@ -14,7 +14,7 @@ use crate::core::ics04_channel::context::{ChannelKeeper, SendPacketReader};
 use crate::core::ics04_channel::error::PacketError;
 use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
-use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as AcknowledgementBytes;
+use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
@@ -258,20 +258,22 @@ pub fn on_recv_packet<Ctx: 'static + TokenTransferContext>(
     output: &mut ModuleOutputBuilder,
     packet: &Packet,
     _relayer: &Signer,
-) -> AcknowledgementBytes {
+) -> Acknowledgement {
     let data = match serde_json::from_slice::<PacketData>(&packet.data) {
         Ok(data) => data,
         Err(_) => {
-            let ack =
-                Acknowledgement::Error(TokenTransferError::PacketDataDeserialization.to_string());
+            let ack = TokenTransferAcknowledgement::Error(
+                TokenTransferError::PacketDataDeserialization.to_string(),
+            );
             return ack.into();
         }
     };
 
-    let ack: Acknowledgement = match process_recv_packet(ctx, output, packet, data.clone()) {
-        Ok(()) => Acknowledgement::success(),
-        Err(e) => Acknowledgement::from_error(e),
-    };
+    let ack: TokenTransferAcknowledgement =
+        match process_recv_packet(ctx, output, packet, data.clone()) {
+            Ok(()) => TokenTransferAcknowledgement::success(),
+            Err(e) => TokenTransferAcknowledgement::from_error(e),
+        };
 
     let recv_event = RecvEvent {
         receiver: data.receiver,
@@ -288,14 +290,15 @@ pub fn on_acknowledgement_packet(
     ctx: &mut impl TokenTransferContext,
     output: &mut ModuleOutputBuilder,
     packet: &Packet,
-    acknowledgement: &AcknowledgementBytes,
+    acknowledgement: &Acknowledgement,
     _relayer: &Signer,
 ) -> Result<(), TokenTransferError> {
     let data = serde_json::from_slice::<PacketData>(&packet.data)
         .map_err(|_| TokenTransferError::PacketDataDeserialization)?;
 
-    let acknowledgement = serde_json::from_slice::<Acknowledgement>(acknowledgement.as_ref())
-        .map_err(|_| TokenTransferError::AckDeserialization)?;
+    let acknowledgement =
+        serde_json::from_slice::<TokenTransferAcknowledgement>(acknowledgement.as_ref())
+            .map_err(|_| TokenTransferError::AckDeserialization)?;
 
     process_ack_packet(ctx, packet, &data, &acknowledgement)?;
 

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -268,20 +268,20 @@ pub fn on_recv_packet<Ctx: 'static + TokenTransferContext>(
         }
     };
 
-    let (ack, success) = match process_recv_packet(ctx, output, packet, data.clone()) {
-        Ok(()) => (Acknowledgement::success().into(), true),
-        Err(e) => (Acknowledgement::from_error(e).into(), false),
+    let ack: Acknowledgement = match process_recv_packet(ctx, output, packet, data.clone()) {
+        Ok(()) => Acknowledgement::success(),
+        Err(e) => Acknowledgement::from_error(e),
     };
 
     let recv_event = RecvEvent {
         receiver: data.receiver,
         denom: data.token.denom,
         amount: data.token.amount,
-        success,
+        success: ack.is_successful(),
     };
     output.emit(recv_event.into());
 
-    ack
+    ack.into()
 }
 
 pub fn on_acknowledgement_packet(

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -14,7 +14,7 @@ use crate::core::ics04_channel::context::{ChannelKeeper, SendPacketReader};
 use crate::core::ics04_channel::error::PacketError;
 use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
-use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as GenericAcknowledgement;
+use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement as AcknowledgementBytes;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
@@ -258,7 +258,7 @@ pub fn on_recv_packet<Ctx: 'static + TokenTransferContext>(
     output: &mut ModuleOutputBuilder,
     packet: &Packet,
     _relayer: &Signer,
-) -> GenericAcknowledgement {
+) -> AcknowledgementBytes {
     let data = match serde_json::from_slice::<PacketData>(&packet.data) {
         Ok(data) => data,
         Err(_) => {
@@ -288,7 +288,7 @@ pub fn on_acknowledgement_packet(
     ctx: &mut impl TokenTransferContext,
     output: &mut ModuleOutputBuilder,
     packet: &Packet,
-    acknowledgement: &GenericAcknowledgement,
+    acknowledgement: &AcknowledgementBytes,
     _relayer: &Signer,
 ) -> Result<(), TokenTransferError> {
     let data = serde_json::from_slice::<PacketData>(&packet.data)

--- a/crates/ibc/src/applications/transfer/events.rs
+++ b/crates/ibc/src/applications/transfer/events.rs
@@ -1,4 +1,4 @@
-use crate::applications::transfer::acknowledgement::Acknowledgement;
+use crate::applications::transfer::acknowledgement::TokenTransferAcknowledgement;
 use crate::applications::transfer::{Amount, PrefixedDenom, MODULE_ID_STR};
 use crate::events::ModuleEvent;
 use crate::prelude::*;
@@ -50,7 +50,7 @@ pub struct AckEvent {
     pub receiver: Signer,
     pub denom: PrefixedDenom,
     pub amount: Amount,
-    pub acknowledgement: Acknowledgement,
+    pub acknowledgement: TokenTransferAcknowledgement,
 }
 
 impl From<AckEvent> for ModuleEvent {
@@ -75,7 +75,7 @@ impl From<AckEvent> for ModuleEvent {
 }
 
 pub struct AckStatusEvent {
-    pub acknowledgement: Acknowledgement,
+    pub acknowledgement: TokenTransferAcknowledgement,
 }
 
 impl From<AckStatusEvent> for ModuleEvent {
@@ -87,8 +87,8 @@ impl From<AckStatusEvent> for ModuleEvent {
             attributes: vec![],
         };
         let attr_label = match acknowledgement {
-            Acknowledgement::Success(_) => "success",
-            Acknowledgement::Error(_) => "error",
+            TokenTransferAcknowledgement::Success(_) => "success",
+            TokenTransferAcknowledgement::Error(_) => "error",
         };
         event
             .attributes

--- a/crates/ibc/src/applications/transfer/relay/on_ack_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_ack_packet.rs
@@ -11,7 +11,7 @@ pub fn process_ack_packet(
     data: &PacketData,
     ack: &TokenTransferAcknowledgement,
 ) -> Result<(), TokenTransferError> {
-    if matches!(ack, TokenTransferAcknowledgement::Error(_)) {
+    if !ack.is_successful() {
         refund_packet_token(ctx, packet, data)?;
     }
 

--- a/crates/ibc/src/applications/transfer/relay/on_ack_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_ack_packet.rs
@@ -1,4 +1,4 @@
-use crate::applications::transfer::acknowledgement::Acknowledgement;
+use crate::applications::transfer::acknowledgement::TokenTransferAcknowledgement;
 use crate::applications::transfer::context::TokenTransferContext;
 use crate::applications::transfer::error::TokenTransferError;
 use crate::applications::transfer::packet::PacketData;
@@ -9,9 +9,9 @@ pub fn process_ack_packet(
     ctx: &mut impl TokenTransferContext,
     packet: &Packet,
     data: &PacketData,
-    ack: &Acknowledgement,
+    ack: &TokenTransferAcknowledgement,
 ) -> Result<(), TokenTransferError> {
-    if matches!(ack, Acknowledgement::Error(_)) {
+    if matches!(ack, TokenTransferAcknowledgement::Error(_)) {
         refund_packet_token(ctx, packet, data)?;
     }
 

--- a/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -53,13 +53,6 @@ impl From<&[u8]> for Acknowledgement {
     }
 }
 
-#[cfg(any(test, feature = "mocks"))]
-impl Default for Acknowledgement {
-    fn default() -> Self {
-        Self(vec![1])
-    }
-}
-
 ///
 /// Message definition for packet acknowledgements.
 ///

--- a/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -47,12 +47,6 @@ impl AsRef<[u8]> for Acknowledgement {
     }
 }
 
-impl From<&[u8]> for Acknowledgement {
-    fn from(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
-    }
-}
-
 ///
 /// Message definition for packet acknowledgements.
 ///

--- a/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -47,6 +47,19 @@ impl AsRef<[u8]> for Acknowledgement {
     }
 }
 
+impl From<&[u8]> for Acknowledgement {
+    fn from(bytes: &[u8]) -> Self {
+        Self(bytes.to_vec())
+    }
+}
+
+#[cfg(any(test, feature = "mocks"))]
+impl Default for Acknowledgement {
+    fn default() -> Self {
+        Self(vec![1])
+    }
+}
+
 ///
 /// Message definition for packet acknowledgements.
 ///

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1974,8 +1974,7 @@ mod tests {
             ) -> Acknowledgement {
                 self.counter += 1;
 
-                let ack_bytes = [1u8];
-                Acknowledgement::from(ack_bytes.as_ref())
+                Acknowledgement::from(vec![1u8])
             }
         }
 
@@ -2065,8 +2064,7 @@ mod tests {
                 _packet: &Packet,
                 _relayer: &Signer,
             ) -> Acknowledgement {
-                let ack_bytes = [1u8];
-                Acknowledgement::from(ack_bytes.as_ref())
+                Acknowledgement::from(vec![1u8])
             }
         }
 

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1974,7 +1974,8 @@ mod tests {
             ) -> Acknowledgement {
                 self.counter += 1;
 
-                Acknowledgement::default()
+                let ack_bytes = [1u8];
+                Acknowledgement::from(ack_bytes.as_ref())
             }
         }
 
@@ -2064,7 +2065,8 @@ mod tests {
                 _packet: &Packet,
                 _relayer: &Signer,
             ) -> Acknowledgement {
-                Acknowledgement::default()
+                let ack_bytes = [1u8];
+                Acknowledgement::from(ack_bytes.as_ref())
             }
         }
 

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -19,10 +19,11 @@ use crate::core::ics04_channel::commitment::PacketCommitment;
 use crate::core::ics04_channel::context::SendPacketReader;
 use crate::core::ics04_channel::error::{ChannelError, PacketError};
 use crate::core::ics04_channel::handler::ModuleExtras;
-use crate::core::ics04_channel::packet::Sequence;
+use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
+use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-use crate::core::ics26_routing::context::Module;
+use crate::core::ics26_routing::context::{Module, ModuleOutputBuilder};
 use crate::mock::context::MockIbcStore;
 use crate::prelude::*;
 use crate::signer::Signer;
@@ -163,6 +164,15 @@ impl Module for DummyTransferModule {
             },
             counterparty_version.clone(),
         ))
+    }
+
+    fn on_recv_packet(
+        &mut self,
+        _output: &mut ModuleOutputBuilder,
+        _packet: &Packet,
+        _relayer: &Signer,
+    ) -> Acknowledgement {
+        Acknowledgement::default()
     }
 }
 

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -172,7 +172,8 @@ impl Module for DummyTransferModule {
         _packet: &Packet,
         _relayer: &Signer,
     ) -> Acknowledgement {
-        Acknowledgement::default()
+        let ack_bytes = [1u8];
+        Acknowledgement::from(ack_bytes.as_ref())
     }
 }
 

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -172,8 +172,7 @@ impl Module for DummyTransferModule {
         _packet: &Packet,
         _relayer: &Signer,
     ) -> Acknowledgement {
-        let ack_bytes = [1u8];
-        Acknowledgement::from(ack_bytes.as_ref())
+        Acknowledgement::from(vec![1u8])
     }
 }
 


### PR DESCRIPTION
Closes: #361
Closes: #369

## Description

This PR contains consensus-breaking changes: serialization of successful acknowledgements of packets in `onRecvPacket()` changed (in order to become compliant with ibc-go).

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
