### PR TITLE
Implement ICS-26 router for `RecvPacket` in `{Validation,Execution}Context`

### DIFF
--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -517,10 +517,7 @@ mod val_exec_ctx {
 
         let (mut extras, ack) = match process_recv_packet_execute(ctx, packet, data.clone()) {
             Ok(extras) => (extras, TokenTransferAcknowledgement::success()),
-            Err(e) => (
-                ModuleExtras::empty(),
-                TokenTransferAcknowledgement::from_error(e),
-            ),
+            Err((extras, error)) => (extras, TokenTransferAcknowledgement::from_error(error)),
         };
 
         let recv_event = RecvEvent {

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -339,6 +339,8 @@ pub fn on_timeout_packet(
 pub use val_exec_ctx::*;
 #[cfg(feature = "val_exec_ctx")]
 mod val_exec_ctx {
+    use crate::applications::transfer::relay::on_recv_packet::process_recv_packet_execute;
+
     pub use super::*;
 
     #[allow(clippy::too_many_arguments)]
@@ -497,6 +499,39 @@ mod val_exec_ctx {
         _channel_id: &ChannelId,
     ) -> Result<ModuleExtras, TokenTransferError> {
         Ok(ModuleExtras::empty())
+    }
+
+    pub fn on_recv_packet_execute(
+        ctx: &mut impl TokenTransferContext,
+        packet: &Packet,
+    ) -> (ModuleExtras, Acknowledgement) {
+        let data = match serde_json::from_slice::<PacketData>(&packet.data) {
+            Ok(data) => data,
+            Err(_) => {
+                let ack = TokenTransferAcknowledgement::Error(
+                    TokenTransferError::PacketDataDeserialization.to_string(),
+                );
+                return (ModuleExtras::empty(), ack.into());
+            }
+        };
+
+        let (mut extras, ack) = match process_recv_packet_execute(ctx, packet, data.clone()) {
+            Ok(extras) => (extras, TokenTransferAcknowledgement::success()),
+            Err(e) => (
+                ModuleExtras::empty(),
+                TokenTransferAcknowledgement::from_error(e),
+            ),
+        };
+
+        let recv_event = RecvEvent {
+            receiver: data.receiver,
+            denom: data.token.denom,
+            amount: data.token.amount,
+            success: ack.is_successful(),
+        };
+        extras.events.push(recv_event.into());
+
+        (extras, ack.into())
     }
 }
 

--- a/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
@@ -60,3 +60,73 @@ pub fn process_recv_packet<Ctx: 'static + TokenTransferContext>(
 
     Ok(())
 }
+
+#[cfg(feature = "val_exec_ctx")]
+pub use val_exec_ctx::*;
+#[cfg(feature = "val_exec_ctx")]
+mod val_exec_ctx {
+    pub use super::*;
+    use crate::core::ics04_channel::handler::ModuleExtras;
+
+    ////////////////////////////////////////////////////////////
+    // FIXME BEFORE MERGE: events need to be emitted even when there's an error
+    ////////////////////////////////////////////////////////////
+    pub fn process_recv_packet_execute<Ctx: TokenTransferContext>(
+        ctx: &mut Ctx,
+        packet: &Packet,
+        data: PacketData,
+    ) -> Result<ModuleExtras, TokenTransferError> {
+        if !ctx.is_receive_enabled() {
+            return Err(TokenTransferError::ReceiveDisabled);
+        }
+
+        let receiver_account = data
+            .receiver
+            .clone()
+            .try_into()
+            .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+
+        let extras = if is_receiver_chain_source(
+            packet.port_on_a.clone(),
+            packet.chan_on_a.clone(),
+            &data.token.denom,
+        ) {
+            // sender chain is not the source, unescrow tokens
+            let prefix = TracePrefix::new(packet.port_on_a.clone(), packet.chan_on_a.clone());
+            let coin = {
+                let mut c = data.token;
+                c.denom.remove_trace_prefix(&prefix);
+                c
+            };
+
+            let escrow_address =
+                ctx.get_channel_escrow_address(&packet.port_on_b, &packet.chan_on_b)?;
+
+            ctx.send_coins(&escrow_address, &receiver_account, &coin)?;
+
+            ModuleExtras::empty()
+        } else {
+            // sender chain is the source, mint vouchers
+            let prefix = TracePrefix::new(packet.port_on_b.clone(), packet.chan_on_b.clone());
+            let coin = {
+                let mut c = data.token;
+                c.denom.add_trace_prefix(prefix);
+                c
+            };
+
+            let denom_trace_event = DenomTraceEvent {
+                trace_hash: ctx.denom_hash_string(&coin.denom),
+                denom: coin.denom.clone(),
+            };
+
+            ctx.mint_coins(&receiver_account, &coin)?;
+
+            ModuleExtras {
+                events: vec![denom_trace_event.into()],
+                log: Vec::new(),
+            }
+        };
+
+        Ok(extras)
+    }
+}

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -225,7 +225,7 @@ mod val_exec_ctx {
                     }
 
                     match msg {
-                        PacketMsg::Recv(msg) => recv_packet_validate(self, module_id, msg),
+                        PacketMsg::Recv(msg) => recv_packet_validate(self, msg),
                         PacketMsg::Ack(_) => todo!(),
                         PacketMsg::Timeout(_) => todo!(),
                         PacketMsg::TimeoutOnClose(_) => todo!(),
@@ -1152,20 +1152,12 @@ mod val_exec_ctx {
         Ok(())
     }
 
-    fn recv_packet_validate<ValCtx>(
-        ctx_b: &ValCtx,
-        module_id: ModuleId,
-        msg: MsgRecvPacket,
-    ) -> Result<(), ContextError>
+    fn recv_packet_validate<ValCtx>(ctx_b: &ValCtx, msg: MsgRecvPacket) -> Result<(), ContextError>
     where
         ValCtx: ValidationContext,
     {
-        recv_packet::validate(ctx_b, &msg)?;
+        recv_packet::validate(ctx_b, &msg)
 
-        let _module = ctx_b
-            .get_route(&module_id)
-            .ok_or(ChannelError::RouteNotFound)?;
-
-        todo!()
+        // nothing to validate with the module, since `onRecvPacket` cannot fail.
     }
 }

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -471,7 +471,24 @@ mod val_exec_ctx {
                     }
                     .map_err(RouterError::ContextError)
                 }
-                MsgEnvelope::Packet(_msg) => todo!(),
+                MsgEnvelope::Packet(msg) => {
+                    let module_id = self
+                        .lookup_module_packet(&msg)
+                        .map_err(ContextError::from)?;
+                    if !self.has_route(&module_id) {
+                        return Err(ChannelError::RouteNotFound)
+                            .map_err(ContextError::ChannelError)
+                            .map_err(RouterError::ContextError);
+                    }
+
+                    match msg {
+                        PacketMsg::Recv(msg) => recv_packet_execute(self, module_id, msg),
+                        PacketMsg::Ack(_) => todo!(),
+                        PacketMsg::Timeout(_) => todo!(),
+                        PacketMsg::TimeoutOnClose(_) => todo!(),
+                    }
+                    .map_err(RouterError::ContextError)
+                }
             }
         }
 
@@ -1159,5 +1176,16 @@ mod val_exec_ctx {
         recv_packet::validate(ctx_b, &msg)
 
         // nothing to validate with the module, since `onRecvPacket` cannot fail.
+    }
+
+    fn recv_packet_execute<ExecCtx>(
+        _ctx_b: &mut ExecCtx,
+        _module_id: ModuleId,
+        _msg: MsgRecvPacket,
+    ) -> Result<(), ContextError>
+    where
+        ExecCtx: ExecutionContext,
+    {
+        todo!()
     }
 }

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -1174,6 +1174,7 @@ mod val_exec_ctx {
     where
         ValCtx: ValidationContext,
     {
+        // Note: this contains the validation for `write_acknowledgement` as well.
         recv_packet::validate(ctx_b, &msg)
 
         // nothing to validate with the module, since `onRecvPacket` cannot fail.

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -82,7 +82,7 @@ mod val_exec_ctx {
     };
     use crate::core::ics04_channel::handler::{
         chan_close_confirm, chan_close_init, chan_open_ack, chan_open_confirm, chan_open_init,
-        chan_open_try,
+        chan_open_try, recv_packet,
     };
     use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
     use crate::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
@@ -91,6 +91,7 @@ mod val_exec_ctx {
     use crate::core::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
     use crate::core::ics04_channel::msgs::chan_open_init::MsgChannelOpenInit;
     use crate::core::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
+    use crate::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
     use crate::core::ics04_channel::msgs::{ChannelMsg, PacketMsg};
     use crate::core::ics04_channel::packet::{Receipt, Sequence};
     use crate::core::ics04_channel::timeout::TimeoutHeight;
@@ -223,12 +224,15 @@ mod val_exec_ctx {
                             .map_err(RouterError::ContextError);
                     }
 
-                    match msg {
-                        PacketMsg::Recv(_) => todo!(),
+                    // TODO: use the return value appropriately
+                    let _ = match msg {
+                        PacketMsg::Recv(msg) => recv_packet_validate(self, module_id, msg),
                         PacketMsg::Ack(_) => todo!(),
                         PacketMsg::Timeout(_) => todo!(),
                         PacketMsg::TimeoutOnClose(_) => todo!(),
-                    }
+                    };
+
+                    todo!()
                 }
             }
         }
@@ -1148,5 +1152,22 @@ mod val_exec_ctx {
         }
 
         Ok(())
+    }
+
+    fn recv_packet_validate<ValCtx>(
+        ctx_b: &ValCtx,
+        module_id: ModuleId,
+        msg: MsgRecvPacket,
+    ) -> Result<(), ContextError>
+    where
+        ValCtx: ValidationContext,
+    {
+        recv_packet::validate(ctx_b, &msg)?;
+
+        let _module = ctx_b
+            .get_route(&module_id)
+            .ok_or(ChannelError::RouteNotFound)?;
+
+        todo!()
     }
 }

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -1224,11 +1224,6 @@ mod val_exec_ctx {
 
         let (extras, acknowledgement) = module.on_recv_packet_execute(&msg.packet, &msg.signer);
 
-        // FIXME: Enforce this in the type instead (e.g. constructor revokes empty vecs)
-        if acknowledgement.is_empty() {
-            return Err(PacketError::InvalidAcknowledgement.into());
-        }
-
         // state changes
         {
             // `recvPacket` core handler state changes

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -224,15 +224,13 @@ mod val_exec_ctx {
                             .map_err(RouterError::ContextError);
                     }
 
-                    // TODO: use the return value appropriately
-                    let _ = match msg {
+                    match msg {
                         PacketMsg::Recv(msg) => recv_packet_validate(self, module_id, msg),
                         PacketMsg::Ack(_) => todo!(),
                         PacketMsg::Timeout(_) => todo!(),
                         PacketMsg::TimeoutOnClose(_) => todo!(),
-                    };
-
-                    todo!()
+                    }
+                    .map_err(RouterError::ContextError)
                 }
             }
         }

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -176,6 +176,22 @@ pub trait ClientState:
     ) -> Result<(), ClientError>;
 
     /// Verify a `proof` that a packet has been commited.
+    #[cfg(feature = "val_exec_ctx")]
+    #[allow(clippy::too_many_arguments)]
+    fn new_verify_packet_data(
+        &self,
+        ctx: &dyn ValidationContext,
+        height: Height,
+        connection_end: &ConnectionEnd,
+        proof: &CommitmentProofBytes,
+        root: &CommitmentRoot,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        sequence: Sequence,
+        commitment: PacketCommitment,
+    ) -> Result<(), ClientError>;
+
+    /// Verify a `proof` that a packet has been commited.
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_data(
         &self,

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -175,7 +175,7 @@ pub trait ClientState:
         expected_client_state: Any,
     ) -> Result<(), ClientError>;
 
-    /// Verify a `proof` that a packet has been commited.
+    /// Verify a `proof` that a packet has been committed.
     #[cfg(feature = "val_exec_ctx")]
     #[allow(clippy::too_many_arguments)]
     fn new_verify_packet_data(
@@ -191,7 +191,7 @@ pub trait ClientState:
         commitment: PacketCommitment,
     ) -> Result<(), ClientError>;
 
-    /// Verify a `proof` that a packet has been commited.
+    /// Verify a `proof` that a packet has been committed.
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_data(
         &self,
@@ -206,7 +206,7 @@ pub trait ClientState:
         commitment: PacketCommitment,
     ) -> Result<(), ClientError>;
 
-    /// Verify a `proof` that a packet has been commited.
+    /// Verify a `proof` that a packet has been committed.
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_acknowledgement(
         &self,

--- a/crates/ibc/src/core/ics04_channel/handler.rs
+++ b/crates/ibc/src/core/ics04_channel/handler.rs
@@ -49,6 +49,7 @@ pub struct ChannelResult {
     pub channel_end: ChannelEnd,
 }
 
+#[derive(Clone, Debug)]
 pub struct ModuleExtras {
     pub events: Vec<ModuleEvent>,
     pub log: Vec<String>,

--- a/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
@@ -12,6 +12,127 @@ use crate::handler::{HandlerOutput, HandlerResult};
 use crate::timestamp::Expiry;
 use alloc::string::ToString;
 
+#[cfg(feature = "val_exec_ctx")]
+pub(crate) use val_exec_ctx::*;
+#[cfg(feature = "val_exec_ctx")]
+pub(crate) mod val_exec_ctx {
+    use super::*;
+    use crate::core::{ContextError, ValidationContext};
+
+    pub fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgRecvPacket) -> Result<(), ContextError>
+    where
+        Ctx: ValidationContext,
+    {
+        let port_chan_id_on_b = &(msg.packet.port_on_b.clone(), msg.packet.chan_on_b.clone());
+        let chan_end_on_b = ctx_b.channel_end(port_chan_id_on_b)?;
+
+        if !chan_end_on_b.state_matches(&State::Open) {
+            return Err(PacketError::InvalidChannelState {
+                channel_id: msg.packet.chan_on_a.clone(),
+                state: chan_end_on_b.state,
+            }
+            .into());
+        }
+
+        let counterparty = Counterparty::new(
+            msg.packet.port_on_a.clone(),
+            Some(msg.packet.chan_on_a.clone()),
+        );
+
+        if !chan_end_on_b.counterparty_matches(&counterparty) {
+            return Err(PacketError::InvalidPacketCounterparty {
+                port_id: msg.packet.port_on_a.clone(),
+                channel_id: msg.packet.chan_on_a.clone(),
+            }
+            .into());
+        }
+
+        let conn_id_on_b = &chan_end_on_b.connection_hops()[0];
+        let conn_end_on_b = ctx_b.connection_end(conn_id_on_b)?;
+
+        if !conn_end_on_b.state_matches(&ConnectionState::Open) {
+            return Err(PacketError::ConnectionNotOpen {
+                connection_id: chan_end_on_b.connection_hops()[0].clone(),
+            }
+            .into());
+        }
+
+        let latest_height = ctx_b.host_height()?;
+        if msg.packet.timeout_height_on_b.has_expired(latest_height) {
+            return Err(PacketError::LowPacketHeight {
+                chain_height: latest_height,
+                timeout_height: msg.packet.timeout_height_on_b,
+            }
+            .into());
+        }
+
+        let latest_timestamp = ctx_b.host_timestamp()?;
+        if let Expiry::Expired = latest_timestamp.check_expiry(&msg.packet.timeout_timestamp_on_b) {
+            return Err(PacketError::LowPacketTimestamp.into());
+        }
+
+        // Verify proofs
+        {
+            let client_id_on_b = conn_end_on_b.client_id();
+            let client_state_of_a_on_b = ctx_b.client_state(client_id_on_b)?;
+
+            // The client must not be frozen.
+            if client_state_of_a_on_b.is_frozen() {
+                return Err(PacketError::FrozenClient {
+                    client_id: client_id_on_b.clone(),
+                }
+                .into());
+            }
+
+            let consensus_state_of_a_on_b =
+                ctx_b.consensus_state(client_id_on_b, &msg.proof_height_on_a)?;
+
+            let expected_commitment_on_a = ctx_b.packet_commitment(
+                &msg.packet.data,
+                &msg.packet.timeout_height_on_b,
+                &msg.packet.timeout_timestamp_on_b,
+            );
+            // Verify the proof for the packet against the chain store.
+            client_state_of_a_on_b
+                .new_verify_packet_data(
+                    ctx_b,
+                    msg.proof_height_on_a,
+                    &conn_end_on_b,
+                    &msg.proof_commitment_on_a,
+                    consensus_state_of_a_on_b.root(),
+                    &msg.packet.port_on_a,
+                    &msg.packet.chan_on_a,
+                    msg.packet.sequence,
+                    expected_commitment_on_a,
+                )
+                .map_err(|e| ChannelError::PacketVerificationFailed {
+                    sequence: msg.packet.sequence,
+                    client_error: e,
+                })
+                .map_err(PacketError::Channel)?;
+        }
+
+        if chan_end_on_b.order_matches(&Order::Ordered) {
+            let next_seq_recv = ctx_b.get_next_sequence_recv(port_chan_id_on_b)?;
+            if msg.packet.sequence > next_seq_recv {
+                return Err(PacketError::InvalidPacketSequence {
+                    given_sequence: msg.packet.sequence,
+                    next_sequence: next_seq_recv,
+                }
+                .into());
+            }
+        } else {
+            ctx_b.get_packet_receipt(&(
+                msg.packet.port_on_b.clone(),
+                msg.packet.chan_on_b.clone(),
+                msg.packet.sequence,
+            ))?;
+        };
+
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum RecvPacketResult {
     NoOp,

--- a/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -56,10 +56,6 @@ pub fn process<Ctx: ChannelReader>(
         Err(e) => return Err(e),
     }
 
-    if ack.is_empty() {
-        return Err(PacketError::InvalidAcknowledgement);
-    }
-
     let result = PacketResult::WriteAck(WriteAckPacketResult {
         port_id: packet.port_on_b.clone(),
         channel_id: packet.chan_on_b.clone(),
@@ -181,7 +177,7 @@ mod tests {
         .collect();
 
         for test in tests {
-            let res = process(&test.ctx, test.packet.clone(), test.ack.into());
+            let res = process(&test.ctx, test.packet.clone(), test.ack.try_into().unwrap());
             // Additionally check the events and the output objects in the result.
             match res {
                 Ok(proto_output) => {

--- a/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -149,15 +149,14 @@ mod tests {
             Test {
                 name: "Good parameters".to_string(),
                 ctx: context
-                    .clone()
                     .with_client(&ClientId::default(), client_height)
-                    .with_connection(ConnectionId::default(), connection_end.clone())
+                    .with_connection(ConnectionId::default(), connection_end)
                     .with_channel(
                         packet.port_on_b.clone(),
                         packet.chan_on_b.clone(),
-                        dest_channel_end.clone(),
+                        dest_channel_end,
                     ),
-                packet: packet.clone(),
+                packet,
                 ack,
                 want_pass: true,
             },

--- a/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -93,7 +93,7 @@ mod tests {
     use crate::core::ics04_channel::handler::write_acknowledgement::process;
     use crate::core::ics04_channel::packet::test_utils::get_dummy_raw_packet;
     use crate::core::ics04_channel::Version;
-    use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+    use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
     use crate::mock::context::MockContext;
     use crate::timestamp::ZERO_DURATION;
     use crate::{core::ics04_channel::packet::Packet, events::IbcEvent};
@@ -117,7 +117,6 @@ mod tests {
         packet.data = vec![0];
 
         let ack = vec![0];
-        let ack_null = Vec::new();
 
         let dest_channel_end = ChannelEnd::new(
             State::Open,
@@ -161,16 +160,6 @@ mod tests {
                 packet: packet.clone(),
                 ack,
                 want_pass: true,
-            },
-            Test {
-                name: "Zero ack".to_string(),
-                ctx: context
-                    .with_client(&ClientId::default(), Height::new(0, 1).unwrap())
-                    .with_connection(ConnectionId::default(), connection_end)
-                    .with_channel(PortId::default(), ChannelId::default(), dest_channel_end),
-                packet,
-                ack: ack_null,
-                want_pass: false,
             },
         ]
         .into_iter()

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -270,6 +270,13 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
         Ok(ModuleExtras::empty())
     }
 
+    #[cfg(feature = "val_exec_ctx")]
+    fn on_recv_packet_execute(
+        &mut self,
+        packet: &Packet,
+        relayer: &Signer,
+    ) -> (ModuleExtras, Acknowledgement);
+
     fn on_recv_packet(
         &mut self,
         _output: &mut ModuleOutputBuilder,

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -355,6 +355,22 @@ impl ClientState for MockClientState {
         Ok(())
     }
 
+    #[cfg(feature = "val_exec_ctx")]
+    fn new_verify_packet_data(
+        &self,
+        _ctx: &dyn ValidationContext,
+        _height: Height,
+        _connection_end: &ConnectionEnd,
+        _proof: &CommitmentProofBytes,
+        _root: &CommitmentRoot,
+        _port_id: &PortId,
+        _channel_id: &ChannelId,
+        _sequence: Sequence,
+        _commitment: PacketCommitment,
+    ) -> Result<(), ClientError> {
+        Ok(())
+    }
+
     fn verify_packet_data(
         &self,
         _ctx: &dyn ChannelReader,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1966,6 +1966,17 @@ mod tests {
                 Ok((ModuleExtras::empty(), counterparty_version.clone()))
             }
 
+            #[cfg(feature = "val_exec_ctx")]
+            fn on_recv_packet_execute(
+                &mut self,
+                _packet: &Packet,
+                _relayer: &Signer,
+            ) -> (ModuleExtras, Acknowledgement) {
+                self.counter += 1;
+
+                (ModuleExtras::empty(), Acknowledgement::from(vec![1u8]))
+            }
+
             fn on_recv_packet(
                 &mut self,
                 _output: &mut ModuleOutputBuilder,
@@ -2056,6 +2067,15 @@ mod tests {
                 counterparty_version: &Version,
             ) -> Result<(ModuleExtras, Version), ChannelError> {
                 Ok((ModuleExtras::empty(), counterparty_version.clone()))
+            }
+
+            #[cfg(feature = "val_exec_ctx")]
+            fn on_recv_packet_execute(
+                &mut self,
+                _packet: &Packet,
+                _relayer: &Signer,
+            ) -> (ModuleExtras, Acknowledgement) {
+                (ModuleExtras::empty(), Acknowledgement::from(vec![1u8]))
             }
 
             fn on_recv_packet(

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1974,7 +1974,10 @@ mod tests {
             ) -> (ModuleExtras, Acknowledgement) {
                 self.counter += 1;
 
-                (ModuleExtras::empty(), Acknowledgement::from(vec![1u8]))
+                (
+                    ModuleExtras::empty(),
+                    Acknowledgement::try_from(vec![1u8]).unwrap(),
+                )
             }
 
             fn on_recv_packet(
@@ -1985,7 +1988,7 @@ mod tests {
             ) -> Acknowledgement {
                 self.counter += 1;
 
-                Acknowledgement::from(vec![1u8])
+                Acknowledgement::try_from(vec![1u8]).unwrap()
             }
         }
 
@@ -2075,7 +2078,10 @@ mod tests {
                 _packet: &Packet,
                 _relayer: &Signer,
             ) -> (ModuleExtras, Acknowledgement) {
-                (ModuleExtras::empty(), Acknowledgement::from(vec![1u8]))
+                (
+                    ModuleExtras::empty(),
+                    Acknowledgement::try_from(vec![1u8]).unwrap(),
+                )
             }
 
             fn on_recv_packet(
@@ -2084,7 +2090,7 @@ mod tests {
                 _packet: &Packet,
                 _relayer: &Signer,
             ) -> Acknowledgement {
-                Acknowledgement::from(vec![1u8])
+                Acknowledgement::try_from(vec![1u8]).unwrap()
             }
         }
 

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -166,6 +166,15 @@ impl Module for DummyTransferModule {
         ))
     }
 
+    #[cfg(feature = "val_exec_ctx")]
+    fn on_recv_packet_execute(
+        &mut self,
+        _packet: &Packet,
+        _relayer: &Signer,
+    ) -> (ModuleExtras, Acknowledgement) {
+        (ModuleExtras::empty(), Acknowledgement::from(vec![1u8]))
+    }
+
     fn on_recv_packet(
         &mut self,
         _output: &mut ModuleOutputBuilder,

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -172,7 +172,10 @@ impl Module for DummyTransferModule {
         _packet: &Packet,
         _relayer: &Signer,
     ) -> (ModuleExtras, Acknowledgement) {
-        (ModuleExtras::empty(), Acknowledgement::from(vec![1u8]))
+        (
+            ModuleExtras::empty(),
+            Acknowledgement::try_from(vec![1u8]).unwrap(),
+        )
     }
 
     fn on_recv_packet(
@@ -181,7 +184,7 @@ impl Module for DummyTransferModule {
         _packet: &Packet,
         _relayer: &Signer,
     ) -> Acknowledgement {
-        Acknowledgement::from(vec![1u8])
+        Acknowledgement::try_from(vec![1u8]).unwrap()
     }
 }
 


### PR DESCRIPTION
Work towards: #322

Changed the scope of this PR to include only `recvPacket`, since it turned out to have many subtleties to get right.

## Description

As with the other PRs, this one focuses on correctness. The more we get closer to being done with #322, the more it becomes obvious that we need a refactor. Let's hold off until we're completely done though; it will be easier to make a big refactor after #279.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
