### PR TITLE
Implement `dispatch()` for `ValidationContext` and `ExecutionContext`

### DIFF
--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -22,3 +22,9 @@ where
     let envelope: MsgEnvelope = message.try_into()?;
     ctx.execute(envelope)
 }
+
+/// Entrypoint which performs both validation and message execution
+pub fn dispatch(ctx: &mut impl ExecutionContext, msg: MsgEnvelope) -> Result<(), RouterError> {
+    ctx.validate(msg.clone())?;
+    ctx.execute(msg)
+}

--- a/crates/ibc/src/core/mod.rs
+++ b/crates/ibc/src/core/mod.rs
@@ -36,6 +36,8 @@ pub mod context;
 #[cfg(feature = "val_exec_ctx")]
 pub mod handler;
 #[cfg(feature = "val_exec_ctx")]
+pub use handler::dispatch;
+#[cfg(feature = "val_exec_ctx")]
 pub use handler::execute;
 #[cfg(feature = "val_exec_ctx")]
 pub use handler::validate;


### PR DESCRIPTION

Closes: #395

This is not an efficient implementation, as there are operations performed twice between `validate()` and `execute()`, but it is correct.