### PR TITLE
Refactor store_* and get_* methods to take *Path structs instead

### DIFF
--- a/.changelog/unreleased/breaking-changes/382-refactor-get-and-store-methods.md
+++ b/.changelog/unreleased/breaking-changes/382-refactor-get-and-store-methods.md
@@ -1,0 +1,2 @@
+- Refactor get_* and store_* methods to take *Path structs instead 
+  ([#382](https://github.com/cosmos/ibc-rs/issues/382))

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -6,6 +6,7 @@ use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::{is_sender_chain_source, Coin, PrefixedCoin};
 use crate::core::ics04_channel::handler::send_packet::send_packet;
 use crate::core::ics04_channel::packet::Packet;
+use crate::core::ics24_host::path::{ChannelEndsPath, SeqSendsPath};
 use crate::events::ModuleEvent;
 use crate::handler::{HandlerOutput, HandlerOutputBuilder};
 use crate::prelude::*;
@@ -25,9 +26,9 @@ where
     if !ctx.is_send_enabled() {
         return Err(TokenTransferError::SendDisabled);
     }
-
+    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_on_a, &msg.chan_on_a);
     let chan_end_on_a = ctx
-        .channel_end(&msg.port_on_a, &msg.chan_on_a)
+        .channel_end(&chan_end_path_on_a)
         .map_err(TokenTransferError::PacketError)?;
 
     let port_on_b = chan_end_on_a.counterparty().port_id().clone();
@@ -41,8 +42,9 @@ where
         .clone();
 
     // get the next sequence
+    let seq_send_path_on_a = SeqSendsPath::new(&msg.port_on_a, &msg.chan_on_a);
     let sequence = ctx
-        .get_next_sequence_send(&msg.port_on_a, &msg.chan_on_a)
+        .get_next_sequence_send(&seq_send_path_on_a)
         .map_err(TokenTransferError::PacketError)?;
 
     let token = msg

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -6,7 +6,7 @@ use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::{is_sender_chain_source, Coin, PrefixedCoin};
 use crate::core::ics04_channel::handler::send_packet::send_packet;
 use crate::core::ics04_channel::packet::Packet;
-use crate::core::ics24_host::path::{ChannelEndsPath, SeqSendsPath};
+use crate::core::ics24_host::path::{ChannelEndPath, SeqSendPath};
 use crate::events::ModuleEvent;
 use crate::handler::{HandlerOutput, HandlerOutputBuilder};
 use crate::prelude::*;
@@ -26,7 +26,7 @@ where
     if !ctx.is_send_enabled() {
         return Err(TokenTransferError::SendDisabled);
     }
-    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_on_a, &msg.chan_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&msg.port_on_a, &msg.chan_on_a);
     let chan_end_on_a = ctx
         .channel_end(&chan_end_path_on_a)
         .map_err(TokenTransferError::PacketError)?;
@@ -42,7 +42,7 @@ where
         .clone();
 
     // get the next sequence
-    let seq_send_path_on_a = SeqSendsPath::new(&msg.port_on_a, &msg.chan_on_a);
+    let seq_send_path_on_a = SeqSendPath::new(&msg.port_on_a, &msg.chan_on_a);
     let sequence = ctx
         .get_next_sequence_send(&seq_send_path_on_a)
         .map_err(TokenTransferError::PacketError)?;

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -1,4 +1,3 @@
-use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::prelude::*;
 
 use core::convert::{TryFrom, TryInto};
@@ -30,6 +29,7 @@ use crate::core::ics02_client::context::ClientReader;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics02_client::trust_threshold::TrustThreshold;
 use crate::core::ics03_connection::connection::ConnectionEnd;
+use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
 use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::packet::Sequence;

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -40,8 +40,8 @@ use crate::core::ics23_commitment::merkle::{apply_prefix, MerkleProof};
 use crate::core::ics23_commitment::specs::ProofSpecs;
 use crate::core::ics24_host::identifier::{ChainId, ClientId};
 use crate::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, ClientUpgradePath,
-    CommitmentsPath, ConnectionsPath, ReceiptsPath, SeqRecvsPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, ClientStatePath, ClientUpgradePath,
+    CommitmentPath, ConnectionPath, ReceiptPath, SeqRecvPath,
 };
 use crate::core::ics24_host::Path;
 use crate::timestamp::{Timestamp, ZERO_DURATION};
@@ -1051,7 +1051,7 @@ impl Ics2ClientState for ClientState {
         prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        conn_path: &ConnectionsPath,
+        conn_path: &ConnectionPath,
         expected_connection_end: &ConnectionEnd,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1069,7 +1069,7 @@ impl Ics2ClientState for ClientState {
         prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        channel_end_path: &ChannelEndsPath,
+        channel_end_path: &ChannelEndPath,
         expected_channel_end: &ChannelEnd,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1118,7 +1118,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1142,7 +1142,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1166,7 +1166,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
         ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1190,7 +1190,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
         ack_commitment: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1215,7 +1215,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        seq_recv_path: &SeqRecvsPath,
+        seq_recv_path: &SeqRecvPath,
         sequence: Sequence,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1244,7 +1244,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        seq_recv_path: &SeqRecvsPath,
+        seq_recv_path: &SeqRecvPath,
         sequence: Sequence,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1274,7 +1274,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        receipt_path: &ReceiptsPath,
+        receipt_path: &ReceiptPath,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
@@ -1296,7 +1296,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        receipt_path: &ReceiptsPath,
+        receipt_path: &ReceiptPath,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -1,3 +1,4 @@
+use crate::core::ics04_channel::channel::ChannelEnd;
 use crate::prelude::*;
 
 use core::convert::{TryFrom, TryInto};
@@ -37,7 +38,7 @@ use crate::core::ics23_commitment::commitment::{
 };
 use crate::core::ics23_commitment::merkle::{apply_prefix, MerkleProof};
 use crate::core::ics23_commitment::specs::ProofSpecs;
-use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
+use crate::core::ics24_host::identifier::{ChainId, ClientId};
 use crate::core::ics24_host::path::{
     AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, ClientUpgradePath,
     CommitmentsPath, ConnectionsPath, ReceiptsPath, SeqRecvsPath,
@@ -394,10 +395,9 @@ impl Ics2ClientState for ClientState {
     ) -> Result<UpdatedState, ClientError> {
         fn maybe_consensus_state(
             ctx: &dyn ClientReader,
-            client_id: &ClientId,
-            height: &Height,
+            client_cons_state_path: &ClientConsensusStatePath,
         ) -> Result<Option<Box<dyn ConsensusState>>, ClientError> {
-            match ctx.consensus_state(client_id, height) {
+            match ctx.consensus_state(client_cons_state_path) {
                 Ok(cs) => Ok(Some(cs)),
                 Err(e) => match e {
                     ClientError::ConsensusStateNotFound {
@@ -425,27 +425,29 @@ impl Ics2ClientState for ClientState {
         // Check if a consensus state is already installed; if so it should
         // match the untrusted header.
         let header_consensus_state = TmConsensusState::from(header.clone());
-        let existing_consensus_state =
-            match maybe_consensus_state(ctx, &client_id, &header.height())? {
-                Some(cs) => {
-                    let cs = downcast_tm_consensus_state(cs.as_ref())?;
-                    // If this consensus state matches, skip verification
-                    // (optimization)
-                    if cs == header_consensus_state {
-                        // Header is already installed and matches the incoming
-                        // header (already verified)
-                        return Ok(UpdatedState {
-                            client_state: client_state.into_box(),
-                            consensus_state: cs.into_box(),
-                        });
-                    }
-                    Some(cs)
+        let client_cons_state_path = ClientConsensusStatePath::new(&client_id, &header.height());
+        let existing_consensus_state = match maybe_consensus_state(ctx, &client_cons_state_path)? {
+            Some(cs) => {
+                let cs = downcast_tm_consensus_state(cs.as_ref())?;
+                // If this consensus state matches, skip verification
+                // (optimization)
+                if cs == header_consensus_state {
+                    // Header is already installed and matches the incoming
+                    // header (already verified)
+                    return Ok(UpdatedState {
+                        client_state: client_state.into_box(),
+                        consensus_state: cs.into_box(),
+                    });
                 }
-                None => None,
-            };
+                Some(cs)
+            }
+            None => None,
+        };
 
+        let trusted_client_cons_state_path =
+            ClientConsensusStatePath::new(&client_id, &header.trusted_height);
         let trusted_consensus_state = downcast_tm_consensus_state(
-            ctx.consensus_state(&client_id, &header.trusted_height)?
+            ctx.consensus_state(&trusted_client_cons_state_path)?
                 .as_ref(),
         )?;
 
@@ -497,12 +499,12 @@ impl Ics2ClientState for ClientState {
                 });
             }
         }
-
+        let client_cons_state_path = ClientConsensusStatePath::new(&client_id, &header.height());
         // Monotonicity checks for timestamps for in-the-middle updates
         // (cs-new, cs-next, cs-latest)
         if header.height() < client_state.latest_height() {
             let maybe_next_cs = ctx
-                .next_consensus_state(&client_id, &header.height())?
+                .next_consensus_state(&client_cons_state_path)?
                 .as_ref()
                 .map(|cs| downcast_tm_consensus_state(cs.as_ref()))
                 .transpose()?;
@@ -525,7 +527,7 @@ impl Ics2ClientState for ClientState {
         // (cs-trusted, cs-prev, cs-new)
         if header.trusted_height < header.height() {
             let maybe_prev_cs = ctx
-                .prev_consensus_state(&client_id, &header.height())?
+                .prev_consensus_state(&client_cons_state_path)?
                 .as_ref()
                 .map(|cs| downcast_tm_consensus_state(cs.as_ref()))
                 .transpose()?;
@@ -574,13 +576,17 @@ impl Ics2ClientState for ClientState {
                 return Err(Error::MisbehaviourHeadersNotAtSameHeight.into());
             }
         }
-
+        let client_cons_state_path_1 =
+            ClientConsensusStatePath::new(&client_id, &header_1.trusted_height);
         let consensus_state_1 = {
-            let cs = ctx.consensus_state(&client_id, &header_1.trusted_height)?;
+            let cs = ctx.consensus_state(&client_cons_state_path_1)?;
             downcast_tm_consensus_state(cs.as_ref())
         }?;
+
+        let client_cons_state_path_2 =
+            ClientConsensusStatePath::new(&client_id, &header_2.trusted_height);
         let consensus_state_2 = {
-            let cs = ctx.consensus_state(&client_id, &header_2.trusted_height)?;
+            let cs = ctx.consensus_state(&client_cons_state_path_2)?;
             downcast_tm_consensus_state(cs.as_ref())
         }?;
 
@@ -637,13 +643,17 @@ impl Ics2ClientState for ClientState {
                 ));
             }
         }
-
+        let client_cons_state_path_1 =
+            ClientConsensusStatePath::new(&client_id, &header_1.trusted_height);
         let consensus_state_1 = {
-            let cs = ctx.consensus_state(&client_id, &header_1.trusted_height)?;
+            let cs = ctx.consensus_state(&client_cons_state_path_1)?;
             downcast_tm_consensus_state(cs.as_ref())
         }?;
+
+        let client_cons_state_path_2 =
+            ClientConsensusStatePath::new(&client_id, &header_2.trusted_height);
         let consensus_state_2 = {
-            let cs = ctx.consensus_state(&client_id, &header_2.trusted_height)?;
+            let cs = ctx.consensus_state(&client_cons_state_path_2)?;
             downcast_tm_consensus_state(cs.as_ref())
         }?;
 
@@ -683,10 +693,9 @@ impl Ics2ClientState for ClientState {
     ) -> Result<UpdatedState, ClientError> {
         fn maybe_consensus_state(
             ctx: &dyn ValidationContext,
-            client_id: &ClientId,
-            height: Height,
+            client_cons_state_path: &ClientConsensusStatePath,
         ) -> Result<Option<Box<dyn ConsensusState>>, ClientError> {
-            match ctx.consensus_state(client_id, &height) {
+            match ctx.consensus_state(client_cons_state_path) {
                 Ok(cs) => Ok(Some(cs)),
                 Err(e) => match e {
                     ContextError::ClientError(ClientError::ConsensusStateNotFound {
@@ -717,27 +726,29 @@ impl Ics2ClientState for ClientState {
         // Check if a consensus state is already installed; if so it should
         // match the untrusted header.
         let header_consensus_state = TmConsensusState::from(header.clone());
-        let existing_consensus_state =
-            match maybe_consensus_state(ctx, &client_id, header.height())? {
-                Some(cs) => {
-                    let cs = downcast_tm_consensus_state(cs.as_ref())?;
-                    // If this consensus state matches, skip verification
-                    // (optimization)
-                    if cs == header_consensus_state {
-                        // Header is already installed and matches the incoming
-                        // header (already verified)
-                        return Ok(UpdatedState {
-                            client_state: client_state.into_box(),
-                            consensus_state: cs.into_box(),
-                        });
-                    }
-                    Some(cs)
+        let client_cons_state_path = ClientConsensusStatePath::new(&client_id, &header.height());
+        let existing_consensus_state = match maybe_consensus_state(ctx, &client_cons_state_path)? {
+            Some(cs) => {
+                let cs = downcast_tm_consensus_state(cs.as_ref())?;
+                // If this consensus state matches, skip verification
+                // (optimization)
+                if cs == header_consensus_state {
+                    // Header is already installed and matches the incoming
+                    // header (already verified)
+                    return Ok(UpdatedState {
+                        client_state: client_state.into_box(),
+                        consensus_state: cs.into_box(),
+                    });
                 }
-                None => None,
-            };
+                Some(cs)
+            }
+            None => None,
+        };
 
+        let trusted_client_cons_state_path =
+            ClientConsensusStatePath::new(&client_id, &header.trusted_height);
         let trusted_consensus_state = downcast_tm_consensus_state(
-            ctx.consensus_state(&client_id, &header.trusted_height)
+            ctx.consensus_state(&trusted_client_cons_state_path)
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => todo!(),
@@ -796,11 +807,12 @@ impl Ics2ClientState for ClientState {
             }
         }
 
+        let client_cons_state_path = ClientConsensusStatePath::new(&client_id, &header.height());
         // Monotonicity checks for timestamps for in-the-middle updates
         // (cs-new, cs-next, cs-latest)
         if header.height() < client_state.latest_height() {
             let maybe_next_cs = ctx
-                .next_consensus_state(&client_id, &header.height())
+                .next_consensus_state(&client_cons_state_path)
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => todo!(),
@@ -827,7 +839,7 @@ impl Ics2ClientState for ClientState {
         // (cs-trusted, cs-prev, cs-new)
         if header.trusted_height < header.height() {
             let maybe_prev_cs = ctx
-                .prev_consensus_state(&client_id, &header.height())
+                .prev_consensus_state(&client_cons_state_path)
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => todo!(),
@@ -1013,23 +1025,24 @@ impl Ics2ClientState for ClientState {
         prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        client_id: &ClientId,
-        consensus_height: Height,
+        client_cons_state_path: &ClientConsensusStatePath,
         expected_consensus_state: &dyn ConsensusState,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
 
-        let path = ClientConsensusStatePath {
-            client_id: client_id.clone(),
-            epoch: consensus_height.revision_number(),
-            height: consensus_height.revision_height(),
-        };
         let value = expected_consensus_state
             .encode_vec()
             .map_err(ClientError::InvalidAnyConsensusState)?;
 
-        verify_membership(client_state, prefix, proof, root, path, value)
+        verify_membership(
+            client_state,
+            prefix,
+            proof,
+            root,
+            client_cons_state_path.clone(),
+            value,
+        )
     }
 
     fn verify_connection_state(
@@ -1038,17 +1051,16 @@ impl Ics2ClientState for ClientState {
         prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        connection_id: &ConnectionId,
+        conn_path: &ConnectionsPath,
         expected_connection_end: &ConnectionEnd,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
 
-        let path = ConnectionsPath(connection_id.clone());
         let value = expected_connection_end
             .encode_vec()
             .map_err(ClientError::InvalidConnectionEnd)?;
-        verify_membership(client_state, prefix, proof, root, path, value)
+        verify_membership(client_state, prefix, proof, root, conn_path.clone(), value)
     }
 
     fn verify_channel_state(
@@ -1057,18 +1069,23 @@ impl Ics2ClientState for ClientState {
         prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        expected_channel_end: &crate::core::ics04_channel::channel::ChannelEnd,
+        channel_end_path: &ChannelEndsPath,
+        expected_channel_end: &ChannelEnd,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
-
-        let path = ChannelEndsPath(port_id.clone(), channel_id.clone());
         let value = expected_channel_end
             .encode_vec()
             .map_err(ClientError::InvalidChannelEnd)?;
-        verify_membership(client_state, prefix, proof, root, path, value)
+
+        verify_membership(
+            client_state,
+            prefix,
+            proof,
+            root,
+            channel_end_path.clone(),
+            value,
+        )
     }
 
     fn verify_client_full_state(
@@ -1077,15 +1094,21 @@ impl Ics2ClientState for ClientState {
         prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        client_id: &ClientId,
+        client_state_path: &ClientStatePath,
         expected_client_state: Any,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
-
-        let path = ClientStatePath(client_id.clone());
         let value = expected_client_state.encode_to_vec();
-        verify_membership(client_state, prefix, proof, root, path, value)
+
+        verify_membership(
+            client_state,
+            prefix,
+            proof,
+            root,
+            client_state_path.clone(),
+            value,
+        )
     }
 
     fn new_verify_packet_data(
@@ -1095,27 +1118,19 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        commitment_path: &CommitmentsPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
         new_verify_delay_passed(ctx, height, connection_end)?;
 
-        let commitment_path = CommitmentsPath {
-            port_id: port_id.clone(),
-            channel_id: channel_id.clone(),
-            sequence,
-        };
-
         verify_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            commitment_path,
+            commitment_path.clone(),
             commitment.into_vec(),
         )
     }
@@ -1127,27 +1142,19 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        commitment_path: &CommitmentsPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
         verify_delay_passed(ctx, height, connection_end)?;
 
-        let commitment_path = CommitmentsPath {
-            port_id: port_id.clone(),
-            channel_id: channel_id.clone(),
-            sequence,
-        };
-
         verify_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            commitment_path,
+            commitment_path.clone(),
             commitment.into_vec(),
         )
     }
@@ -1159,26 +1166,19 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        ack_path: &AcksPath,
         ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
         new_verify_delay_passed(ctx, height, connection_end)?;
 
-        let ack_path = AcksPath {
-            port_id: port_id.clone(),
-            channel_id: channel_id.clone(),
-            sequence,
-        };
         verify_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            ack_path,
+            ack_path.clone(),
             ack.into_vec(),
         )
     }
@@ -1190,26 +1190,19 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        ack_path: &AcksPath,
         ack_commitment: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
         verify_delay_passed(ctx, height, connection_end)?;
 
-        let ack_path = AcksPath {
-            port_id: port_id.clone(),
-            channel_id: channel_id.clone(),
-            sequence,
-        };
         verify_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            ack_path,
+            ack_path.clone(),
             ack_commitment.into_vec(),
         )
     }
@@ -1222,8 +1215,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
+        seq_recv_path: &SeqRecvsPath,
         sequence: Sequence,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1235,14 +1227,12 @@ impl Ics2ClientState for ClientState {
             .encode(&mut seq_bytes)
             .expect("buffer size too small");
 
-        let seq_path = SeqRecvsPath(port_id.clone(), channel_id.clone());
-
         verify_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            seq_path,
+            seq_recv_path.clone(),
             seq_bytes,
         )
     }
@@ -1254,8 +1244,7 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
+        seq_recv_path: &SeqRecvsPath,
         sequence: Sequence,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
@@ -1267,14 +1256,12 @@ impl Ics2ClientState for ClientState {
             .encode(&mut seq_bytes)
             .expect("buffer size too small");
 
-        let seq_path = SeqRecvsPath(port_id.clone(), channel_id.clone());
-
         verify_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            seq_path,
+            seq_recv_path.clone(),
             seq_bytes,
         )
     }
@@ -1287,25 +1274,18 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        receipt_path: &ReceiptsPath,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
         new_verify_delay_passed(ctx, height, connection_end)?;
 
-        let receipt_path = ReceiptsPath {
-            port_id: port_id.clone(),
-            channel_id: channel_id.clone(),
-            sequence,
-        };
         verify_non_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            receipt_path,
+            receipt_path.clone(),
         )
     }
 
@@ -1316,25 +1296,18 @@ impl Ics2ClientState for ClientState {
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        receipt_path: &ReceiptsPath,
     ) -> Result<(), ClientError> {
         let client_state = downcast_tm_client_state(self)?;
         client_state.verify_height(height)?;
         verify_delay_passed(ctx, height, connection_end)?;
 
-        let receipt_path = ReceiptsPath {
-            port_id: port_id.clone(),
-            channel_id: channel_id.clone(),
-            sequence,
-        };
         verify_non_membership(
             client_state,
             connection_end.counterparty().prefix(),
             proof,
             root,
-            receipt_path,
+            receipt_path.clone(),
         )
     }
 }

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -519,14 +519,14 @@ pub trait ExecutionContext: ValidationContext {
     /// Stores the given connection_end at path
     fn store_connection(
         &mut self,
-        connection_path: ConnectionPath,
+        connection_path: &ConnectionPath,
         connection_end: ConnectionEnd,
     ) -> Result<(), ContextError>;
 
     /// Stores the given connection_id at a path associated with the client_id.
     fn store_connection_to_client(
         &mut self,
-        client_connection_path: ClientConnectionPath,
+        client_connection_path: &ClientConnectionPath,
         conn_id: ConnectionId,
     ) -> Result<(), ContextError>;
 
@@ -537,48 +537,51 @@ pub trait ExecutionContext: ValidationContext {
 
     fn store_packet_commitment(
         &mut self,
-        commitment_path: CommitmentPath,
+        commitment_path: &CommitmentPath,
         commitment: PacketCommitment,
     ) -> Result<(), ContextError>;
 
-    fn delete_packet_commitment(&mut self, key: CommitmentPath) -> Result<(), ContextError>;
+    fn delete_packet_commitment(
+        &mut self,
+        commitment_path: &CommitmentPath,
+    ) -> Result<(), ContextError>;
 
     fn store_packet_receipt(
         &mut self,
-        receipt_path: ReceiptPath,
+        receipt_path: &ReceiptPath,
         receipt: Receipt,
     ) -> Result<(), ContextError>;
 
     fn store_packet_acknowledgement(
         &mut self,
-        ack_path: AckPath,
+        ack_path: &AckPath,
         ack_commitment: AcknowledgementCommitment,
     ) -> Result<(), ContextError>;
 
-    fn delete_packet_acknowledgement(&mut self, ack_path: AckPath) -> Result<(), ContextError>;
+    fn delete_packet_acknowledgement(&mut self, ack_path: &AckPath) -> Result<(), ContextError>;
 
     /// Stores the given channel_end at a path associated with the port_id and channel_id.
     fn store_channel(
         &mut self,
-        channel_end_path: ChannelEndPath,
+        channel_end_path: &ChannelEndPath,
         channel_end: ChannelEnd,
     ) -> Result<(), ContextError>;
 
     fn store_next_sequence_send(
         &mut self,
-        seq_send_path: SeqSendPath,
+        seq_send_path: &SeqSendPath,
         seq: Sequence,
     ) -> Result<(), ContextError>;
 
     fn store_next_sequence_recv(
         &mut self,
-        seq_recv_path: SeqRecvPath,
+        seq_recv_path: &SeqRecvPath,
         seq: Sequence,
     ) -> Result<(), ContextError>;
 
     fn store_next_sequence_ack(
         &mut self,
-        seq_ack_path: SeqAckPath,
+        seq_ack_path: &SeqAckPath,
         seq: Sequence,
     ) -> Result<(), ContextError>;
 
@@ -653,19 +656,19 @@ where
             msg.version_proposal.clone(),
         );
         let chan_end_path_on_a = ChannelEndPath::new(&msg.port_id_on_a, &chan_id_on_a);
-        ctx_a.store_channel(chan_end_path_on_a, chan_end_on_a)?;
+        ctx_a.store_channel(&chan_end_path_on_a, chan_end_on_a)?;
 
         ctx_a.increase_channel_counter();
 
         // Initialize send, recv, and ack sequence numbers.
         let seq_send_path = SeqSendPath::new(&msg.port_id_on_a, &chan_id_on_a);
-        ctx_a.store_next_sequence_send(seq_send_path, 1.into())?;
+        ctx_a.store_next_sequence_send(&seq_send_path, 1.into())?;
 
         let seq_recv_path = SeqRecvPath::new(&msg.port_id_on_a, &chan_id_on_a);
-        ctx_a.store_next_sequence_recv(seq_recv_path, 1.into())?;
+        ctx_a.store_next_sequence_recv(&seq_recv_path, 1.into())?;
 
         let seq_ack_path = SeqAckPath::new(&msg.port_id_on_a, &chan_id_on_a);
-        ctx_a.store_next_sequence_ack(seq_ack_path, 1.into())?;
+        ctx_a.store_next_sequence_ack(&seq_ack_path, 1.into())?;
     }
 
     // emit events and logs
@@ -755,18 +758,18 @@ where
         );
 
         let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &chan_id_on_b);
-        ctx_b.store_channel(chan_end_path_on_b, chan_end_on_b)?;
+        ctx_b.store_channel(&chan_end_path_on_b, chan_end_on_b)?;
         ctx_b.increase_channel_counter();
 
         // Initialize send, recv, and ack sequence numbers.
         let seq_send_path = SeqSendPath::new(&msg.port_id_on_b, &chan_id_on_b);
-        ctx_b.store_next_sequence_send(seq_send_path, 1.into())?;
+        ctx_b.store_next_sequence_send(&seq_send_path, 1.into())?;
 
         let seq_recv_path = SeqRecvPath::new(&msg.port_id_on_b, &chan_id_on_b);
-        ctx_b.store_next_sequence_recv(seq_recv_path, 1.into())?;
+        ctx_b.store_next_sequence_recv(&seq_recv_path, 1.into())?;
 
         let seq_ack_path = SeqAckPath::new(&msg.port_id_on_b, &chan_id_on_b);
-        ctx_b.store_next_sequence_ack(seq_ack_path, 1.into())?;
+        ctx_b.store_next_sequence_ack(&seq_ack_path, 1.into())?;
     }
 
     // emit events and logs
@@ -842,7 +845,7 @@ where
 
             chan_end_on_a
         };
-        ctx_a.store_channel(chan_end_path_on_a, chan_end_on_a)?;
+        ctx_a.store_channel(&chan_end_path_on_a, chan_end_on_a)?;
     }
 
     // emit events and logs
@@ -917,7 +920,7 @@ where
 
             chan_end_on_b
         };
-        ctx_b.store_channel(chan_end_path_on_b, chan_end_on_b)?;
+        ctx_b.store_channel(&chan_end_path_on_b, chan_end_on_b)?;
     }
 
     // emit events and logs
@@ -998,7 +1001,7 @@ where
             chan_end_on_a
         };
 
-        ctx_a.store_channel(chan_end_path_on_a, chan_end_on_a)?;
+        ctx_a.store_channel(&chan_end_path_on_a, chan_end_on_a)?;
     }
 
     // emit events and logs
@@ -1080,7 +1083,7 @@ where
             chan_end_on_b.set_state(State::Closed);
             chan_end_on_b
         };
-        ctx_b.store_channel(chan_end_path_on_b, chan_end_on_b)?;
+        ctx_b.store_channel(&chan_end_path_on_b, chan_end_on_b)?;
     }
 
     // emit events and logs
@@ -1188,13 +1191,13 @@ where
                     sequence: msg.packet.sequence,
                 };
 
-                ctx_b.store_packet_receipt(receipt_path_on_b, Receipt::Ok)?;
+                ctx_b.store_packet_receipt(&receipt_path_on_b, Receipt::Ok)?;
             }
             Order::Ordered => {
                 let seq_recv_path_on_b =
                     SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
                 let next_seq_recv = ctx_b.get_next_sequence_recv(&seq_recv_path_on_b)?;
-                ctx_b.store_next_sequence_recv(seq_recv_path_on_b, next_seq_recv.increment())?;
+                ctx_b.store_next_sequence_recv(&seq_recv_path_on_b, next_seq_recv.increment())?;
             }
             _ => {}
         }
@@ -1205,7 +1208,7 @@ where
         );
         // `writeAcknowledgement` handler state changes
         ctx_b
-            .store_packet_acknowledgement(ack_path_on_b, ctx_b.ack_commitment(&acknowledgement))?;
+            .store_packet_acknowledgement(&ack_path_on_b, ctx_b.ack_commitment(&acknowledgement))?;
     }
 
     // emit events and logs
@@ -1301,18 +1304,18 @@ where
 
     // apply state changes
     {
-        let commitment_path = CommitmentPath {
+        let commitment_path_on_a = CommitmentPath {
             port_id: msg.packet.port_on_a.clone(),
             channel_id: msg.packet.chan_on_a.clone(),
             sequence: msg.packet.sequence,
         };
-        ctx_a.delete_packet_commitment(commitment_path)?;
+        ctx_a.delete_packet_commitment(&commitment_path_on_a)?;
 
         if let Order::Ordered = chan_end_on_a.ordering {
             // Note: in validation, we verified that `msg.packet.sequence == nextSeqRecv`
             // (where `nextSeqRecv` is the value in the store)
             let seq_ack_path_on_a = SeqAckPath::new(&msg.packet.port_on_a, &msg.packet.chan_on_a);
-            ctx_a.store_next_sequence_ack(seq_ack_path_on_a, msg.packet.sequence.increment())?;
+            ctx_a.store_next_sequence_ack(&seq_ack_path_on_a, msg.packet.sequence.increment())?;
         }
     }
 
@@ -1409,17 +1412,17 @@ where
 
     // apply state changes
     let chan_end_on_a = {
-        let commitment_path = CommitmentPath {
+        let commitment_path_on_a = CommitmentPath {
             port_id: packet.port_on_a.clone(),
             channel_id: packet.chan_on_a.clone(),
             sequence: packet.sequence,
         };
-        ctx_a.delete_packet_commitment(commitment_path)?;
+        ctx_a.delete_packet_commitment(&commitment_path_on_a)?;
 
         if let Order::Ordered = chan_end_on_a.ordering {
             let mut chan_end_on_a = chan_end_on_a;
             chan_end_on_a.state = State::Closed;
-            ctx_a.store_channel(chan_end_path_on_a, chan_end_on_a.clone())?;
+            ctx_a.store_channel(&chan_end_path_on_a, chan_end_on_a.clone())?;
 
             chan_end_on_a
         } else {

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -321,15 +321,11 @@ pub trait ValidationContext: Router {
         cid: &ConnectionId,
     ) -> Result<Vec<(PortId, ChannelId)>, ContextError>;
 
-    fn get_next_sequence_send(
-        &self,
-        seq_send_path: &SeqSendPath,
-    ) -> Result<Sequence, ContextError>;
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath)
+        -> Result<Sequence, ContextError>;
 
-    fn get_next_sequence_recv(
-        &self,
-        seq_recv_path: &SeqRecvPath,
-    ) -> Result<Sequence, ContextError>;
+    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath)
+        -> Result<Sequence, ContextError>;
 
     fn get_next_sequence_ack(&self, seq_acks_path: &SeqAckPath) -> Result<Sequence, ContextError>;
 

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -327,14 +327,14 @@ pub trait ValidationContext: Router {
     fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath)
         -> Result<Sequence, ContextError>;
 
-    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAckPath) -> Result<Sequence, ContextError>;
+    fn get_next_sequence_ack(&self, seq_ack_path: &SeqAckPath) -> Result<Sequence, ContextError>;
 
     fn get_packet_commitment(
         &self,
         commitment_path: &CommitmentPath,
     ) -> Result<PacketCommitment, ContextError>;
 
-    fn get_packet_receipt(&self, receipts_path: &ReceiptPath) -> Result<Receipt, ContextError>;
+    fn get_packet_receipt(&self, receipt_path: &ReceiptPath) -> Result<Receipt, ContextError>;
 
     fn get_packet_acknowledgement(
         &self,
@@ -555,7 +555,7 @@ pub trait ExecutionContext: ValidationContext {
         ack_commitment: AcknowledgementCommitment,
     ) -> Result<(), ContextError>;
 
-    fn delete_packet_acknowledgement(&mut self, acks_path: AckPath) -> Result<(), ContextError>;
+    fn delete_packet_acknowledgement(&mut self, ack_path: AckPath) -> Result<(), ContextError>;
 
     /// Stores the given channel_end at a path associated with the port_id and channel_id.
     fn store_channel(

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -16,7 +16,11 @@ use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
 };
-use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
+use crate::core::ics24_host::identifier::{ChainId, ClientId};
+use crate::core::ics24_host::path::{
+    AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, CommitmentsPath,
+    ConnectionsPath, ReceiptsPath, SeqRecvsPath,
+};
 use crate::dynamic_typing::AsAny;
 use crate::erased::ErasedSerialize;
 use crate::prelude::*;
@@ -139,52 +143,46 @@ pub trait ClientState:
     /// matches the input `consensus_state`. The parameter `counterparty_height` represent the
     /// height of the counterparty chain that this proof assumes (i.e., the height at which this
     /// proof was computed).
-    #[allow(clippy::too_many_arguments)]
     fn verify_client_consensus_state(
         &self,
         proof_height: Height,
         counterparty_prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        counterparty_client_id: &ClientId,
-        consensus_height: Height,
+        client_cons_state_path: &ClientConsensusStatePath,
         expected_consensus_state: &dyn ConsensusState,
     ) -> Result<(), ClientError>;
 
     /// Verify a `proof` that a connection state matches that of the input `connection_end`.
-    #[allow(clippy::too_many_arguments)]
     fn verify_connection_state(
         &self,
         proof_height: Height,
         counterparty_prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        counterparty_connection_id: &ConnectionId,
+        counterparty_conn_path: &ConnectionsPath,
         expected_counterparty_connection_end: &ConnectionEnd,
     ) -> Result<(), ClientError>;
 
     /// Verify a `proof` that a channel state matches that of the input `channel_end`.
-    #[allow(clippy::too_many_arguments)]
     fn verify_channel_state(
         &self,
         proof_height: Height,
         counterparty_prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        counterparty_port_id: &PortId,
-        counterparty_channel_id: &ChannelId,
+        counterparty_chan_end_path: &ChannelEndsPath,
         expected_counterparty_channel_end: &ChannelEnd,
     ) -> Result<(), ClientError>;
 
     /// Verify the client state for this chain that it is stored on the counterparty chain.
-    #[allow(clippy::too_many_arguments)]
     fn verify_client_full_state(
         &self,
         proof_height: Height,
         counterparty_prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        client_id: &ClientId,
+        client_state_path: &ClientStatePath,
         expected_client_state: Any,
     ) -> Result<(), ClientError>;
 
@@ -198,9 +196,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        commitment_path: &CommitmentsPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError>;
 
@@ -213,9 +209,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        commitment_path: &CommitmentsPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError>;
 
@@ -229,9 +223,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        ack_path: &AcksPath,
         ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError>;
 
@@ -244,9 +236,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        ack_path: &AcksPath,
         ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError>;
 
@@ -260,8 +250,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
+        seq_recv_path: &SeqRecvsPath,
         sequence: Sequence,
     ) -> Result<(), ClientError>;
 
@@ -274,14 +263,11 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
+        seq_recv_path: &SeqRecvsPath,
         sequence: Sequence,
     ) -> Result<(), ClientError>;
 
     /// Verify a `proof` that a packet has not been received.
-
-    #[allow(clippy::too_many_arguments)]
     fn new_verify_packet_receipt_absence(
         &self,
         ctx: &dyn ValidationContext,
@@ -289,13 +275,10 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        receipt_path: &ReceiptsPath,
     ) -> Result<(), ClientError>;
 
     /// Verify a `proof` that a packet has not been received.
-    #[allow(clippy::too_many_arguments)]
     fn verify_packet_receipt_absence(
         &self,
         ctx: &dyn ChannelReader,
@@ -303,9 +286,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: Sequence,
+        receipt_path: &ReceiptsPath,
     ) -> Result<(), ClientError>;
 }
 

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -18,8 +18,8 @@ use crate::core::ics23_commitment::commitment::{
 };
 use crate::core::ics24_host::identifier::{ChainId, ClientId};
 use crate::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, CommitmentsPath,
-    ConnectionsPath, ReceiptsPath, SeqRecvsPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, ClientStatePath, CommitmentPath,
+    ConnectionPath, ReceiptPath, SeqRecvPath,
 };
 use crate::dynamic_typing::AsAny;
 use crate::erased::ErasedSerialize;
@@ -160,7 +160,7 @@ pub trait ClientState:
         counterparty_prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        counterparty_conn_path: &ConnectionsPath,
+        counterparty_conn_path: &ConnectionPath,
         expected_counterparty_connection_end: &ConnectionEnd,
     ) -> Result<(), ClientError>;
 
@@ -171,7 +171,7 @@ pub trait ClientState:
         counterparty_prefix: &CommitmentPrefix,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        counterparty_chan_end_path: &ChannelEndsPath,
+        counterparty_chan_end_path: &ChannelEndPath,
         expected_counterparty_channel_end: &ChannelEnd,
     ) -> Result<(), ClientError>;
 
@@ -196,7 +196,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError>;
 
@@ -209,7 +209,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
         commitment: PacketCommitment,
     ) -> Result<(), ClientError>;
 
@@ -223,7 +223,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
         ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError>;
 
@@ -236,7 +236,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
         ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError>;
 
@@ -250,7 +250,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        seq_recv_path: &SeqRecvsPath,
+        seq_recv_path: &SeqRecvPath,
         sequence: Sequence,
     ) -> Result<(), ClientError>;
 
@@ -263,7 +263,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        seq_recv_path: &SeqRecvsPath,
+        seq_recv_path: &SeqRecvPath,
         sequence: Sequence,
     ) -> Result<(), ClientError>;
 
@@ -275,7 +275,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        receipt_path: &ReceiptsPath,
+        receipt_path: &ReceiptPath,
     ) -> Result<(), ClientError>;
 
     /// Verify a `proof` that a packet has not been received.
@@ -286,7 +286,7 @@ pub trait ClientState:
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
         root: &CommitmentRoot,
-        receipt_path: &ReceiptsPath,
+        receipt_path: &ReceiptPath,
     ) -> Result<(), ClientError>;
 }
 

--- a/crates/ibc/src/core/ics02_client/context.rs
+++ b/crates/ibc/src/core/ics02_client/context.rs
@@ -12,6 +12,7 @@ use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics02_client::handler::ClientResult::{self, Create, Update, Upgrade};
 use crate::core::ics24_host::identifier::ClientId;
+use crate::core::ics24_host::path::ClientConsensusStatePath;
 use crate::timestamp::Timestamp;
 use crate::Height;
 
@@ -32,22 +33,19 @@ pub trait ClientReader {
     /// Returns an error if no such state exists.
     fn consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, ClientError>;
 
     /// Search for the lowest consensus state higher than `height`.
     fn next_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        next_client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Option<Box<dyn ConsensusState>>, ClientError>;
 
     /// Search for the highest consensus state lower than `height`.
     fn prev_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        prev_client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Option<Box<dyn ConsensusState>>, ClientError>;
 
     /// Returns the current height of the local chain.

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -93,10 +93,10 @@ where
     })?;
     let consensus_state = client_state.initialise(consensus_state)?;
 
-    ctx.store_client_type(ClientTypePath(client_id.clone()), client_type.clone())?;
-    ctx.store_client_state(ClientStatePath(client_id.clone()), client_state.clone())?;
+    ctx.store_client_type(ClientTypePath::new(&client_id), client_type.clone())?;
+    ctx.store_client_state(ClientStatePath::new(&client_id), client_state.clone())?;
     ctx.store_consensus_state(
-        ClientConsensusStatePath::new(client_id.clone(), client_state.latest_height()),
+        ClientConsensusStatePath::new(&client_id, &client_state.latest_height()),
         consensus_state,
     )?;
     ctx.increase_client_counter();

--- a/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
@@ -77,7 +77,7 @@ where
         client_state.client_type(),
     )));
 
-    ctx.store_client_state(ClientStatePath(client_id), client_state)
+    ctx.store_client_state(ClientStatePath::new(&client_id), client_state)
 }
 
 pub(crate) fn process(

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -104,7 +104,7 @@ where
     } = old_client_state
         .update_state_with_upgrade_client(msg.client_state.clone(), msg.consensus_state)?;
 
-    ctx.store_client_state(ClientStatePath(client_id.clone()), client_state.clone())?;
+    ctx.store_client_state(ClientStatePath::new(&client_id), client_state.clone())?;
     ctx.store_consensus_state(
         ClientConsensusStatePath::new(&client_id, &client_state.latest_height()),
         consensus_state,

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -51,8 +51,10 @@ where
     }
 
     // Read the latest consensus state from the host chain store.
+    let old_client_cons_state_path =
+        ClientConsensusStatePath::new(&client_id, &old_client_state.latest_height());
     let old_consensus_state = ctx
-        .consensus_state(&client_id, &old_client_state.latest_height())
+        .consensus_state(&old_client_cons_state_path)
         .map_err(|_| ClientError::ConsensusStateNotFound {
             client_id: client_id.clone(),
             height: old_client_state.latest_height(),
@@ -104,7 +106,7 @@ where
 
     ctx.store_client_state(ClientStatePath(client_id.clone()), client_state.clone())?;
     ctx.store_consensus_state(
-        ClientConsensusStatePath::new(client_id.clone(), client_state.latest_height()),
+        ClientConsensusStatePath::new(&client_id, &client_state.latest_height()),
         consensus_state,
     )?;
 
@@ -140,8 +142,10 @@ pub(crate) fn process(
     }
 
     // Read the latest consensus state from the host chain store.
+    let old_client_cons_state_path =
+        ClientConsensusStatePath::new(&client_id, &old_client_state.latest_height());
     let old_consensus_state = ctx
-        .consensus_state(&client_id, &old_client_state.latest_height())
+        .consensus_state(&old_client_cons_state_path)
         .map_err(|_| ClientError::ConsensusStateNotFound {
             client_id: client_id.clone(),
             height: old_client_state.latest_height(),

--- a/crates/ibc/src/core/ics03_connection/context.rs
+++ b/crates/ibc/src/core/ics03_connection/context.rs
@@ -10,6 +10,7 @@ use crate::core::ics03_connection::handler::ConnectionResult;
 use crate::core::ics03_connection::version::{get_compatible_versions, pick_version, Version};
 use crate::core::ics23_commitment::commitment::CommitmentPrefix;
 use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
+use crate::core::ics24_host::path::ClientConsensusStatePath;
 use crate::prelude::*;
 use crate::Height;
 use ibc_proto::google::protobuf::Any;
@@ -43,8 +44,7 @@ pub trait ConnectionReader {
     /// Returns the ConsensusState that the given client stores at a specific height.
     fn client_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, ConnectionError>;
 
     /// Returns the ConsensusState of the host (local) chain at a specific height.

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -14,7 +14,7 @@ use crate::core::context::ContextError;
 
 use crate::core::ics24_host::identifier::ClientId;
 
-use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath, ConnectionsPath};
+use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath, ConnectionPath};
 
 use crate::core::{ExecutionContext, ValidationContext};
 
@@ -96,7 +96,7 @@ where
                     prefix_on_b,
                     &msg.proof_conn_end_on_b,
                     consensus_state_of_b_on_a.root(),
-                    &ConnectionsPath(msg.conn_id_on_b.clone()),
+                    &ConnectionPath(msg.conn_id_on_b.clone()),
                     &expected_conn_end_on_b,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
@@ -180,7 +180,7 @@ where
             new_conn_end_on_a
         };
 
-        ctx_a.store_connection(ConnectionsPath(msg.conn_id_on_a), new_conn_end_on_a)?;
+        ctx_a.store_connection(ConnectionPath(msg.conn_id_on_a), new_conn_end_on_a)?;
     }
 
     Ok(())
@@ -267,7 +267,7 @@ pub(crate) fn process(
                     prefix_on_b,
                     &msg.proof_conn_end_on_b,
                     consensus_state_of_b_on_a.root(),
-                    &ConnectionsPath::new(&msg.conn_id_on_b),
+                    &ConnectionPath::new(&msg.conn_id_on_b),
                     &expected_conn_end_on_b,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -180,7 +180,7 @@ where
             new_conn_end_on_a
         };
 
-        ctx_a.store_connection(ConnectionPath::new(&msg.conn_id_on_a), new_conn_end_on_a)?;
+        ctx_a.store_connection(&ConnectionPath::new(&msg.conn_id_on_a), new_conn_end_on_a)?;
     }
 
     Ok(())

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -96,7 +96,7 @@ where
                     prefix_on_b,
                     &msg.proof_conn_end_on_b,
                     consensus_state_of_b_on_a.root(),
-                    &ConnectionPath(msg.conn_id_on_b.clone()),
+                    &ConnectionPath::new(&msg.conn_id_on_b),
                     &expected_conn_end_on_b,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
@@ -180,7 +180,7 @@ where
             new_conn_end_on_a
         };
 
-        ctx_a.store_connection(ConnectionPath(msg.conn_id_on_a), new_conn_end_on_a)?;
+        ctx_a.store_connection(ConnectionPath::new(&msg.conn_id_on_a), new_conn_end_on_a)?;
     }
 
     Ok(())
@@ -279,7 +279,7 @@ pub(crate) fn process(
                 prefix_on_b,
                 &msg.proof_client_state_of_a_on_b,
                 consensus_state_of_b_on_a.root(),
-                &ClientStatePath(client_id_on_b.clone()),
+                &ClientStatePath::new(client_id_on_b),
                 msg.client_state_of_a_on_b,
             )
             .map_err(|e| ConnectionError::ClientStateVerificationFailure {

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -14,7 +14,7 @@ use crate::core::context::ContextError;
 
 use crate::core::ics24_host::identifier::{ClientId, ConnectionId};
 
-use crate::core::ics24_host::path::{ClientConsensusStatePath, ConnectionsPath};
+use crate::core::ics24_host::path::{ClientConsensusStatePath, ConnectionPath};
 
 use crate::core::{ExecutionContext, ValidationContext};
 
@@ -83,7 +83,7 @@ where
                 prefix_on_a,
                 &msg.proof_conn_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                &ConnectionsPath(conn_id_on_a.clone()),
+                &ConnectionPath(conn_id_on_a.clone()),
                 &expected_conn_end_on_a,
             )
             .map_err(ConnectionError::VerifyConnectionState)?;
@@ -131,7 +131,7 @@ where
             new_conn_end_on_b
         };
 
-        ctx_b.store_connection(ConnectionsPath(msg.conn_id_on_b.clone()), new_conn_end_on_b)?;
+        ctx_b.store_connection(ConnectionPath(msg.conn_id_on_b.clone()), new_conn_end_on_b)?;
     }
 
     Ok(())
@@ -220,7 +220,7 @@ pub(crate) fn process(
                 prefix_on_a,
                 &msg.proof_conn_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                &ConnectionsPath::new(conn_id_on_a),
+                &ConnectionPath::new(conn_id_on_a),
                 &expected_conn_end_on_a,
             )
             .map_err(ConnectionError::VerifyConnectionState)?;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -131,7 +131,7 @@ where
             new_conn_end_on_b
         };
 
-        ctx_b.store_connection(ConnectionPath(msg.conn_id_on_b.clone()), new_conn_end_on_b)?;
+        ctx_b.store_connection(&ConnectionPath(msg.conn_id_on_b.clone()), new_conn_end_on_b)?;
     }
 
     Ok(())

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -83,7 +83,7 @@ where
                 prefix_on_a,
                 &msg.proof_conn_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                &ConnectionPath(conn_id_on_a.clone()),
+                &ConnectionPath::new(conn_id_on_a),
                 &expected_conn_end_on_a,
             )
             .map_err(ConnectionError::VerifyConnectionState)?;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -81,10 +81,10 @@ where
 
     ctx_a.increase_connection_counter();
     ctx_a.store_connection_to_client(
-        ClientConnectionPath::new(&msg.client_id_on_a),
+        &ClientConnectionPath::new(&msg.client_id_on_a),
         conn_id_on_a.clone(),
     )?;
-    ctx_a.store_connection(ConnectionPath::new(&conn_id_on_a), conn_end_on_a)?;
+    ctx_a.store_connection(&ConnectionPath::new(&conn_id_on_a), conn_end_on_a)?;
 
     Ok(())
 }

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -13,7 +13,7 @@ use crate::handler::{HandlerOutput, HandlerResult};
 
 use crate::core::context::ContextError;
 
-use crate::core::ics24_host::path::{ClientConnectionsPath, ConnectionsPath};
+use crate::core::ics24_host::path::{ClientConnectionPath, ConnectionPath};
 
 use crate::core::{ExecutionContext, ValidationContext};
 
@@ -81,10 +81,10 @@ where
 
     ctx_a.increase_connection_counter();
     ctx_a.store_connection_to_client(
-        ClientConnectionsPath::new(&msg.client_id_on_a),
+        ClientConnectionPath::new(&msg.client_id_on_a),
         conn_id_on_a.clone(),
     )?;
-    ctx_a.store_connection(ConnectionsPath::new(&conn_id_on_a), conn_end_on_a)?;
+    ctx_a.store_connection(ConnectionPath::new(&conn_id_on_a), conn_end_on_a)?;
 
     Ok(())
 }

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -81,10 +81,10 @@ where
 
     ctx_a.increase_connection_counter();
     ctx_a.store_connection_to_client(
-        ClientConnectionsPath(msg.client_id_on_a),
+        ClientConnectionsPath::new(&msg.client_id_on_a),
         conn_id_on_a.clone(),
     )?;
-    ctx_a.store_connection(ConnectionsPath(conn_id_on_a), conn_end_on_a)?;
+    ctx_a.store_connection(ConnectionsPath::new(&conn_id_on_a), conn_end_on_a)?;
 
     Ok(())
 }

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -18,7 +18,7 @@ use crate::core::context::ContextError;
 use crate::core::ics24_host::identifier::ClientId;
 
 use crate::core::ics24_host::path::{
-    ClientConnectionsPath, ClientConsensusStatePath, ClientStatePath, ConnectionsPath,
+    ClientConnectionPath, ClientConsensusStatePath, ClientStatePath, ConnectionPath,
 };
 
 use crate::core::{ExecutionContext, ValidationContext};
@@ -89,7 +89,7 @@ where
                     prefix_on_a,
                     &msg.proof_conn_end_on_a,
                     consensus_state_of_a_on_b.root(),
-                    &ConnectionsPath::new(&vars.conn_id_on_a),
+                    &ConnectionPath::new(&vars.conn_id_on_a),
                     &expected_conn_end_on_a,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
@@ -166,10 +166,10 @@ where
 
     ctx_b.increase_connection_counter();
     ctx_b.store_connection_to_client(
-        ClientConnectionsPath::new(&msg.client_id_on_b),
+        ClientConnectionPath::new(&msg.client_id_on_b),
         vars.conn_id_on_b.clone(),
     )?;
-    ctx_b.store_connection(ConnectionsPath::new(&vars.conn_id_on_b), vars.conn_end_on_b)?;
+    ctx_b.store_connection(ConnectionPath::new(&vars.conn_id_on_b), vars.conn_end_on_b)?;
 
     Ok(())
 }
@@ -270,7 +270,7 @@ pub(crate) fn process(
                     prefix_on_a,
                     &msg.proof_conn_end_on_a,
                     consensus_state_of_a_on_b.root(),
-                    &ConnectionsPath::new(conn_id_on_a),
+                    &ConnectionPath::new(conn_id_on_a),
                     &expected_conn_end_on_a,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -17,7 +17,9 @@ use crate::core::context::ContextError;
 
 use crate::core::ics24_host::identifier::ClientId;
 
-use crate::core::ics24_host::path::{ClientConnectionsPath, ConnectionsPath};
+use crate::core::ics24_host::path::{
+    ClientConnectionsPath, ClientConsensusStatePath, ClientStatePath, ConnectionsPath,
+};
 
 use crate::core::{ExecutionContext, ValidationContext};
 
@@ -61,8 +63,10 @@ where
                 .map_err(|_| ConnectionError::Other {
                     description: "failed to fetch client state".to_string(),
                 })?;
+        let client_cons_state_path_on_b =
+            ClientConsensusStatePath::new(&msg.client_id_on_b, &msg.proofs_height_on_a);
         let consensus_state_of_a_on_b = ctx_b
-            .consensus_state(&msg.client_id_on_b, &msg.proofs_height_on_a)
+            .consensus_state(&client_cons_state_path_on_b)
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch client consensus state".to_string(),
             })?;
@@ -85,7 +89,7 @@ where
                     prefix_on_a,
                     &msg.proof_conn_end_on_a,
                     consensus_state_of_a_on_b.root(),
-                    &vars.conn_id_on_a,
+                    &ConnectionsPath::new(&vars.conn_id_on_a),
                     &expected_conn_end_on_a,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
@@ -97,7 +101,7 @@ where
                 prefix_on_a,
                 &msg.proof_client_state_of_b_on_a,
                 consensus_state_of_a_on_b.root(),
-                client_id_on_a,
+                &ClientStatePath::new(client_id_on_a),
                 msg.client_state_of_b_on_a.clone(),
             )
             .map_err(|e| ConnectionError::ClientStateVerificationFailure {
@@ -110,14 +114,16 @@ where
             .map_err(|_| ConnectionError::Other {
                 description: "failed to fetch host consensus state".to_string(),
             })?;
+
+        let client_cons_state_path_on_a =
+            ClientConsensusStatePath::new(&msg.client_id_on_b, &msg.consensus_height_of_b_on_a);
         client_state_of_a_on_b
             .verify_client_consensus_state(
                 msg.proofs_height_on_a,
                 prefix_on_a,
                 &msg.proof_consensus_state_of_b_on_a,
                 consensus_state_of_a_on_b.root(),
-                client_id_on_a,
-                msg.consensus_height_of_b_on_a,
+                &client_cons_state_path_on_a,
                 expected_consensus_state_of_b_on_a.as_ref(),
             )
             .map_err(|e| ConnectionError::ClientStateVerificationFailure {
@@ -160,10 +166,10 @@ where
 
     ctx_b.increase_connection_counter();
     ctx_b.store_connection_to_client(
-        ClientConnectionsPath(msg.client_id_on_b),
+        ClientConnectionsPath::new(&msg.client_id_on_b),
         vars.conn_id_on_b.clone(),
     )?;
-    ctx_b.store_connection(ConnectionsPath(vars.conn_id_on_b), vars.conn_end_on_b)?;
+    ctx_b.store_connection(ConnectionsPath::new(&vars.conn_id_on_b), vars.conn_end_on_b)?;
 
     Ok(())
 }
@@ -240,8 +246,10 @@ pub(crate) fn process(
     // Verify proofs
     {
         let client_state_of_a_on_b = ctx_b.client_state(conn_end_on_b.client_id())?;
+        let client_cons_state_path_on_b =
+            ClientConsensusStatePath::new(&msg.client_id_on_b, &msg.proofs_height_on_a);
         let consensus_state_of_a_on_b =
-            ctx_b.client_consensus_state(&msg.client_id_on_b, &msg.proofs_height_on_a)?;
+            ctx_b.client_consensus_state(&client_cons_state_path_on_b)?;
 
         let prefix_on_a = conn_end_on_b.counterparty().prefix();
         let prefix_on_b = ctx_b.commitment_prefix();
@@ -262,7 +270,7 @@ pub(crate) fn process(
                     prefix_on_a,
                     &msg.proof_conn_end_on_a,
                     consensus_state_of_a_on_b.root(),
-                    conn_id_on_a,
+                    &ConnectionsPath::new(conn_id_on_a),
                     &expected_conn_end_on_a,
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
@@ -274,7 +282,7 @@ pub(crate) fn process(
                 prefix_on_a,
                 &msg.proof_client_state_of_b_on_a,
                 consensus_state_of_a_on_b.root(),
-                client_id_on_a,
+                &ClientStatePath::new(client_id_on_a),
                 msg.client_state_of_b_on_a,
             )
             .map_err(|e| ConnectionError::ClientStateVerificationFailure {
@@ -284,14 +292,16 @@ pub(crate) fn process(
 
         let expected_consensus_state_of_b_on_a =
             ctx_b.host_consensus_state(&msg.consensus_height_of_b_on_a)?;
+
+        let client_cons_state_path_on_a =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.consensus_height_of_b_on_a);
         client_state_of_a_on_b
             .verify_client_consensus_state(
                 msg.proofs_height_on_a,
                 prefix_on_a,
                 &msg.proof_consensus_state_of_b_on_a,
                 consensus_state_of_a_on_b.root(),
-                client_id_on_a,
-                msg.consensus_height_of_b_on_a,
+                &client_cons_state_path_on_a,
                 expected_consensus_state_of_b_on_a.as_ref(),
             )
             .map_err(|e| ConnectionError::ConsensusStateVerificationFailure {

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -166,10 +166,10 @@ where
 
     ctx_b.increase_connection_counter();
     ctx_b.store_connection_to_client(
-        ClientConnectionPath::new(&msg.client_id_on_b),
+        &ClientConnectionPath::new(&msg.client_id_on_b),
         vars.conn_id_on_b.clone(),
     )?;
-    ctx_b.store_connection(ConnectionPath::new(&vars.conn_id_on_b), vars.conn_end_on_b)?;
+    ctx_b.store_connection(&ConnectionPath::new(&vars.conn_id_on_b), vars.conn_end_on_b)?;
 
     Ok(())
 }

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -2,6 +2,10 @@
 //! the interface that any host chain must implement to be able to process any `ChannelMsg`.
 //!
 use crate::core::ics02_client::client_state::ClientState;
+use crate::core::ics24_host::path::{
+    AcksPath, ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath,
+    SeqAcksPath, SeqRecvsPath, SeqSendsPath,
+};
 use core::time::Duration;
 use num_traits::float::FloatCore;
 
@@ -27,11 +31,7 @@ use super::timeout::TimeoutHeight;
 /// A context supplying all the necessary read-only dependencies for processing any `ChannelMsg`.
 pub trait ChannelReader {
     /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
-    fn channel_end(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<ChannelEnd, ChannelError>;
+    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, ChannelError>;
 
     /// Returns the ConnectionState for the given identifier `connection_id`.
     fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, ChannelError>;
@@ -47,47 +47,27 @@ pub trait ChannelReader {
 
     fn client_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, ChannelError>;
 
-    fn get_next_sequence_send(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<Sequence, PacketError>;
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendsPath)
+        -> Result<Sequence, PacketError>;
 
-    fn get_next_sequence_recv(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<Sequence, PacketError>;
+    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvsPath)
+        -> Result<Sequence, PacketError>;
 
-    fn get_next_sequence_ack(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<Sequence, PacketError>;
+    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAcksPath) -> Result<Sequence, PacketError>;
 
     fn get_packet_commitment(
         &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: &Sequence,
+        commitment_path: &CommitmentsPath,
     ) -> Result<PacketCommitment, PacketError>;
 
-    fn get_packet_receipt(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: &Sequence,
-    ) -> Result<Receipt, PacketError>;
+    fn get_packet_receipt(&self, receipts_path: &ReceiptsPath) -> Result<Receipt, PacketError>;
 
     fn get_packet_acknowledgement(
         &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        sequence: &Sequence,
+        ack_path: &AcksPath,
     ) -> Result<AcknowledgementCommitment, PacketError>;
 
     /// Compute the commitment for a packet.
@@ -173,11 +153,7 @@ pub trait ChannelReader {
 
 pub trait SendPacketReader {
     /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
-    fn channel_end(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<ChannelEnd, PacketError>;
+    fn channel_end(&self, channel_end_path: &ChannelEndsPath) -> Result<ChannelEnd, PacketError>;
 
     /// Returns the ConnectionState for the given identifier `connection_id`.
     fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, PacketError>;
@@ -188,15 +164,11 @@ pub trait SendPacketReader {
 
     fn client_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, PacketError>;
 
-    fn get_next_sequence_send(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<Sequence, PacketError>;
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendsPath)
+        -> Result<Sequence, PacketError>;
 
     fn hash(&self, value: &[u8]) -> Vec<u8>;
 
@@ -225,12 +197,8 @@ impl<T> SendPacketReader for T
 where
     T: ChannelReader,
 {
-    fn channel_end(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<ChannelEnd, PacketError> {
-        ChannelReader::channel_end(self, port_id, channel_id).map_err(PacketError::Channel)
+    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, PacketError> {
+        ChannelReader::channel_end(self, chan_end_path).map_err(PacketError::Channel)
     }
 
     fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, PacketError> {
@@ -243,18 +211,17 @@ where
 
     fn client_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, PacketError> {
-        ChannelReader::client_consensus_state(self, client_id, height).map_err(PacketError::Channel)
+        ChannelReader::client_consensus_state(self, client_cons_state_path)
+            .map_err(PacketError::Channel)
     }
 
     fn get_next_sequence_send(
         &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
+        seq_sends_path: &SeqSendsPath,
     ) -> Result<Sequence, PacketError> {
-        ChannelReader::get_next_sequence_send(self, port_id, channel_id)
+        ChannelReader::get_next_sequence_send(self, seq_sends_path)
     }
 
     fn hash(&self, value: &[u8]) -> Vec<u8> {

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -3,8 +3,8 @@
 //!
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics24_host::path::{
-    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath,
-    SeqAckPath, SeqRecvPath, SeqSendPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath, SeqAckPath,
+    SeqRecvPath, SeqSendPath,
 };
 use core::time::Duration;
 use num_traits::float::FloatCore;
@@ -50,11 +50,9 @@ pub trait ChannelReader {
         client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, ChannelError>;
 
-    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath)
-        -> Result<Sequence, PacketError>;
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath) -> Result<Sequence, PacketError>;
 
-    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath)
-        -> Result<Sequence, PacketError>;
+    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath) -> Result<Sequence, PacketError>;
 
     fn get_next_sequence_ack(&self, seq_acks_path: &SeqAckPath) -> Result<Sequence, PacketError>;
 
@@ -167,8 +165,7 @@ pub trait SendPacketReader {
         client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, PacketError>;
 
-    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath)
-        -> Result<Sequence, PacketError>;
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath) -> Result<Sequence, PacketError>;
 
     fn hash(&self, value: &[u8]) -> Vec<u8>;
 

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -3,8 +3,8 @@
 //!
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath,
-    SeqAcksPath, SeqRecvsPath, SeqSendsPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath,
+    SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use core::time::Duration;
 use num_traits::float::FloatCore;
@@ -31,7 +31,7 @@ use super::timeout::TimeoutHeight;
 /// A context supplying all the necessary read-only dependencies for processing any `ChannelMsg`.
 pub trait ChannelReader {
     /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
-    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, ChannelError>;
+    fn channel_end(&self, chan_end_path: &ChannelEndPath) -> Result<ChannelEnd, ChannelError>;
 
     /// Returns the ConnectionState for the given identifier `connection_id`.
     fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, ChannelError>;
@@ -50,24 +50,24 @@ pub trait ChannelReader {
         client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, ChannelError>;
 
-    fn get_next_sequence_send(&self, seq_send_path: &SeqSendsPath)
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath)
         -> Result<Sequence, PacketError>;
 
-    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvsPath)
+    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath)
         -> Result<Sequence, PacketError>;
 
-    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAcksPath) -> Result<Sequence, PacketError>;
+    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAckPath) -> Result<Sequence, PacketError>;
 
     fn get_packet_commitment(
         &self,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
     ) -> Result<PacketCommitment, PacketError>;
 
-    fn get_packet_receipt(&self, receipts_path: &ReceiptsPath) -> Result<Receipt, PacketError>;
+    fn get_packet_receipt(&self, receipts_path: &ReceiptPath) -> Result<Receipt, PacketError>;
 
     fn get_packet_acknowledgement(
         &self,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
     ) -> Result<AcknowledgementCommitment, PacketError>;
 
     /// Compute the commitment for a packet.
@@ -153,7 +153,7 @@ pub trait ChannelReader {
 
 pub trait SendPacketReader {
     /// Returns the ChannelEnd for the given `port_id` and `chan_id`.
-    fn channel_end(&self, channel_end_path: &ChannelEndsPath) -> Result<ChannelEnd, PacketError>;
+    fn channel_end(&self, channel_end_path: &ChannelEndPath) -> Result<ChannelEnd, PacketError>;
 
     /// Returns the ConnectionState for the given identifier `connection_id`.
     fn connection_end(&self, connection_id: &ConnectionId) -> Result<ConnectionEnd, PacketError>;
@@ -167,7 +167,7 @@ pub trait SendPacketReader {
         client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, PacketError>;
 
-    fn get_next_sequence_send(&self, seq_send_path: &SeqSendsPath)
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath)
         -> Result<Sequence, PacketError>;
 
     fn hash(&self, value: &[u8]) -> Vec<u8>;
@@ -197,7 +197,7 @@ impl<T> SendPacketReader for T
 where
     T: ChannelReader,
 {
-    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, PacketError> {
+    fn channel_end(&self, chan_end_path: &ChannelEndPath) -> Result<ChannelEnd, PacketError> {
         ChannelReader::channel_end(self, chan_end_path).map_err(PacketError::Channel)
     }
 
@@ -219,7 +219,7 @@ where
 
     fn get_next_sequence_send(
         &self,
-        seq_sends_path: &SeqSendsPath,
+        seq_sends_path: &SeqSendPath,
     ) -> Result<Sequence, PacketError> {
         ChannelReader::get_next_sequence_send(self, seq_sends_path)
     }

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -214,11 +214,8 @@ where
             .map_err(PacketError::Channel)
     }
 
-    fn get_next_sequence_send(
-        &self,
-        seq_sends_path: &SeqSendPath,
-    ) -> Result<Sequence, PacketError> {
-        ChannelReader::get_next_sequence_send(self, seq_sends_path)
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath) -> Result<Sequence, PacketError> {
+        ChannelReader::get_next_sequence_send(self, seq_send_path)
     }
 
     fn hash(&self, value: &[u8]) -> Vec<u8> {

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -54,14 +54,14 @@ pub trait ChannelReader {
 
     fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath) -> Result<Sequence, PacketError>;
 
-    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAckPath) -> Result<Sequence, PacketError>;
+    fn get_next_sequence_ack(&self, seq_ack_path: &SeqAckPath) -> Result<Sequence, PacketError>;
 
     fn get_packet_commitment(
         &self,
         commitment_path: &CommitmentPath,
     ) -> Result<PacketCommitment, PacketError>;
 
-    fn get_packet_receipt(&self, receipts_path: &ReceiptPath) -> Result<Receipt, PacketError>;
+    fn get_packet_receipt(&self, receipt_path: &ReceiptPath) -> Result<Receipt, PacketError>;
 
     fn get_packet_acknowledgement(
         &self,

--- a/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
@@ -51,11 +51,11 @@ where
         .into());
     }
 
-    let commitments_path =
+    let commitment_path_on_a =
         CommitmentPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
 
     // Verify packet commitment
-    let commitment_on_a = match ctx_a.get_packet_commitment(&commitments_path) {
+    let commitment_on_a = match ctx_a.get_packet_commitment(&commitment_path_on_a) {
         Ok(commitment_on_a) => commitment_on_a,
 
         // This error indicates that the timeout has already been relayed
@@ -79,8 +79,8 @@ where
     }
 
     if let Order::Ordered = chan_end_on_a.ordering {
-        let seq_ack_path = SeqAckPath::new(&packet.port_on_a, &packet.chan_on_a);
-        let next_seq_ack = ctx_a.get_next_sequence_ack(&seq_ack_path)?;
+        let seq_ack_path_on_a = SeqAckPath::new(&packet.port_on_a, &packet.chan_on_a);
+        let next_seq_ack = ctx_a.get_next_sequence_ack(&seq_ack_path_on_a)?;
         if packet.sequence != next_seq_ack {
             return Err(PacketError::InvalidPacketSequence {
                 given_sequence: packet.sequence,
@@ -106,7 +106,7 @@ where
             ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
         let consensus_state = ctx_a.consensus_state(&client_cons_state_path_on_a)?;
         let ack_commitment = ctx_a.ack_commitment(&msg.acknowledgement);
-        let ack_path_on_b = AckPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
+        let ack_path_on_b = AckPath::new(&packet.port_on_b, &packet.chan_on_b, packet.sequence);
         // Verify the proof for the packet against the chain store.
         client_state_on_a
             .new_verify_packet_acknowledgement(
@@ -173,10 +173,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
         });
     }
 
-    let commitments_path =
+    let commitment_path_on_a =
         CommitmentPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
     // Verify packet commitment
-    let packet_commitment = ctx_a.get_packet_commitment(&commitments_path)?;
+    let packet_commitment = ctx_a.get_packet_commitment(&commitment_path_on_a)?;
 
     if packet_commitment
         != ctx_a.packet_commitment(

--- a/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
@@ -7,6 +7,9 @@ use crate::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
 use crate::core::ics04_channel::packet::{PacketResult, Sequence};
 use crate::core::ics04_channel::{context::ChannelReader, error::PacketError};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
+use crate::core::ics24_host::path::{
+    AcksPath, ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, SeqAcksPath,
+};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
@@ -18,9 +21,8 @@ where
     Ctx: ValidationContext,
 {
     let packet = &msg.packet;
-
-    let port_chan_id_on_a = &(msg.packet.port_on_a.clone(), msg.packet.chan_on_a.clone());
-    let chan_end_on_a = ctx_a.channel_end(port_chan_id_on_a)?;
+    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     if !chan_end_on_a.state_matches(&State::Open) {
         return Err(PacketError::ChannelClosed {
@@ -49,12 +51,11 @@ where
         .into());
     }
 
+    let commitments_path =
+        CommitmentsPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
+
     // Verify packet commitment
-    let commitment_on_a = match ctx_a.get_packet_commitment(&(
-        msg.packet.port_on_a.clone(),
-        msg.packet.chan_on_a.clone(),
-        msg.packet.sequence,
-    )) {
+    let commitment_on_a = match ctx_a.get_packet_commitment(&commitments_path) {
         Ok(commitment_on_a) => commitment_on_a,
 
         // This error indicates that the timeout has already been relayed
@@ -78,8 +79,8 @@ where
     }
 
     if let Order::Ordered = chan_end_on_a.ordering {
-        let next_seq_ack = ctx_a.get_next_sequence_ack(port_chan_id_on_a)?;
-
+        let seq_ack_path = SeqAcksPath::new(&packet.port_on_a, &packet.chan_on_a);
+        let next_seq_ack = ctx_a.get_next_sequence_ack(&seq_ack_path)?;
         if packet.sequence != next_seq_ack {
             return Err(PacketError::InvalidPacketSequence {
                 given_sequence: packet.sequence,
@@ -101,11 +102,11 @@ where
             }
             .into());
         }
-
-        let consensus_state = ctx_a.consensus_state(client_id_on_a, &msg.proof_height_on_b)?;
-
+        let client_cons_state_path_on_a =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
+        let consensus_state = ctx_a.consensus_state(&client_cons_state_path_on_a)?;
         let ack_commitment = ctx_a.ack_commitment(&msg.acknowledgement);
-
+        let ack_path_on_b = AcksPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
         // Verify the proof for the packet against the chain store.
         client_state_on_a
             .new_verify_packet_acknowledgement(
@@ -114,9 +115,7 @@ where
                 &conn_end_on_a,
                 &msg.proof_acked_on_b,
                 consensus_state.root(),
-                &packet.port_on_b,
-                &packet.chan_on_b,
-                packet.sequence,
+                &ack_path_on_b,
                 ack_commitment,
             )
             .map_err(|e| ChannelError::PacketVerificationFailed {
@@ -143,9 +142,9 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     let packet = &msg.packet;
-
+    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
     let chan_end_on_a = ctx_a
-        .channel_end(&packet.port_on_a, &packet.chan_on_a)
+        .channel_end(&chan_end_path_on_a)
         .map_err(PacketError::Channel)?;
 
     if !chan_end_on_a.state_matches(&State::Open) {
@@ -174,9 +173,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
         });
     }
 
+    let commitments_path =
+        CommitmentsPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
     // Verify packet commitment
-    let packet_commitment =
-        ctx_a.get_packet_commitment(&packet.port_on_a, &packet.chan_on_a, &packet.sequence)?;
+    let packet_commitment = ctx_a.get_packet_commitment(&commitments_path)?;
 
     if packet_commitment
         != ctx_a.packet_commitment(
@@ -204,12 +204,13 @@ pub(crate) fn process<Ctx: ChannelReader>(
             });
         }
 
+        let client_cons_state_path_on_a =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
         let consensus_state = ctx_a
-            .client_consensus_state(client_id_on_a, &msg.proof_height_on_b)
+            .client_consensus_state(&client_cons_state_path_on_a)
             .map_err(PacketError::Channel)?;
-
         let ack_commitment = ctx_a.ack_commitment(&msg.acknowledgement);
-
+        let ack_path_on_b = AcksPath::new(&packet.port_on_b, &packet.chan_on_b, packet.sequence);
         // Verify the proof for the packet against the chain store.
         client_state_on_a
             .verify_packet_acknowledgement(
@@ -218,9 +219,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 &conn_end_on_a,
                 &msg.proof_acked_on_b,
                 consensus_state.root(),
-                &packet.port_on_b,
-                &packet.chan_on_b,
-                packet.sequence,
+                &ack_path_on_b,
                 ack_commitment,
             )
             .map_err(|e| ChannelError::PacketVerificationFailed {
@@ -231,7 +230,8 @@ pub(crate) fn process<Ctx: ChannelReader>(
     }
 
     let result = if chan_end_on_a.order_matches(&Order::Ordered) {
-        let next_seq_ack = ctx_a.get_next_sequence_ack(&packet.port_on_a, &packet.chan_on_a)?;
+        let ack_path_on_a = SeqAcksPath::new(&packet.port_on_a, &packet.chan_on_a);
+        let next_seq_ack = ctx_a.get_next_sequence_ack(&ack_path_on_a)?;
 
         if packet.sequence != next_seq_ack {
             return Err(PacketError::InvalidPacketSequence {

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -5,7 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
-use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath};
+use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath};
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
@@ -16,7 +16,7 @@ where
     Ctx: ValidationContext,
 {
     // Retrieve the old channel end and validate it against the message.
-    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
     let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be closed.
@@ -79,7 +79,7 @@ where
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version().clone(),
         );
-        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
+        let chan_end_path_on_a = ChannelEndPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -106,7 +106,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     // Retrieve the old channel end and validate it against the message.
-    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
     let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be closed.
@@ -166,7 +166,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version().clone(),
         );
-        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
+        let chan_end_path_on_a = ChannelEndPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -5,6 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
+use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath};
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
@@ -15,7 +16,8 @@ where
     Ctx: ValidationContext,
 {
     // Retrieve the old channel end and validate it against the message.
-    let chan_end_on_b = ctx_b.channel_end(&(msg.port_id_on_b.clone(), msg.chan_id_on_b.clone()))?;
+    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be closed.
     if chan_end_on_b.state_matches(&State::Closed) {
@@ -47,8 +49,9 @@ where
     {
         let client_id_on_b = conn_end_on_b.client_id();
         let client_state_of_a_on_b = ctx_b.client_state(client_id_on_b)?;
-        let consensus_state_of_a_on_b =
-            ctx_b.consensus_state(client_id_on_b, &msg.proof_height_on_a)?;
+        let client_cons_state_path_on_b =
+            ClientConsensusStatePath::new(client_id_on_b, &msg.proof_height_on_a);
+        let consensus_state_of_a_on_b = ctx_b.consensus_state(&client_cons_state_path_on_b)?;
         let prefix_on_a = conn_end_on_b.counterparty().prefix();
         let port_id_on_a = &chan_end_on_b.counterparty().port_id;
         let chan_id_on_a = chan_end_on_b
@@ -76,6 +79,7 @@ where
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version().clone(),
         );
+        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -85,8 +89,7 @@ where
                 prefix_on_a,
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                port_id_on_a,
-                chan_id_on_a,
+                &chan_end_path_on_a,
                 &expected_chan_end_on_a,
             )
             .map_err(ChannelError::VerifyChannelFailed)?;
@@ -103,7 +106,8 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     // Retrieve the old channel end and validate it against the message.
-    let chan_end_on_b = ctx_b.channel_end(&msg.port_id_on_b, &msg.chan_id_on_b)?;
+    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be closed.
     if chan_end_on_b.state_matches(&State::Closed) {
@@ -132,8 +136,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
     {
         let client_id_on_b = conn_end_on_b.client_id();
         let client_state_of_a_on_b = ctx_b.client_state(client_id_on_b)?;
+        let client_cons_state_path_on_b =
+            ClientConsensusStatePath::new(client_id_on_b, &msg.proof_height_on_a);
         let consensus_state_of_a_on_b =
-            ctx_b.client_consensus_state(client_id_on_b, &msg.proof_height_on_a)?;
+            ctx_b.client_consensus_state(&client_cons_state_path_on_b)?;
         let prefix_on_a = conn_end_on_b.counterparty().prefix();
         let port_id_on_a = &chan_end_on_b.counterparty().port_id;
         let chan_id_on_a = chan_end_on_b
@@ -160,6 +166,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version().clone(),
         );
+        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -169,8 +176,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 prefix_on_a,
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                port_id_on_a,
-                chan_id_on_a,
+                &chan_end_path_on_a,
                 &expected_chan_end_on_a,
             )
             .map_err(ChannelError::VerifyChannelFailed)?;

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
@@ -5,6 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
+use crate::core::ics24_host::path::ChannelEndsPath;
 use crate::handler::{HandlerOutput, HandlerResult};
 
 use crate::core::{ContextError, ValidationContext};
@@ -13,7 +14,8 @@ pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgChannelCloseInit) -> Result<(), Conte
 where
     Ctx: ValidationContext,
 {
-    let chan_end_on_a = ctx_a.channel_end(&(msg.port_id_on_a.clone(), msg.chan_id_on_a.clone()))?;
+    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be closed.
     if chan_end_on_a.state_matches(&State::Closed) {
@@ -52,7 +54,8 @@ pub(crate) fn process<Ctx: ChannelReader>(
 ) -> HandlerResult<ChannelResult, ChannelError> {
     let mut output = HandlerOutput::builder();
 
-    let chan_end_on_a = ctx_a.channel_end(&msg.port_id_on_a, &msg.chan_id_on_a)?;
+    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be closed.
     if chan_end_on_a.state_matches(&State::Closed) {

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
@@ -5,7 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
-use crate::core::ics24_host::path::ChannelEndsPath;
+use crate::core::ics24_host::path::ChannelEndPath;
 use crate::handler::{HandlerOutput, HandlerResult};
 
 use crate::core::{ContextError, ValidationContext};
@@ -14,7 +14,7 @@ pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgChannelCloseInit) -> Result<(), Conte
 where
     Ctx: ValidationContext,
 {
-    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be closed.
@@ -54,7 +54,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
 ) -> HandlerResult<ChannelResult, ChannelError> {
     let mut output = HandlerOutput::builder();
 
-    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be closed.

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -105,8 +105,8 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let chan_ends_path_on_a = &ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
-    let chan_end_on_a = ctx_a.channel_end(chan_ends_path_on_a)?;
+    let chan_end_path_on_a = &ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_end_on_a = ctx_a.channel_end(chan_end_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be ack.
     if !chan_end_on_a.state_matches(&State::Init) {

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -5,7 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_open_ack::MsgChannelOpenAck;
-use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath};
+use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath};
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
@@ -15,7 +15,7 @@ pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgChannelOpenAck) -> Result<(), Context
 where
     Ctx: ValidationContext,
 {
-    let chan_end_path_on_a = ChannelEndsPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be ack.
@@ -78,7 +78,7 @@ where
             vec![conn_id_on_b.clone()],
             msg.version_on_b.clone(),
         );
-        let chan_end_path_on_b = ChannelEndsPath::new(port_id_on_b, &msg.chan_id_on_b);
+        let chan_end_path_on_b = ChannelEndPath::new(port_id_on_b, &msg.chan_id_on_b);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -105,7 +105,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let chan_ends_path_on_a = &ChannelEndsPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
+    let chan_ends_path_on_a = &ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let chan_end_on_a = ctx_a.channel_end(chan_ends_path_on_a)?;
 
     // Validate that the channel end is in a state where it can be ack.
@@ -165,7 +165,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             vec![conn_id_on_b.clone()],
             msg.version_on_b.clone(),
         );
-        let chan_end_path_on_b = ChannelEndsPath::new(port_id_on_b, &msg.chan_id_on_b);
+        let chan_end_path_on_b = ChannelEndPath::new(port_id_on_b, &msg.chan_id_on_b);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -5,7 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
-use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath};
+use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath};
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
@@ -16,7 +16,7 @@ where
     Ctx: ValidationContext,
 {
     // Unwrap the old channel end and validate it against the message.
-    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
     let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be confirmed.
@@ -80,7 +80,7 @@ where
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version.clone(),
         );
-        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
+        let chan_end_path_on_a = ChannelEndPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked in msg.
@@ -107,7 +107,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
     let mut chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be confirmed.
@@ -168,7 +168,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version.clone(),
         );
-        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
+        let chan_end_path_on_a = ChannelEndPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked in msg.

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -5,6 +5,7 @@ use crate::core::ics04_channel::context::ChannelReader;
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
+use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath};
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
@@ -15,7 +16,8 @@ where
     Ctx: ValidationContext,
 {
     // Unwrap the old channel end and validate it against the message.
-    let chan_end_on_b = ctx_b.channel_end(&(msg.port_id_on_b.clone(), msg.chan_id_on_b.clone()))?;
+    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be confirmed.
     if !chan_end_on_b.state_matches(&State::TryOpen) {
@@ -48,8 +50,9 @@ where
     {
         let client_id_on_b = conn_end_on_b.client_id();
         let client_state_of_a_on_b = ctx_b.client_state(client_id_on_b)?;
-        let consensus_state_of_a_on_b =
-            ctx_b.consensus_state(client_id_on_b, &msg.proof_height_on_a)?;
+        let client_cons_state_path_on_b =
+            ClientConsensusStatePath::new(client_id_on_b, &msg.proof_height_on_a);
+        let consensus_state_of_a_on_b = ctx_b.consensus_state(&client_cons_state_path_on_b)?;
         let prefix_on_a = conn_end_on_b.counterparty().prefix();
         let port_id_on_a = &chan_end_on_b.counterparty().port_id;
         let chan_id_on_a = chan_end_on_b
@@ -77,6 +80,7 @@ where
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version.clone(),
         );
+        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked in msg.
@@ -86,8 +90,7 @@ where
                 prefix_on_a,
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                port_id_on_a,
-                chan_id_on_a,
+                &chan_end_path_on_a,
                 &expected_chan_end_on_a,
             )
             .map_err(ChannelError::VerifyChannelFailed)?;
@@ -104,7 +107,8 @@ pub(crate) fn process<Ctx: ChannelReader>(
     let mut output = HandlerOutput::builder();
 
     // Unwrap the old channel end and validate it against the message.
-    let mut chan_end_on_b = ctx_b.channel_end(&msg.port_id_on_b, &msg.chan_id_on_b)?;
+    let chan_end_path_on_b = ChannelEndsPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
+    let mut chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
 
     // Validate that the channel end is in a state where it can be confirmed.
     if !chan_end_on_b.state_matches(&State::TryOpen) {
@@ -134,8 +138,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
     {
         let client_id_on_b = conn_end_on_b.client_id();
         let client_state_of_a_on_b = ctx_b.client_state(client_id_on_b)?;
+        let client_cons_state_path_on_b =
+            ClientConsensusStatePath::new(client_id_on_b, &msg.proof_height_on_a);
         let consensus_state_of_a_on_b =
-            ctx_b.client_consensus_state(client_id_on_b, &msg.proof_height_on_a)?;
+            ctx_b.client_consensus_state(&client_cons_state_path_on_b)?;
         let prefix_on_a = conn_end_on_b.counterparty().prefix();
         let port_id_on_a = &chan_end_on_b.counterparty().port_id;
         let chan_id_on_a = chan_end_on_b
@@ -162,6 +168,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             vec![conn_id_on_a.clone()],
             chan_end_on_b.version.clone(),
         );
+        let chan_end_path_on_a = ChannelEndsPath::new(port_id_on_a, chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked in msg.
@@ -171,8 +178,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 prefix_on_a,
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
-                port_id_on_a,
-                chan_id_on_a,
+                &chan_end_path_on_a,
                 &expected_chan_end_on_a,
             )
             .map_err(ChannelError::VerifyChannelFailed)?;

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -8,7 +8,7 @@ use crate::core::ics04_channel::handler::{ChannelIdState, ChannelResult};
 use crate::core::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::ChannelId;
-use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath};
+use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath};
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 
@@ -80,7 +80,7 @@ where
             vec![conn_id_on_a.clone()],
             msg.version_supported_on_a.clone(),
         );
-        let chan_end_path_on_a = ChannelEndsPath::new(&port_id_on_a, &chan_id_on_a);
+        let chan_end_path_on_a = ChannelEndPath::new(&port_id_on_a, &chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -162,7 +162,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             vec![conn_id_on_a.clone()],
             msg.version_supported_on_a.clone(),
         );
-        let chan_end_path_on_a = ChannelEndsPath::new(&port_id_on_a, &chan_id_on_a);
+        let chan_end_path_on_a = ChannelEndPath::new(&port_id_on_a, &chan_id_on_a);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.

--- a/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
@@ -8,8 +8,7 @@ use crate::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
 use crate::core::ics04_channel::packet::{PacketResult, Receipt, Sequence};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
 use crate::core::ics24_host::path::{
-    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath,
-    SeqRecvPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath, SeqRecvPath,
 };
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -5,9 +5,9 @@ use crate::core::ics04_channel::events::SendPacket;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics04_channel::{context::SendPacketReader, error::PacketError, packet::Packet};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
-use crate::core::ics24_host::path::ChannelEndsPath;
+use crate::core::ics24_host::path::ChannelEndPath;
 use crate::core::ics24_host::path::ClientConsensusStatePath;
-use crate::core::ics24_host::path::SeqSendsPath;
+use crate::core::ics24_host::path::SeqSendPath;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
@@ -29,7 +29,7 @@ pub fn send_packet(
 ) -> HandlerResult<SendPacketResult, PacketError> {
     let mut output = HandlerOutput::builder();
 
-    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     if chan_end_on_a.state_matches(&State::Closed) {
@@ -78,7 +78,7 @@ pub fn send_packet(
         return Err(PacketError::LowPacketTimestamp);
     }
 
-    let seq_send_path_on_a = SeqSendsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let seq_send_path_on_a = SeqSendPath::new(&packet.port_on_a, &packet.chan_on_a);
     let next_seq_send_on_a = ctx_a.get_next_sequence_send(&seq_send_path_on_a)?;
 
     if packet.sequence != next_seq_send_on_a {

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -5,6 +5,9 @@ use crate::core::ics04_channel::events::SendPacket;
 use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics04_channel::{context::SendPacketReader, error::PacketError, packet::Packet};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
+use crate::core::ics24_host::path::ChannelEndsPath;
+use crate::core::ics24_host::path::ClientConsensusStatePath;
+use crate::core::ics24_host::path::SeqSendsPath;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
@@ -26,7 +29,8 @@ pub fn send_packet(
 ) -> HandlerResult<SendPacketResult, PacketError> {
     let mut output = HandlerOutput::builder();
 
-    let chan_end_on_a = ctx_a.channel_end(&packet.port_on_a, &packet.chan_on_a)?;
+    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     if chan_end_on_a.state_matches(&State::Closed) {
         return Err(PacketError::ChannelClosed {
@@ -65,15 +69,17 @@ pub fn send_packet(
         });
     }
 
-    let consensus_state_of_b_on_a =
-        ctx_a.client_consensus_state(client_id_on_a, &latest_height_on_a)?;
+    let client_cons_state_path_on_a =
+        ClientConsensusStatePath::new(client_id_on_a, &latest_height_on_a);
+    let consensus_state_of_b_on_a = ctx_a.client_consensus_state(&client_cons_state_path_on_a)?;
     let latest_timestamp = consensus_state_of_b_on_a.timestamp();
     let packet_timestamp = packet.timeout_timestamp_on_b;
     if let Expiry::Expired = latest_timestamp.check_expiry(&packet_timestamp) {
         return Err(PacketError::LowPacketTimestamp);
     }
 
-    let next_seq_send_on_a = ctx_a.get_next_sequence_send(&packet.port_on_a, &packet.chan_on_a)?;
+    let seq_send_path_on_a = SeqSendsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let next_seq_send_on_a = ctx_a.get_next_sequence_send(&seq_send_path_on_a)?;
 
     if packet.sequence != next_seq_send_on_a {
         return Err(PacketError::InvalidPacketSequence {

--- a/crates/ibc/src/core/ics04_channel/handler/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout.rs
@@ -7,7 +7,7 @@ use crate::core::ics04_channel::packet::{PacketResult, Sequence};
 use crate::core::ics04_channel::{context::ChannelReader, error::PacketError};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
 use crate::core::ics24_host::path::{
-    ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath, SeqRecvsPath,
+    ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath, SeqRecvPath,
 };
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
@@ -20,7 +20,7 @@ pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgTimeout) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
 {
-    let chan_end_on_a = ctx_a.channel_end(&ChannelEndsPath::new(
+    let chan_end_on_a = ctx_a.channel_end(&ChannelEndPath::new(
         &msg.packet.port_on_a,
         &msg.packet.chan_on_a,
     ))?;
@@ -49,7 +49,7 @@ where
     let conn_end_on_a = ctx_a.connection_end(&conn_id_on_a)?;
 
     //verify packet commitment
-    let commitment_path_on_a = CommitmentsPath::new(
+    let commitment_path_on_a = CommitmentPath::new(
         &msg.packet.port_on_a,
         &msg.packet.chan_on_a,
         msg.packet.sequence,
@@ -118,7 +118,7 @@ where
                 .into());
             }
             let seq_recv_path_on_b =
-                SeqRecvsPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
+                SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
             client_state_of_b_on_a.new_verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
@@ -129,7 +129,7 @@ where
                 msg.packet.sequence,
             )
         } else {
-            let receipt_path_on_b = ReceiptsPath::new(
+            let receipt_path_on_b = ReceiptPath::new(
                 &msg.packet.port_on_b,
                 &msg.packet.chan_on_b,
                 msg.packet.sequence,
@@ -173,7 +173,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
     msg: &MsgTimeout,
 ) -> HandlerResult<PacketResult, PacketError> {
     let mut output = HandlerOutput::builder();
-    let chan_end_path_on_a = ChannelEndsPath::new(&msg.packet.port_on_a, &msg.packet.chan_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&msg.packet.port_on_a, &msg.packet.chan_on_a);
     let mut chan_end_on_a = ctx_a
         .channel_end(&chan_end_path_on_a)
         .map_err(PacketError::Channel)?;
@@ -202,7 +202,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
         .map_err(PacketError::Channel)?;
 
     //verify packet commitment
-    let commitment_path_on_a = CommitmentsPath::new(
+    let commitment_path_on_a = CommitmentPath::new(
         &msg.packet.port_on_a,
         &msg.packet.chan_on_a,
         msg.packet.sequence,
@@ -263,7 +263,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 });
             }
             let seq_recv_path_on_b =
-                SeqRecvsPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
+                SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
             client_state_of_b_on_a.verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
@@ -274,7 +274,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 msg.packet.sequence,
             )
         } else {
-            let receipt_path_on_b = ReceiptsPath::new(
+            let receipt_path_on_b = ReceiptPath::new(
                 &msg.packet.port_on_b,
                 &msg.packet.chan_on_b,
                 msg.packet.sequence,
@@ -344,7 +344,7 @@ mod tests {
     use crate::core::ics04_channel::msgs::timeout::MsgTimeout;
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-    use crate::core::ics24_host::path::ChannelEndsPath;
+    use crate::core::ics24_host::path::ChannelEndPath;
     use crate::events::IbcEvent;
     use crate::mock::context::MockContext;
     use crate::prelude::*;
@@ -502,7 +502,7 @@ mod tests {
                     let events = proto_output.events;
                     let src_channel_end = test
                         .ctx
-                        .channel_end(&ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a))
+                        .channel_end(&ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a))
                         .unwrap();
 
                     if src_channel_end.order_matches(&Order::Ordered) {

--- a/crates/ibc/src/core/ics04_channel/handler/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout.rs
@@ -117,8 +117,7 @@ where
                 }
                 .into());
             }
-            let seq_recv_path_on_b =
-                SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
+            let seq_recv_path_on_b = SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
             client_state_of_b_on_a.new_verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
@@ -262,8 +261,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                     next_sequence: msg.next_seq_recv_on_b,
                 });
             }
-            let seq_recv_path_on_b =
-                SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
+            let seq_recv_path_on_b = SeqRecvPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
             client_state_of_b_on_a.verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,

--- a/crates/ibc/src/core/ics04_channel/handler/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout.rs
@@ -6,6 +6,9 @@ use crate::core::ics04_channel::msgs::timeout::MsgTimeout;
 use crate::core::ics04_channel::packet::{PacketResult, Sequence};
 use crate::core::ics04_channel::{context::ChannelReader, error::PacketError};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
+use crate::core::ics24_host::path::{
+    ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath, SeqRecvsPath,
+};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
@@ -17,8 +20,10 @@ pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgTimeout) -> Result<(), ContextError>
 where
     Ctx: ValidationContext,
 {
-    let port_chan_id_on_a = &(msg.packet.port_on_a.clone(), msg.packet.chan_on_a.clone());
-    let chan_end_on_a = ctx_a.channel_end(port_chan_id_on_a)?;
+    let chan_end_on_a = ctx_a.channel_end(&ChannelEndsPath::new(
+        &msg.packet.port_on_a,
+        &msg.packet.chan_on_a,
+    ))?;
 
     if !chan_end_on_a.state_matches(&State::Open) {
         return Err(PacketError::ChannelClosed {
@@ -44,11 +49,12 @@ where
     let conn_end_on_a = ctx_a.connection_end(&conn_id_on_a)?;
 
     //verify packet commitment
-    let commitment_on_a = match ctx_a.get_packet_commitment(&(
-        msg.packet.port_on_a.clone(),
-        msg.packet.chan_on_a.clone(),
+    let commitment_path_on_a = CommitmentsPath::new(
+        &msg.packet.port_on_a,
+        &msg.packet.chan_on_a,
         msg.packet.sequence,
-    )) {
+    );
+    let commitment_on_a = match ctx_a.get_packet_commitment(&commitment_path_on_a) {
         Ok(commitment_on_a) => commitment_on_a,
 
         // This error indicates that the timeout has already been relayed
@@ -87,9 +93,9 @@ where
             }
             .into());
         }
-
-        let consensus_state_of_b_on_a =
-            ctx_a.consensus_state(client_id_on_a, &msg.proof_height_on_b)?;
+        let client_cons_state_path_on_a =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
+        let consensus_state_of_b_on_a = ctx_a.consensus_state(&client_cons_state_path_on_a)?;
         let timestamp_of_b = consensus_state_of_b_on_a.timestamp();
 
         if let Expiry::Expired = msg
@@ -111,26 +117,30 @@ where
                 }
                 .into());
             }
+            let seq_recv_path_on_b =
+                SeqRecvsPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
             client_state_of_b_on_a.new_verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &msg.packet.port_on_b,
-                &msg.packet.chan_on_b,
+                &seq_recv_path_on_b,
                 msg.packet.sequence,
             )
         } else {
+            let receipt_path_on_b = ReceiptsPath::new(
+                &msg.packet.port_on_b,
+                &msg.packet.chan_on_b,
+                msg.packet.sequence,
+            );
             client_state_of_b_on_a.new_verify_packet_receipt_absence(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &msg.packet.port_on_b,
-                &msg.packet.chan_on_b,
-                msg.packet.sequence,
+                &receipt_path_on_b,
             )
         };
         next_seq_recv_verification_result
@@ -163,9 +173,9 @@ pub(crate) fn process<Ctx: ChannelReader>(
     msg: &MsgTimeout,
 ) -> HandlerResult<PacketResult, PacketError> {
     let mut output = HandlerOutput::builder();
-
+    let chan_end_path_on_a = ChannelEndsPath::new(&msg.packet.port_on_a, &msg.packet.chan_on_a);
     let mut chan_end_on_a = ctx_a
-        .channel_end(&msg.packet.port_on_a, &msg.packet.chan_on_a)
+        .channel_end(&chan_end_path_on_a)
         .map_err(PacketError::Channel)?;
 
     if !chan_end_on_a.state_matches(&State::Open) {
@@ -192,12 +202,12 @@ pub(crate) fn process<Ctx: ChannelReader>(
         .map_err(PacketError::Channel)?;
 
     //verify packet commitment
-    let commitment_on_a = ctx_a.get_packet_commitment(
+    let commitment_path_on_a = CommitmentsPath::new(
         &msg.packet.port_on_a,
         &msg.packet.chan_on_a,
-        &msg.packet.sequence,
-    )?;
-
+        msg.packet.sequence,
+    );
+    let commitment_on_a = ctx_a.get_packet_commitment(&commitment_path_on_a)?;
     let expected_commitment_on_a = ctx_a.packet_commitment(
         &msg.packet.data,
         &msg.packet.timeout_height_on_b,
@@ -228,8 +238,10 @@ pub(crate) fn process<Ctx: ChannelReader>(
             });
         }
 
+        let client_cons_state_path =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
         let consensus_state_of_b_on_a = ctx_a
-            .client_consensus_state(client_id_on_a, &msg.proof_height_on_b)
+            .client_consensus_state(&client_cons_state_path)
             .map_err(PacketError::Channel)?;
         let timestamp_of_b = consensus_state_of_b_on_a.timestamp();
 
@@ -250,26 +262,30 @@ pub(crate) fn process<Ctx: ChannelReader>(
                     next_sequence: msg.next_seq_recv_on_b,
                 });
             }
+            let seq_recv_path_on_b =
+                SeqRecvsPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
             client_state_of_b_on_a.verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &msg.packet.port_on_b,
-                &msg.packet.chan_on_b,
+                &seq_recv_path_on_b,
                 msg.packet.sequence,
             )
         } else {
+            let receipt_path_on_b = ReceiptsPath::new(
+                &msg.packet.port_on_b,
+                &msg.packet.chan_on_b,
+                msg.packet.sequence,
+            );
             client_state_of_b_on_a.verify_packet_receipt_absence(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &msg.packet.port_on_b,
-                &msg.packet.chan_on_b,
-                msg.packet.sequence,
+                &receipt_path_on_b,
             )
         };
         next_seq_recv_verification_result
@@ -328,6 +344,7 @@ mod tests {
     use crate::core::ics04_channel::msgs::timeout::MsgTimeout;
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+    use crate::core::ics24_host::path::ChannelEndsPath;
     use crate::events::IbcEvent;
     use crate::mock::context::MockContext;
     use crate::prelude::*;
@@ -485,7 +502,7 @@ mod tests {
                     let events = proto_output.events;
                     let src_channel_end = test
                         .ctx
-                        .channel_end(&packet.port_on_a, &packet.chan_on_a)
+                        .channel_end(&ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a))
                         .unwrap();
 
                     if src_channel_end.order_matches(&Order::Ordered) {

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -106,7 +106,7 @@ where
             chan_end_on_a.version().clone(),
         );
 
-        let chan_ends_path_on_b = ChannelEndPath(port_id_on_b, chan_id_on_b.clone());
+        let chan_end_path_on_b = ChannelEndPath(port_id_on_b, chan_id_on_b.clone());
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -116,7 +116,7 @@ where
                 prefix_on_b,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &chan_ends_path_on_b,
+                &chan_end_path_on_b,
                 &expected_chan_end_on_b,
             )
             .map_err(ChannelError::VerifyChannelFailed)
@@ -189,11 +189,11 @@ pub(crate) fn process<Ctx: ChannelReader>(
         });
     }
 
-    let commitment_path =
+    let commitment_path_on_a =
         CommitmentPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
 
     //verify the packet was sent, check the store
-    let commitment_on_a = ctx_a.get_packet_commitment(&commitment_path)?;
+    let commitment_on_a = ctx_a.get_packet_commitment(&commitment_path_on_a)?;
 
     let expected_commitment_on_a = ctx_a.packet_commitment(
         &packet.data,

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -7,6 +7,9 @@ use crate::core::ics04_channel::packet::PacketResult;
 use crate::core::ics04_channel::{
     context::ChannelReader, error::PacketError, handler::timeout::TimeoutPacketResult,
 };
+use crate::core::ics24_host::path::{
+    ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath, SeqRecvsPath,
+};
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
@@ -18,9 +21,8 @@ where
     Ctx: ValidationContext,
 {
     let packet = &msg.packet;
-
-    let port_chan_id_on_a = &(msg.packet.port_on_a.clone(), msg.packet.chan_on_a.clone());
-    let chan_end_on_a = ctx_a.channel_end(port_chan_id_on_a)?;
+    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     let counterparty = Counterparty::new(packet.port_on_b.clone(), Some(packet.chan_on_b.clone()));
 
@@ -32,12 +34,14 @@ where
         .into());
     }
 
-    //verify the packet was sent, check the store
-    let commitment_on_a = match ctx_a.get_packet_commitment(&(
-        msg.packet.port_on_a.clone(),
-        msg.packet.chan_on_a.clone(),
+    let commitment_path_on_a = CommitmentsPath::new(
+        &msg.packet.port_on_a,
+        &msg.packet.chan_on_a,
         msg.packet.sequence,
-    )) {
+    );
+
+    //verify the packet was sent, check the store
+    let commitment_on_a = match ctx_a.get_packet_commitment(&commitment_path_on_a) {
         Ok(commitment_on_a) => commitment_on_a,
 
         // This error indicates that the timeout has already been relayed
@@ -74,11 +78,11 @@ where
             }
             .into());
         }
-
-        let consensus_state_of_b_on_a =
-            ctx_a.consensus_state(client_id_on_a, &msg.proof_height_on_b)?;
+        let client_cons_state_path_on_a =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
+        let consensus_state_of_b_on_a = ctx_a.consensus_state(&client_cons_state_path_on_a)?;
         let prefix_on_b = conn_end_on_a.counterparty().prefix();
-        let port_id_on_b = &chan_end_on_a.counterparty().port_id;
+        let port_id_on_b = chan_end_on_a.counterparty().port_id.clone();
         let chan_id_on_b =
             chan_end_on_a
                 .counterparty()
@@ -102,6 +106,8 @@ where
             chan_end_on_a.version().clone(),
         );
 
+        let chan_ends_path_on_b = ChannelEndsPath(port_id_on_b, chan_id_on_b.clone());
+
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
         client_state_of_b_on_a
@@ -110,8 +116,7 @@ where
                 prefix_on_b,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                port_id_on_b,
-                chan_id_on_b,
+                &chan_ends_path_on_b,
                 &expected_chan_end_on_b,
             )
             .map_err(ChannelError::VerifyChannelFailed)
@@ -125,26 +130,29 @@ where
                 }
                 .into());
             }
+            let seq_recv_path_on_b = SeqRecvsPath::new(&packet.port_on_b, &packet.chan_on_b);
             client_state_of_b_on_a.new_verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &packet.port_on_b,
-                &packet.chan_on_b,
+                &seq_recv_path_on_b,
                 packet.sequence,
             )
         } else {
+            let receipt_path_on_b = ReceiptsPath::new(
+                &msg.packet.port_on_b,
+                &msg.packet.chan_on_b,
+                msg.packet.sequence,
+            );
             client_state_of_b_on_a.new_verify_packet_receipt_absence(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &packet.port_on_b,
-                &packet.chan_on_b,
-                packet.sequence,
+                &receipt_path_on_b,
             )
         };
         next_seq_recv_verification_result
@@ -167,8 +175,9 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
     let packet = &msg.packet;
 
+    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
     let chan_end_on_a = ctx_a
-        .channel_end(&packet.port_on_a, &packet.chan_on_a)
+        .channel_end(&chan_end_path_on_a)
         .map_err(PacketError::Channel)?;
 
     let counterparty = Counterparty::new(packet.port_on_b.clone(), Some(packet.chan_on_b.clone()));
@@ -180,9 +189,11 @@ pub(crate) fn process<Ctx: ChannelReader>(
         });
     }
 
+    let commitment_path =
+        CommitmentsPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
+
     //verify the packet was sent, check the store
-    let commitment_on_a =
-        ctx_a.get_packet_commitment(&packet.port_on_a, &packet.chan_on_a, &packet.sequence)?;
+    let commitment_on_a = ctx_a.get_packet_commitment(&commitment_path)?;
 
     let expected_commitment_on_a = ctx_a.packet_commitment(
         &packet.data,
@@ -213,12 +224,13 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 client_id: client_id_on_a.clone(),
             });
         }
-
+        let client_cons_state_on_a =
+            ClientConsensusStatePath::new(client_id_on_a, &msg.proof_height_on_b);
         let consensus_state_of_b_on_a = ctx_a
-            .client_consensus_state(client_id_on_a, &msg.proof_height_on_b)
+            .client_consensus_state(&client_cons_state_on_a)
             .map_err(PacketError::Channel)?;
         let prefix_on_b = conn_end_on_a.counterparty().prefix();
-        let port_id_on_b = &chan_end_on_a.counterparty().port_id;
+        let port_id_on_b = chan_end_on_a.counterparty().port_id.clone();
         let chan_id_on_b =
             chan_end_on_a
                 .counterparty()
@@ -242,6 +254,8 @@ pub(crate) fn process<Ctx: ChannelReader>(
             chan_end_on_a.version().clone(),
         );
 
+        let chan_end_path_on_b = ChannelEndsPath::new(&port_id_on_b, chan_id_on_b);
+
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
         client_state_of_b_on_a
@@ -250,8 +264,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 prefix_on_b,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                port_id_on_b,
-                chan_id_on_b,
+                &chan_end_path_on_b,
                 &expected_chan_end_on_b,
             )
             .map_err(ChannelError::VerifyChannelFailed)
@@ -264,26 +277,29 @@ pub(crate) fn process<Ctx: ChannelReader>(
                     next_sequence: msg.next_seq_recv_on_b,
                 });
             }
+            let seq_recv_path_on_b = SeqRecvsPath::new(&packet.port_on_b, &packet.chan_on_b);
             client_state_of_b_on_a.verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &packet.port_on_b,
-                &packet.chan_on_b,
+                &seq_recv_path_on_b,
                 packet.sequence,
             )
         } else {
+            let receipt_path_on_b = ReceiptsPath::new(
+                &msg.packet.port_on_b,
+                &msg.packet.chan_on_b,
+                msg.packet.sequence,
+            );
             client_state_of_b_on_a.verify_packet_receipt_absence(
                 ctx_a,
                 msg.proof_height_on_b,
                 &conn_end_on_a,
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
-                &packet.port_on_b,
-                &packet.chan_on_b,
-                packet.sequence,
+                &receipt_path_on_b,
             )
         };
         next_seq_recv_verification_result
@@ -327,6 +343,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
 #[cfg(test)]
 mod tests {
+    use crate::core::ics24_host::path::ChannelEndsPath;
     use crate::prelude::*;
     use test_log::test;
 
@@ -450,7 +467,10 @@ mod tests {
                     let events = proto_output.events;
                     let src_channel_end = test
                         .ctx
-                        .channel_end(&msg.packet.port_on_a, &msg.packet.chan_on_a)
+                        .channel_end(&ChannelEndsPath::new(
+                            &msg.packet.port_on_a,
+                            &msg.packet.chan_on_a,
+                        ))
                         .unwrap();
 
                     if src_channel_end.order_matches(&Order::Ordered) {

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -8,7 +8,7 @@ use crate::core::ics04_channel::{
     context::ChannelReader, error::PacketError, handler::timeout::TimeoutPacketResult,
 };
 use crate::core::ics24_host::path::{
-    ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath, SeqRecvsPath,
+    ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath, SeqRecvPath,
 };
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
@@ -21,7 +21,7 @@ where
     Ctx: ValidationContext,
 {
     let packet = &msg.packet;
-    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     let counterparty = Counterparty::new(packet.port_on_b.clone(), Some(packet.chan_on_b.clone()));
@@ -34,7 +34,7 @@ where
         .into());
     }
 
-    let commitment_path_on_a = CommitmentsPath::new(
+    let commitment_path_on_a = CommitmentPath::new(
         &msg.packet.port_on_a,
         &msg.packet.chan_on_a,
         msg.packet.sequence,
@@ -106,7 +106,7 @@ where
             chan_end_on_a.version().clone(),
         );
 
-        let chan_ends_path_on_b = ChannelEndsPath(port_id_on_b, chan_id_on_b.clone());
+        let chan_ends_path_on_b = ChannelEndPath(port_id_on_b, chan_id_on_b.clone());
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -130,7 +130,7 @@ where
                 }
                 .into());
             }
-            let seq_recv_path_on_b = SeqRecvsPath::new(&packet.port_on_b, &packet.chan_on_b);
+            let seq_recv_path_on_b = SeqRecvPath::new(&packet.port_on_b, &packet.chan_on_b);
             client_state_of_b_on_a.new_verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
@@ -141,7 +141,7 @@ where
                 packet.sequence,
             )
         } else {
-            let receipt_path_on_b = ReceiptsPath::new(
+            let receipt_path_on_b = ReceiptPath::new(
                 &msg.packet.port_on_b,
                 &msg.packet.chan_on_b,
                 msg.packet.sequence,
@@ -175,7 +175,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
     let packet = &msg.packet;
 
-    let chan_end_path_on_a = ChannelEndsPath::new(&packet.port_on_a, &packet.chan_on_a);
+    let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
     let chan_end_on_a = ctx_a
         .channel_end(&chan_end_path_on_a)
         .map_err(PacketError::Channel)?;
@@ -190,7 +190,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
     }
 
     let commitment_path =
-        CommitmentsPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
+        CommitmentPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence);
 
     //verify the packet was sent, check the store
     let commitment_on_a = ctx_a.get_packet_commitment(&commitment_path)?;
@@ -254,7 +254,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
             chan_end_on_a.version().clone(),
         );
 
-        let chan_end_path_on_b = ChannelEndsPath::new(&port_id_on_b, chan_id_on_b);
+        let chan_end_path_on_b = ChannelEndPath::new(&port_id_on_b, chan_id_on_b);
 
         // Verify the proof for the channel state against the expected channel end.
         // A counterparty channel id of None in not possible, and is checked by validate_basic in msg.
@@ -277,7 +277,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                     next_sequence: msg.next_seq_recv_on_b,
                 });
             }
-            let seq_recv_path_on_b = SeqRecvsPath::new(&packet.port_on_b, &packet.chan_on_b);
+            let seq_recv_path_on_b = SeqRecvPath::new(&packet.port_on_b, &packet.chan_on_b);
             client_state_of_b_on_a.verify_next_sequence_recv(
                 ctx_a,
                 msg.proof_height_on_b,
@@ -288,7 +288,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
                 packet.sequence,
             )
         } else {
-            let receipt_path_on_b = ReceiptsPath::new(
+            let receipt_path_on_b = ReceiptPath::new(
                 &msg.packet.port_on_b,
                 &msg.packet.chan_on_b,
                 msg.packet.sequence,
@@ -343,7 +343,7 @@ pub(crate) fn process<Ctx: ChannelReader>(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::ics24_host::path::ChannelEndsPath;
+    use crate::core::ics24_host::path::ChannelEndPath;
     use crate::prelude::*;
     use test_log::test;
 
@@ -467,7 +467,7 @@ mod tests {
                     let events = proto_output.events;
                     let src_channel_end = test
                         .ctx
-                        .channel_end(&ChannelEndsPath::new(
+                        .channel_end(&ChannelEndPath::new(
                             &msg.packet.port_on_a,
                             &msg.packet.chan_on_a,
                         ))

--- a/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/write_acknowledgement.rs
@@ -5,7 +5,7 @@ use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, PacketResult, Sequence};
 use crate::core::ics04_channel::{context::ChannelReader, error::PacketError};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
-use crate::core::ics24_host::path::{AcksPath, ChannelEndsPath};
+use crate::core::ics24_host::path::{AckPath, ChannelEndPath};
 use crate::prelude::*;
 use crate::{
     events::IbcEvent,
@@ -27,7 +27,7 @@ pub fn process<Ctx: ChannelReader>(
     ack: Acknowledgement,
 ) -> HandlerResult<PacketResult, PacketError> {
     let mut output = HandlerOutput::builder();
-    let chan_end_path_on_b = ChannelEndsPath::new(&packet.port_on_b, &packet.chan_on_b);
+    let chan_end_path_on_b = ChannelEndPath::new(&packet.port_on_b, &packet.chan_on_b);
     let chan_end_on_b = ctx_b
         .channel_end(&chan_end_path_on_b)
         .map_err(PacketError::Channel)?;
@@ -42,7 +42,7 @@ pub fn process<Ctx: ChannelReader>(
     // NOTE: IBC app modules might have written the acknowledgement synchronously on
     // the OnRecvPacket callback so we need to check if the acknowledgement is already
     // set on the store and return an error if so.
-    let ack_path_on_b = AcksPath::new(&packet.port_on_b, &packet.chan_on_b, packet.sequence);
+    let ack_path_on_b = AckPath::new(&packet.port_on_b, &packet.chan_on_b, packet.sequence);
     match ctx_b.get_packet_acknowledgement(&ack_path_on_b) {
         Ok(_) => {
             return Err(PacketError::AcknowledgementExists {

--- a/crates/ibc/src/core/ics24_host/path.rs
+++ b/crates/ibc/src/core/ics24_host/path.rs
@@ -49,9 +49,21 @@ pub enum Path {
 #[display(fmt = "clients/{_0}/clientType")]
 pub struct ClientTypePath(pub ClientId);
 
+impl ClientTypePath {
+    pub fn new(client_id: &ClientId) -> ClientTypePath {
+        ClientTypePath(client_id.clone())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "clients/{_0}/clientState")]
 pub struct ClientStatePath(pub ClientId);
+
+impl ClientStatePath {
+    pub fn new(client_id: &ClientId) -> ClientStatePath {
+        ClientStatePath(client_id.clone())
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "clients/{client_id}/consensusStates/{epoch}-{height}")]
@@ -62,9 +74,9 @@ pub struct ClientConsensusStatePath {
 }
 
 impl ClientConsensusStatePath {
-    pub fn new(client_id: ClientId, height: Height) -> ClientConsensusStatePath {
+    pub fn new(client_id: &ClientId, height: &Height) -> ClientConsensusStatePath {
         ClientConsensusStatePath {
-            client_id,
+            client_id: client_id.clone(),
             epoch: height.revision_number(),
             height: height.revision_height(),
         }
@@ -75,29 +87,71 @@ impl ClientConsensusStatePath {
 #[display(fmt = "clients/{_0}/connections")]
 pub struct ClientConnectionsPath(pub ClientId);
 
+impl ClientConnectionsPath {
+    pub fn new(client_id: &ClientId) -> ClientConnectionsPath {
+        ClientConnectionsPath(client_id.clone())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "connections/{_0}")]
 pub struct ConnectionsPath(pub ConnectionId);
+
+impl ConnectionsPath {
+    pub fn new(connection_id: &ConnectionId) -> ConnectionsPath {
+        ConnectionsPath(connection_id.clone())
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "ports/{_0}")]
 pub struct PortsPath(pub PortId);
 
+impl PortsPath {
+    pub fn new(port_id: &PortId) -> PortsPath {
+        PortsPath(port_id.clone())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "channelEnds/ports/{_0}/channels/{_1}")]
 pub struct ChannelEndsPath(pub PortId, pub ChannelId);
+
+impl ChannelEndsPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> ChannelEndsPath {
+        ChannelEndsPath(port_id.clone(), channel_id.clone())
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "nextSequenceSend/ports/{_0}/channels/{_1}")]
 pub struct SeqSendsPath(pub PortId, pub ChannelId);
 
+impl SeqSendsPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqSendsPath {
+        SeqSendsPath(port_id.clone(), channel_id.clone())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "nextSequenceRecv/ports/{_0}/channels/{_1}")]
 pub struct SeqRecvsPath(pub PortId, pub ChannelId);
 
+impl SeqRecvsPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqRecvsPath {
+        SeqRecvsPath(port_id.clone(), channel_id.clone())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "nextSequenceAck/ports/{_0}/channels/{_1}")]
 pub struct SeqAcksPath(pub PortId, pub ChannelId);
+
+impl SeqAcksPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqAcksPath {
+        SeqAcksPath(port_id.clone(), channel_id.clone())
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "commitments/ports/{port_id}/channels/{channel_id}/sequences/{sequence}")]
@@ -105,6 +159,16 @@ pub struct CommitmentsPath {
     pub port_id: PortId,
     pub channel_id: ChannelId,
     pub sequence: Sequence,
+}
+
+impl CommitmentsPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> CommitmentsPath {
+        CommitmentsPath {
+            port_id: port_id.clone(),
+            channel_id: channel_id.clone(),
+            sequence,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
@@ -115,12 +179,32 @@ pub struct AcksPath {
     pub sequence: Sequence,
 }
 
+impl AcksPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> AcksPath {
+        AcksPath {
+            port_id: port_id.clone(),
+            channel_id: channel_id.clone(),
+            sequence,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "receipts/ports/{port_id}/channels/{channel_id}/sequences/{sequence}")]
 pub struct ReceiptsPath {
     pub port_id: PortId,
     pub channel_id: ChannelId,
     pub sequence: Sequence,
+}
+
+impl ReceiptsPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> ReceiptsPath {
+        ReceiptsPath {
+            port_id: port_id.clone(),
+            channel_id: channel_id.clone(),
+            sequence,
+        }
+    }
 }
 
 /// Paths that are specific for client upgrades.

--- a/crates/ibc/src/core/ics24_host/path.rs
+++ b/crates/ibc/src/core/ics24_host/path.rs
@@ -107,12 +107,6 @@ impl ConnectionPath {
 #[display(fmt = "ports/{_0}")]
 pub struct PortPath(pub PortId);
 
-impl PortPath {
-    pub fn new(port_id: &PortId) -> PortPath {
-        PortPath(port_id.clone())
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "channelEnds/ports/{_0}/channels/{_1}")]
 pub struct ChannelEndPath(pub PortId, pub ChannelId);

--- a/crates/ibc/src/core/ics24_host/path.rs
+++ b/crates/ibc/src/core/ics24_host/path.rs
@@ -32,16 +32,16 @@ pub enum Path {
     ClientType(ClientTypePath),
     ClientState(ClientStatePath),
     ClientConsensusState(ClientConsensusStatePath),
-    ClientConnections(ClientConnectionsPath),
-    Connections(ConnectionsPath),
-    Ports(PortsPath),
-    ChannelEnds(ChannelEndsPath),
-    SeqSends(SeqSendsPath),
-    SeqRecvs(SeqRecvsPath),
-    SeqAcks(SeqAcksPath),
-    Commitments(CommitmentsPath),
-    Acks(AcksPath),
-    Receipts(ReceiptsPath),
+    ClientConnection(ClientConnectionPath),
+    Connection(ConnectionPath),
+    Ports(PortPath),
+    ChannelEnd(ChannelEndPath),
+    SeqSend(SeqSendPath),
+    SeqRecv(SeqRecvPath),
+    SeqAck(SeqAckPath),
+    Commitment(CommitmentPath),
+    Ack(AckPath),
+    Receipt(ReceiptPath),
     Upgrade(ClientUpgradePath),
 }
 
@@ -85,85 +85,85 @@ impl ClientConsensusStatePath {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "clients/{_0}/connections")]
-pub struct ClientConnectionsPath(pub ClientId);
+pub struct ClientConnectionPath(pub ClientId);
 
-impl ClientConnectionsPath {
-    pub fn new(client_id: &ClientId) -> ClientConnectionsPath {
-        ClientConnectionsPath(client_id.clone())
+impl ClientConnectionPath {
+    pub fn new(client_id: &ClientId) -> ClientConnectionPath {
+        ClientConnectionPath(client_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "connections/{_0}")]
-pub struct ConnectionsPath(pub ConnectionId);
+pub struct ConnectionPath(pub ConnectionId);
 
-impl ConnectionsPath {
-    pub fn new(connection_id: &ConnectionId) -> ConnectionsPath {
-        ConnectionsPath(connection_id.clone())
+impl ConnectionPath {
+    pub fn new(connection_id: &ConnectionId) -> ConnectionPath {
+        ConnectionPath(connection_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "ports/{_0}")]
-pub struct PortsPath(pub PortId);
+pub struct PortPath(pub PortId);
 
-impl PortsPath {
-    pub fn new(port_id: &PortId) -> PortsPath {
-        PortsPath(port_id.clone())
+impl PortPath {
+    pub fn new(port_id: &PortId) -> PortPath {
+        PortPath(port_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "channelEnds/ports/{_0}/channels/{_1}")]
-pub struct ChannelEndsPath(pub PortId, pub ChannelId);
+pub struct ChannelEndPath(pub PortId, pub ChannelId);
 
-impl ChannelEndsPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> ChannelEndsPath {
-        ChannelEndsPath(port_id.clone(), channel_id.clone())
+impl ChannelEndPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> ChannelEndPath {
+        ChannelEndPath(port_id.clone(), channel_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "nextSequenceSend/ports/{_0}/channels/{_1}")]
-pub struct SeqSendsPath(pub PortId, pub ChannelId);
+pub struct SeqSendPath(pub PortId, pub ChannelId);
 
-impl SeqSendsPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqSendsPath {
-        SeqSendsPath(port_id.clone(), channel_id.clone())
+impl SeqSendPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqSendPath {
+        SeqSendPath(port_id.clone(), channel_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "nextSequenceRecv/ports/{_0}/channels/{_1}")]
-pub struct SeqRecvsPath(pub PortId, pub ChannelId);
+pub struct SeqRecvPath(pub PortId, pub ChannelId);
 
-impl SeqRecvsPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqRecvsPath {
-        SeqRecvsPath(port_id.clone(), channel_id.clone())
+impl SeqRecvPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqRecvPath {
+        SeqRecvPath(port_id.clone(), channel_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "nextSequenceAck/ports/{_0}/channels/{_1}")]
-pub struct SeqAcksPath(pub PortId, pub ChannelId);
+pub struct SeqAckPath(pub PortId, pub ChannelId);
 
-impl SeqAcksPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqAcksPath {
-        SeqAcksPath(port_id.clone(), channel_id.clone())
+impl SeqAckPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId) -> SeqAckPath {
+        SeqAckPath(port_id.clone(), channel_id.clone())
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "commitments/ports/{port_id}/channels/{channel_id}/sequences/{sequence}")]
-pub struct CommitmentsPath {
+pub struct CommitmentPath {
     pub port_id: PortId,
     pub channel_id: ChannelId,
     pub sequence: Sequence,
 }
 
-impl CommitmentsPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> CommitmentsPath {
-        CommitmentsPath {
+impl CommitmentPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> CommitmentPath {
+        CommitmentPath {
             port_id: port_id.clone(),
             channel_id: channel_id.clone(),
             sequence,
@@ -173,15 +173,15 @@ impl CommitmentsPath {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "acks/ports/{port_id}/channels/{channel_id}/sequences/{sequence}")]
-pub struct AcksPath {
+pub struct AckPath {
     pub port_id: PortId,
     pub channel_id: ChannelId,
     pub sequence: Sequence,
 }
 
-impl AcksPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> AcksPath {
-        AcksPath {
+impl AckPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> AckPath {
+        AckPath {
             port_id: port_id.clone(),
             channel_id: channel_id.clone(),
             sequence,
@@ -191,15 +191,15 @@ impl AcksPath {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 #[display(fmt = "receipts/ports/{port_id}/channels/{channel_id}/sequences/{sequence}")]
-pub struct ReceiptsPath {
+pub struct ReceiptPath {
     pub port_id: PortId,
     pub channel_id: ChannelId,
     pub sequence: Sequence,
 }
 
-impl ReceiptsPath {
-    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> ReceiptsPath {
-        ReceiptsPath {
+impl ReceiptPath {
+    pub fn new(port_id: &PortId, channel_id: &ChannelId, sequence: Sequence) -> ReceiptPath {
+        ReceiptPath {
             port_id: port_id.clone(),
             channel_id: channel_id.clone(),
             sequence,
@@ -227,7 +227,7 @@ enum SubPath {
 impl Path {
     /// Indication if the path is provable.
     pub fn is_provable(&self) -> bool {
-        !matches!(&self, Path::ClientConnections(_) | Path::Ports(_))
+        !matches!(&self, Path::ClientConnection(_) | Path::Ports(_))
     }
 
     /// into_bytes implementation
@@ -286,7 +286,7 @@ fn parse_client_paths(components: &[&str]) -> Option<Path> {
         match components[2] {
             "clientType" => Some(ClientTypePath(client_id).into()),
             "clientState" => Some(ClientStatePath(client_id).into()),
-            "connections" => Some(ClientConnectionsPath(client_id).into()),
+            "connections" => Some(ClientConnectionPath(client_id).into()),
             _ => None,
         }
     } else if components.len() == 4 {
@@ -355,7 +355,7 @@ fn parse_connections(components: &[&str]) -> Option<Path> {
         Err(_) => return None,
     };
 
-    Some(ConnectionsPath(connection_id).into())
+    Some(ConnectionPath(connection_id).into())
 }
 
 fn parse_ports(components: &[&str]) -> Option<Path> {
@@ -382,7 +382,7 @@ fn parse_ports(components: &[&str]) -> Option<Path> {
         Err(_) => return None,
     };
 
-    Some(PortsPath(port_id).into())
+    Some(PortPath(port_id).into())
 }
 
 fn parse_channels(components: &[&str]) -> Option<SubPath> {
@@ -454,7 +454,7 @@ fn parse_channel_ends(components: &[&str]) -> Option<Path> {
     let port = parse_ports(&components[1..=2]);
     let channel = parse_channels(&components[3..=4]);
 
-    let port_id = if let Some(Path::Ports(PortsPath(port_id))) = port {
+    let port_id = if let Some(Path::Ports(PortPath(port_id))) = port {
         port_id
     } else {
         return None;
@@ -466,7 +466,7 @@ fn parse_channel_ends(components: &[&str]) -> Option<Path> {
         return None;
     };
 
-    Some(ChannelEndsPath(port_id, channel_id).into())
+    Some(ChannelEndPath(port_id, channel_id).into())
 }
 
 fn parse_seqs(components: &[&str]) -> Option<Path> {
@@ -482,7 +482,7 @@ fn parse_seqs(components: &[&str]) -> Option<Path> {
     let port = parse_ports(&components[1..=2]);
     let channel = parse_channels(&components[3..=4]);
 
-    let port_id = if let Some(Path::Ports(PortsPath(port_id))) = port {
+    let port_id = if let Some(Path::Ports(PortPath(port_id))) = port {
         port_id
     } else {
         return None;
@@ -495,9 +495,9 @@ fn parse_seqs(components: &[&str]) -> Option<Path> {
     };
 
     match first {
-        "nextSequenceSend" => Some(SeqSendsPath(port_id, channel_id).into()),
-        "nextSequenceRecv" => Some(SeqRecvsPath(port_id, channel_id).into()),
-        "nextSequenceAck" => Some(SeqAcksPath(port_id, channel_id).into()),
+        "nextSequenceSend" => Some(SeqSendPath(port_id, channel_id).into()),
+        "nextSequenceRecv" => Some(SeqRecvPath(port_id, channel_id).into()),
+        "nextSequenceAck" => Some(SeqAckPath(port_id, channel_id).into()),
         _ => None,
     }
 }
@@ -520,7 +520,7 @@ fn parse_commitments(components: &[&str]) -> Option<Path> {
     let channel = parse_channels(&components[3..=4]);
     let sequence = parse_sequences(&components[5..]);
 
-    let port_id = if let Some(Path::Ports(PortsPath(port_id))) = port {
+    let port_id = if let Some(Path::Ports(PortPath(port_id))) = port {
         port_id
     } else {
         return None;
@@ -539,7 +539,7 @@ fn parse_commitments(components: &[&str]) -> Option<Path> {
     };
 
     Some(
-        CommitmentsPath {
+        CommitmentPath {
             port_id,
             channel_id,
             sequence,
@@ -566,7 +566,7 @@ fn parse_acks(components: &[&str]) -> Option<Path> {
     let channel = parse_channels(&components[3..=4]);
     let sequence = parse_sequences(&components[5..]);
 
-    let port_id = if let Some(Path::Ports(PortsPath(port_id))) = port {
+    let port_id = if let Some(Path::Ports(PortPath(port_id))) = port {
         port_id
     } else {
         return None;
@@ -585,7 +585,7 @@ fn parse_acks(components: &[&str]) -> Option<Path> {
     };
 
     Some(
-        AcksPath {
+        AckPath {
             port_id,
             channel_id,
             sequence,
@@ -612,7 +612,7 @@ fn parse_receipts(components: &[&str]) -> Option<Path> {
     let channel = parse_channels(&components[3..=4]);
     let sequence = parse_sequences(&components[5..]);
 
-    let port_id = if let Some(Path::Ports(PortsPath(port_id))) = port {
+    let port_id = if let Some(Path::Ports(PortPath(port_id))) = port {
         port_id
     } else {
         return None;
@@ -631,7 +631,7 @@ fn parse_receipts(components: &[&str]) -> Option<Path> {
     };
 
     Some(
-        ReceiptsPath {
+        ReceiptPath {
             port_id,
             channel_id,
             sequence,
@@ -764,7 +764,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::ClientConnections(ClientConnectionsPath(ClientId::default()))
+            Path::ClientConnection(ClientConnectionPath(ClientId::default()))
         );
     }
 
@@ -775,7 +775,7 @@ mod tests {
 
         assert_eq!(
             parse_connections(&components),
-            Some(Path::Connections(ConnectionsPath(ConnectionId::new(0)))),
+            Some(Path::Connection(ConnectionPath(ConnectionId::new(0)))),
         );
     }
 
@@ -787,7 +787,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::Connections(ConnectionsPath(ConnectionId::new(0)))
+            Path::Connection(ConnectionPath(ConnectionId::new(0)))
         );
     }
 
@@ -798,7 +798,7 @@ mod tests {
 
         assert_eq!(
             parse_ports(&components),
-            Some(Path::Ports(PortsPath(PortId::default()))),
+            Some(Path::Ports(PortPath(PortId::default()))),
         );
     }
 
@@ -808,7 +808,7 @@ mod tests {
         let path = Path::from_str(path);
 
         assert!(path.is_ok());
-        assert_eq!(path.unwrap(), Path::Ports(PortsPath(PortId::default())));
+        assert_eq!(path.unwrap(), Path::Ports(PortPath(PortId::default())));
     }
 
     #[test]
@@ -856,7 +856,7 @@ mod tests {
 
         assert_eq!(
             parse_channel_ends(&components),
-            Some(Path::ChannelEnds(ChannelEndsPath(
+            Some(Path::ChannelEnd(ChannelEndPath(
                 PortId::default(),
                 ChannelId::default()
             ))),
@@ -871,7 +871,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::ChannelEnds(ChannelEndsPath(PortId::default(), ChannelId::default())),
+            Path::ChannelEnd(ChannelEndPath(PortId::default(), ChannelId::default())),
         );
     }
 
@@ -882,7 +882,7 @@ mod tests {
 
         assert_eq!(
             parse_seqs(&components),
-            Some(Path::SeqSends(SeqSendsPath(
+            Some(Path::SeqSend(SeqSendPath(
                 PortId::default(),
                 ChannelId::default()
             ))),
@@ -893,7 +893,7 @@ mod tests {
 
         assert_eq!(
             parse_seqs(&components),
-            Some(Path::SeqRecvs(SeqRecvsPath(
+            Some(Path::SeqRecv(SeqRecvPath(
                 PortId::default(),
                 ChannelId::default()
             ))),
@@ -904,7 +904,7 @@ mod tests {
 
         assert_eq!(
             parse_seqs(&components),
-            Some(Path::SeqAcks(SeqAcksPath(
+            Some(Path::SeqAck(SeqAckPath(
                 PortId::default(),
                 ChannelId::default()
             ))),
@@ -919,7 +919,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::SeqSends(SeqSendsPath(PortId::default(), ChannelId::default())),
+            Path::SeqSend(SeqSendPath(PortId::default(), ChannelId::default())),
         );
     }
 
@@ -931,7 +931,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::SeqRecvs(SeqRecvsPath(PortId::default(), ChannelId::default())),
+            Path::SeqRecv(SeqRecvPath(PortId::default(), ChannelId::default())),
         );
     }
 
@@ -943,7 +943,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::SeqAcks(SeqAcksPath(PortId::default(), ChannelId::default())),
+            Path::SeqAck(SeqAckPath(PortId::default(), ChannelId::default())),
         );
     }
 
@@ -954,7 +954,7 @@ mod tests {
 
         assert_eq!(
             parse_commitments(&components),
-            Some(Path::Commitments(CommitmentsPath {
+            Some(Path::Commitment(CommitmentPath {
                 port_id: PortId::default(),
                 channel_id: ChannelId::default(),
                 sequence: Sequence::default(),
@@ -970,7 +970,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::Commitments(CommitmentsPath {
+            Path::Commitment(CommitmentPath {
                 port_id: PortId::default(),
                 channel_id: ChannelId::default(),
                 sequence: Sequence::default(),
@@ -985,7 +985,7 @@ mod tests {
 
         assert_eq!(
             parse_acks(&components),
-            Some(Path::Acks(AcksPath {
+            Some(Path::Ack(AckPath {
                 port_id: PortId::default(),
                 channel_id: ChannelId::default(),
                 sequence: Sequence::default(),
@@ -1001,7 +1001,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::Acks(AcksPath {
+            Path::Ack(AckPath {
                 port_id: PortId::default(),
                 channel_id: ChannelId::default(),
                 sequence: Sequence::default(),
@@ -1016,7 +1016,7 @@ mod tests {
 
         assert_eq!(
             parse_receipts(&components),
-            Some(Path::Receipts(ReceiptsPath {
+            Some(Path::Receipt(ReceiptPath {
                 port_id: PortId::default(),
                 channel_id: ChannelId::default(),
                 sequence: Sequence::default(),
@@ -1032,7 +1032,7 @@ mod tests {
         assert!(path.is_ok());
         assert_eq!(
             path.unwrap(),
-            Path::Receipts(ReceiptsPath {
+            Path::Receipt(ReceiptPath {
                 port_id: PortId::default(),
                 channel_id: ChannelId::default(),
                 sequence: Sequence::default(),

--- a/crates/ibc/src/core/ics26_routing/handler.rs
+++ b/crates/ibc/src/core/ics26_routing/handler.rs
@@ -204,7 +204,7 @@ mod tests {
     use crate::core::ics23_commitment::commitment::test_util::get_dummy_merkle_proof;
     use crate::core::ics23_commitment::commitment::CommitmentPrefix;
     use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-    use crate::core::ics24_host::path::CommitmentsPath;
+    use crate::core::ics24_host::path::CommitmentPath;
     use crate::core::ics26_routing::context::{ModuleId, Router, RouterBuilder, RouterContext};
     use crate::core::ics26_routing::error::RouterError;
     use crate::core::ics26_routing::handler::dispatch;
@@ -515,7 +515,7 @@ mod tests {
                 msg: MsgEnvelope::Packet(PacketMsg::Ack(msg_ack_packet.clone())).into(),
                 want_pass: true,
                 state_check: Some(Box::new(move |ctx| {
-                    ctx.get_packet_commitment(&CommitmentsPath::new(
+                    ctx.get_packet_commitment(&CommitmentPath::new(
                         &msg_ack_packet.packet.port_on_a,
                         &msg_ack_packet.packet.chan_on_a,
                         msg_ack_packet.packet.sequence,

--- a/crates/ibc/src/core/ics26_routing/handler.rs
+++ b/crates/ibc/src/core/ics26_routing/handler.rs
@@ -204,6 +204,7 @@ mod tests {
     use crate::core::ics23_commitment::commitment::test_util::get_dummy_merkle_proof;
     use crate::core::ics23_commitment::commitment::CommitmentPrefix;
     use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+    use crate::core::ics24_host::path::CommitmentsPath;
     use crate::core::ics26_routing::context::{ModuleId, Router, RouterBuilder, RouterContext};
     use crate::core::ics26_routing::error::RouterError;
     use crate::core::ics26_routing::handler::dispatch;
@@ -514,11 +515,11 @@ mod tests {
                 msg: MsgEnvelope::Packet(PacketMsg::Ack(msg_ack_packet.clone())).into(),
                 want_pass: true,
                 state_check: Some(Box::new(move |ctx| {
-                    ctx.get_packet_commitment(
+                    ctx.get_packet_commitment(&CommitmentsPath::new(
                         &msg_ack_packet.packet.port_on_a,
                         &msg_ack_packet.packet.chan_on_a,
-                        &msg_ack_packet.packet.sequence,
-                    )
+                        msg_ack_packet.packet.sequence,
+                    ))
                     .is_err()
                 })),
             },

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -24,8 +24,8 @@ use crate::core::ics23_commitment::commitment::{
 use crate::core::ics23_commitment::merkle::apply_prefix;
 use crate::core::ics24_host::identifier::{ChainId, ClientId};
 use crate::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, CommitmentsPath,
-    ConnectionsPath, ReceiptsPath, SeqRecvsPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, ClientStatePath, CommitmentPath,
+    ConnectionPath, ReceiptPath, SeqRecvPath,
 };
 use crate::core::ics24_host::Path;
 use crate::mock::client_state::client_type as mock_client_type;
@@ -332,7 +332,7 @@ impl ClientState for MockClientState {
         _prefix: &CommitmentPrefix,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _conn_path: &ConnectionsPath,
+        _conn_path: &ConnectionPath,
         _expected_connection_end: &ConnectionEnd,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -344,7 +344,7 @@ impl ClientState for MockClientState {
         _prefix: &CommitmentPrefix,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _chan_end_path: &ChannelEndsPath,
+        _chan_end_path: &ChannelEndPath,
         _expected_channel_end: &ChannelEnd,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -369,7 +369,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _commitment_path: &CommitmentsPath,
+        _commitment_path: &CommitmentPath,
         _commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -382,7 +382,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _commitment_path: &CommitmentsPath,
+        _commitment_path: &CommitmentPath,
         _commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -395,7 +395,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _ack_path: &AcksPath,
+        _ack_path: &AckPath,
         _ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -408,7 +408,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _seq_recv_path: &SeqRecvsPath,
+        _seq_recv_path: &SeqRecvPath,
         _sequence: Sequence,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -421,7 +421,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _seq_recv_path: &SeqRecvsPath,
+        _seq_recv_path: &SeqRecvPath,
         _sequence: Sequence,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -434,7 +434,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _receipt_path: &ReceiptsPath,
+        _receipt_path: &ReceiptPath,
     ) -> Result<(), ClientError> {
         Ok(())
     }
@@ -446,7 +446,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _receipt_path: &ReceiptsPath,
+        _receipt_path: &ReceiptPath,
     ) -> Result<(), ClientError> {
         Ok(())
     }
@@ -458,7 +458,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _ack_path: &AcksPath,
+        _ack_path: &AckPath,
         _ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         Ok(())

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -22,8 +22,11 @@ use crate::core::ics23_commitment::commitment::{
     CommitmentPrefix, CommitmentProofBytes, CommitmentRoot,
 };
 use crate::core::ics23_commitment::merkle::apply_prefix;
-use crate::core::ics24_host::identifier::{ChainId, ChannelId, ClientId, ConnectionId, PortId};
-use crate::core::ics24_host::path::ClientConsensusStatePath;
+use crate::core::ics24_host::identifier::{ChainId, ClientId};
+use crate::core::ics24_host::path::{
+    AcksPath, ChannelEndsPath, ClientConsensusStatePath, ClientStatePath, CommitmentsPath,
+    ConnectionsPath, ReceiptsPath, SeqRecvsPath,
+};
 use crate::core::ics24_host::Path;
 use crate::mock::client_state::client_type as mock_client_type;
 use crate::mock::consensus_state::MockConsensusState;
@@ -312,16 +315,11 @@ impl ClientState for MockClientState {
         prefix: &CommitmentPrefix,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        client_id: &ClientId,
-        consensus_height: Height,
+        client_cons_state_path: &ClientConsensusStatePath,
         _expected_consensus_state: &dyn ConsensusState,
     ) -> Result<(), ClientError> {
-        let client_prefixed_path = Path::ClientConsensusState(ClientConsensusStatePath {
-            client_id: client_id.clone(),
-            epoch: consensus_height.revision_number(),
-            height: consensus_height.revision_height(),
-        })
-        .to_string();
+        let client_prefixed_path =
+            Path::ClientConsensusState(client_cons_state_path.clone()).to_string();
 
         let _path = apply_prefix(prefix, vec![client_prefixed_path]);
 
@@ -334,7 +332,7 @@ impl ClientState for MockClientState {
         _prefix: &CommitmentPrefix,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _connection_id: &ConnectionId,
+        _conn_path: &ConnectionsPath,
         _expected_connection_end: &ConnectionEnd,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -346,8 +344,7 @@ impl ClientState for MockClientState {
         _prefix: &CommitmentPrefix,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
+        _chan_end_path: &ChannelEndsPath,
         _expected_channel_end: &ChannelEnd,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -359,7 +356,7 @@ impl ClientState for MockClientState {
         _prefix: &CommitmentPrefix,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _client_id: &ClientId,
+        _client_state_path: &ClientStatePath,
         _expected_client_state: Any,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -372,9 +369,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _sequence: Sequence,
+        _commitment_path: &CommitmentsPath,
         _commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -387,9 +382,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _sequence: Sequence,
+        _commitment_path: &CommitmentsPath,
         _commitment: PacketCommitment,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -402,9 +395,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _sequence: Sequence,
+        _ack_path: &AcksPath,
         _ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -417,8 +408,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
+        _seq_recv_path: &SeqRecvsPath,
         _sequence: Sequence,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -431,8 +421,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
+        _seq_recv_path: &SeqRecvsPath,
         _sequence: Sequence,
     ) -> Result<(), ClientError> {
         Ok(())
@@ -445,9 +434,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _sequence: Sequence,
+        _receipt_path: &ReceiptsPath,
     ) -> Result<(), ClientError> {
         Ok(())
     }
@@ -459,9 +446,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _sequence: Sequence,
+        _receipt_path: &ReceiptsPath,
     ) -> Result<(), ClientError> {
         Ok(())
     }
@@ -473,9 +458,7 @@ impl ClientState for MockClientState {
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
         _root: &CommitmentRoot,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _sequence: Sequence,
+        _ack_path: &AcksPath,
         _ack: AcknowledgementCommitment,
     ) -> Result<(), ClientError> {
         Ok(())

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -2,8 +2,8 @@
 
 use crate::clients::ics07_tendermint::TENDERMINT_CLIENT_TYPE;
 use crate::core::ics24_host::path::{
-    AcksPath, ChannelEndsPath, ClientConsensusStatePath, CommitmentsPath, ReceiptsPath,
-    SeqAcksPath, SeqRecvsPath, SeqSendsPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath,
+    SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use crate::prelude::*;
 
@@ -711,7 +711,7 @@ impl PortReader for MockContext {
 }
 
 impl ChannelReader for MockContext {
-    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, ChannelError> {
+    fn channel_end(&self, chan_end_path: &ChannelEndPath) -> Result<ChannelEnd, ChannelError> {
         match self
             .ibc_store
             .lock()
@@ -756,7 +756,7 @@ impl ChannelReader for MockContext {
 
     fn get_next_sequence_send(
         &self,
-        seq_send_path: &SeqSendsPath,
+        seq_send_path: &SeqSendPath,
     ) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
@@ -775,7 +775,7 @@ impl ChannelReader for MockContext {
 
     fn get_next_sequence_recv(
         &self,
-        seq_recv_path: &SeqRecvsPath,
+        seq_recv_path: &SeqRecvPath,
     ) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
@@ -792,7 +792,7 @@ impl ChannelReader for MockContext {
         }
     }
 
-    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAcksPath) -> Result<Sequence, PacketError> {
+    fn get_next_sequence_ack(&self, seq_acks_path: &SeqAckPath) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
             .lock()
@@ -810,7 +810,7 @@ impl ChannelReader for MockContext {
 
     fn get_packet_commitment(
         &self,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
     ) -> Result<PacketCommitment, PacketError> {
         match self
             .ibc_store
@@ -827,7 +827,7 @@ impl ChannelReader for MockContext {
         }
     }
 
-    fn get_packet_receipt(&self, receipt_path: &ReceiptsPath) -> Result<Receipt, PacketError> {
+    fn get_packet_receipt(&self, receipt_path: &ReceiptPath) -> Result<Receipt, PacketError> {
         match self
             .ibc_store
             .lock()
@@ -845,7 +845,7 @@ impl ChannelReader for MockContext {
 
     fn get_packet_acknowledgement(
         &self,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
     ) -> Result<AcknowledgementCommitment, PacketError> {
         match self
             .ibc_store
@@ -1567,7 +1567,7 @@ impl ValidationContext for MockContext {
         ConnectionReader::connection_counter(self).map_err(ContextError::ConnectionError)
     }
 
-    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, ContextError> {
+    fn channel_end(&self, chan_end_path: &ChannelEndPath) -> Result<ChannelEnd, ContextError> {
         ChannelReader::channel_end(self, chan_end_path).map_err(ContextError::ChannelError)
     }
 
@@ -1580,7 +1580,7 @@ impl ValidationContext for MockContext {
 
     fn get_next_sequence_send(
         &self,
-        seq_send_path: &SeqSendsPath,
+        seq_send_path: &SeqSendPath,
     ) -> Result<Sequence, ContextError> {
         ChannelReader::get_next_sequence_send(self, seq_send_path)
             .map_err(ContextError::PacketError)
@@ -1588,31 +1588,31 @@ impl ValidationContext for MockContext {
 
     fn get_next_sequence_recv(
         &self,
-        seq_recv_path: &SeqRecvsPath,
+        seq_recv_path: &SeqRecvPath,
     ) -> Result<Sequence, ContextError> {
         ChannelReader::get_next_sequence_recv(self, seq_recv_path)
             .map_err(ContextError::PacketError)
     }
 
-    fn get_next_sequence_ack(&self, seq_ack_path: &SeqAcksPath) -> Result<Sequence, ContextError> {
+    fn get_next_sequence_ack(&self, seq_ack_path: &SeqAckPath) -> Result<Sequence, ContextError> {
         ChannelReader::get_next_sequence_ack(self, seq_ack_path).map_err(ContextError::PacketError)
     }
 
     fn get_packet_commitment(
         &self,
-        commitment_path: &CommitmentsPath,
+        commitment_path: &CommitmentPath,
     ) -> Result<PacketCommitment, ContextError> {
         ChannelReader::get_packet_commitment(self, commitment_path)
             .map_err(ContextError::PacketError)
     }
 
-    fn get_packet_receipt(&self, receipt_path: &ReceiptsPath) -> Result<Receipt, ContextError> {
+    fn get_packet_receipt(&self, receipt_path: &ReceiptPath) -> Result<Receipt, ContextError> {
         ChannelReader::get_packet_receipt(self, receipt_path).map_err(ContextError::PacketError)
     }
 
     fn get_packet_acknowledgement(
         &self,
-        ack_path: &AcksPath,
+        ack_path: &AckPath,
     ) -> Result<AcknowledgementCommitment, ContextError> {
         ChannelReader::get_packet_acknowledgement(self, ack_path).map_err(ContextError::PacketError)
     }

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -2,8 +2,8 @@
 
 use crate::clients::ics07_tendermint::TENDERMINT_CLIENT_TYPE;
 use crate::core::ics24_host::path::{
-    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath,
-    SeqAckPath, SeqRecvPath, SeqSendPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, ReceiptPath, SeqAckPath,
+    SeqRecvPath, SeqSendPath,
 };
 use crate::prelude::*;
 
@@ -754,10 +754,7 @@ impl ChannelReader for MockContext {
             .map_err(|e| ChannelError::Connection(ConnectionError::Client(e)))
     }
 
-    fn get_next_sequence_send(
-        &self,
-        seq_send_path: &SeqSendPath,
-    ) -> Result<Sequence, PacketError> {
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
             .lock()
@@ -773,10 +770,7 @@ impl ChannelReader for MockContext {
         }
     }
 
-    fn get_next_sequence_recv(
-        &self,
-        seq_recv_path: &SeqRecvPath,
-    ) -> Result<Sequence, PacketError> {
+    fn get_next_sequence_recv(&self, seq_recv_path: &SeqRecvPath) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
             .lock()

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -23,7 +23,7 @@ use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath, SeqSendsPath};
+use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath, SeqSendPath};
 use crate::core::ics26_routing::context::{Module, ModuleOutputBuilder};
 use crate::mock::context::MockIbcStore;
 use crate::prelude::*;
@@ -309,7 +309,7 @@ impl TokenTransferReader for DummyTransferModule {
 }
 
 impl SendPacketReader for DummyTransferModule {
-    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, PacketError> {
+    fn channel_end(&self, chan_end_path: &ChannelEndPath) -> Result<ChannelEnd, PacketError> {
         match self
             .ibc_store
             .lock()
@@ -381,7 +381,7 @@ impl SendPacketReader for DummyTransferModule {
 
     fn get_next_sequence_send(
         &self,
-        seq_send_path: &SeqSendsPath,
+        seq_send_path: &SeqSendPath,
     ) -> Result<Sequence, PacketError> {
         match self
             .ibc_store

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -23,6 +23,7 @@ use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
+use crate::core::ics24_host::path::{ChannelEndsPath, ClientConsensusStatePath, SeqSendsPath};
 use crate::core::ics26_routing::context::{Module, ModuleOutputBuilder};
 use crate::mock::context::MockIbcStore;
 use crate::prelude::*;
@@ -308,22 +309,18 @@ impl TokenTransferReader for DummyTransferModule {
 }
 
 impl SendPacketReader for DummyTransferModule {
-    fn channel_end(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<ChannelEnd, PacketError> {
+    fn channel_end(&self, chan_end_path: &ChannelEndsPath) -> Result<ChannelEnd, PacketError> {
         match self
             .ibc_store
             .lock()
             .channels
-            .get(port_id)
-            .and_then(|map| map.get(channel_id))
+            .get(&chan_end_path.0)
+            .and_then(|map| map.get(&chan_end_path.1))
         {
             Some(channel_end) => Ok(channel_end.clone()),
             None => Err(PacketError::ChannelNotFound {
-                port_id: port_id.clone(),
-                channel_id: channel_id.clone(),
+                port_id: chan_end_path.0.clone(),
+                channel_id: chan_end_path.1.clone(),
             }),
         }
     }
@@ -357,20 +354,26 @@ impl SendPacketReader for DummyTransferModule {
 
     fn client_consensus_state(
         &self,
-        client_id: &ClientId,
-        height: &Height,
+        client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Box<dyn ConsensusState>, PacketError> {
-        match self.ibc_store.lock().clients.get(client_id) {
-            Some(client_record) => match client_record.consensus_states.get(height) {
+        let height =
+            Height::new(client_cons_state_path.epoch, client_cons_state_path.height).unwrap();
+        match self
+            .ibc_store
+            .lock()
+            .clients
+            .get(&client_cons_state_path.client_id)
+        {
+            Some(client_record) => match client_record.consensus_states.get(&height) {
                 Some(consensus_state) => Ok(consensus_state.clone()),
                 None => Err(ClientError::ConsensusStateNotFound {
-                    client_id: client_id.clone(),
-                    height: *height,
+                    client_id: client_cons_state_path.client_id.clone(),
+                    height,
                 }),
             },
             None => Err(ClientError::ConsensusStateNotFound {
-                client_id: client_id.clone(),
-                height: *height,
+                client_id: client_cons_state_path.client_id.clone(),
+                height,
             }),
         }
         .map_err(|e| PacketError::Connection(ConnectionError::Client(e)))
@@ -378,20 +381,19 @@ impl SendPacketReader for DummyTransferModule {
 
     fn get_next_sequence_send(
         &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
+        seq_send_path: &SeqSendsPath,
     ) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
             .lock()
             .next_sequence_send
-            .get(port_id)
-            .and_then(|map| map.get(channel_id))
+            .get(&seq_send_path.0)
+            .and_then(|map| map.get(&seq_send_path.1))
         {
             Some(sequence) => Ok(*sequence),
             None => Err(PacketError::MissingNextSendSeq {
-                port_id: port_id.clone(),
-                channel_id: channel_id.clone(),
+                port_id: seq_send_path.0.clone(),
+                channel_id: seq_send_path.1.clone(),
             }),
         }
     }

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -379,10 +379,7 @@ impl SendPacketReader for DummyTransferModule {
         .map_err(|e| PacketError::Connection(ConnectionError::Client(e)))
     }
 
-    fn get_next_sequence_send(
-        &self,
-        seq_send_path: &SeqSendPath,
-    ) -> Result<Sequence, PacketError> {
+    fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath) -> Result<Sequence, PacketError> {
         match self
             .ibc_store
             .lock()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #382 

## Description

I initiated reorganizing the `store_*` methods, but it quickly escalated to more changes. 

- The `store_*` methods take a `Path_*` argument while the `get_*` methods had a different approach, accepting the needed parameters directly. IMHO, we should take a consistent approach throughout the repo. I believe that using `Path_*` is easier to maintain, understand the purpose of args, and align with the [spec](https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#keyvalue-store).
- This change also had an impact on the `verify_*` methods under the `ClientState` trait and allowed us to eliminate some of the `#[allow(clippy::too_many_arguments)]` annotations.
- I also revised the naming of some `*Path` structs to be in the singular form as each abstraction refers to a specific path. This previous naming caused confusion while working with the paths. (See also [ibc-go](https://github.com/cosmos/ibc-go/blob/e093d85b533ab3572b32a7de60b88a0816bed4af/modules/core/24-host/keys.go#L129-L227))
______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [X] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
