### PR TITLE
`ValidationContext::{next,prev}_consensus_state()` don't take a Path

### DIFF
--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -578,12 +578,11 @@ impl Ics2ClientState for ClientState {
             }
         }
 
-        let client_cons_state_path = ClientConsensusStatePath::new(&client_id, &header.height());
         // Monotonicity checks for timestamps for in-the-middle updates
         // (cs-new, cs-next, cs-latest)
         if header.height() < client_state.latest_height() {
             let maybe_next_cs = ctx
-                .next_consensus_state(&client_cons_state_path)
+                .next_consensus_state(&client_id, &header.height())
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => ClientError::Other {
@@ -612,7 +611,7 @@ impl Ics2ClientState for ClientState {
         // (cs-trusted, cs-prev, cs-new)
         if header.trusted_height < header.height() {
             let maybe_prev_cs = ctx
-                .prev_consensus_state(&client_cons_state_path)
+                .prev_consensus_state(&client_id, &header.height())
                 .map_err(|e| match e {
                     ContextError::ClientError(e) => e,
                     _ => ClientError::Other {

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -279,8 +279,9 @@ pub trait ValidationContext: Router {
         height: &Height,
     ) -> Result<Box<dyn ConsensusState>, ContextError>;
 
-    /// Returns a natural number, counting how many clients have been created thus far.
-    /// The value of this counter should increase only via method `ClientKeeper::increase_client_counter`.
+    /// Returns a natural number, counting how many clients have been created
+    /// thus far. The value of this counter should increase only via method
+    /// `ExecutionContext::increase_client_counter`.
     fn client_counter(&self) -> Result<u64, ContextError>;
 
     /// Returns the ConnectionEnd for the given identifier `conn_id`.
@@ -398,7 +399,7 @@ pub trait ValidationContext: Router {
 
     /// Returns a counter on the number of channel ids have been created thus far.
     /// The value of this counter should increase only via method
-    /// `ChannelKeeper::increase_channel_counter`.
+    /// `ExecutionContext::increase_channel_counter`.
     fn channel_counter(&self) -> Result<u64, ContextError>;
 
     /// Returns the maximum expected time per block

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -256,13 +256,15 @@ pub trait ValidationContext: Router {
     /// Search for the lowest consensus state higher than `height`.
     fn next_consensus_state(
         &self,
-        next_client_cons_state_path: &ClientConsensusStatePath,
+        client_id: &ClientId,
+        height: &Height,
     ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
 
     /// Search for the highest consensus state lower than `height`.
     fn prev_consensus_state(
         &self,
-        prev_client_cons_state_path: &ClientConsensusStatePath,
+        client_id: &ClientId,
+        height: &Height,
     ) -> Result<Option<Box<dyn ConsensusState>>, ContextError>;
 
     /// Returns the current height of the local chain.

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -98,8 +98,7 @@ mod tests {
     #[test]
     /// These tests exercise two main paths: (1) the ability of the ICS26 routing module to dispatch
     /// messages to the correct module handler, and more importantly: (2) the ability of ICS handlers
-    /// to work with the context and correctly store results (i.e., the `ClientKeeper`,
-    /// `ConnectionKeeper`, and `ChannelKeeper` traits).
+    /// to work with the context and correctly store results.
     fn routing_module_and_keepers() {
         #[derive(Clone, Debug)]
         enum TestMsg {

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -1,5 +1,5 @@
-//! ICS4 (channel) context. The two traits `ChannelReader ` and `ChannelKeeper` define
-//! the interface that any host chain must implement to be able to process any `ChannelMsg`.
+//! ICS4 (channel) context.
+
 use crate::core::ics02_client::client_state::ClientState;
 use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath, SeqSendPath};
 use crate::core::{ContextError, ValidationContext};

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -742,14 +742,9 @@ impl ValidationContext for MockContext {
 
     fn next_consensus_state(
         &self,
-        next_client_cons_state_path: &ClientConsensusStatePath,
+        client_id: &ClientId,
+        height: &Height,
     ) -> Result<Option<Box<dyn ConsensusState>>, ContextError> {
-        let client_id = &next_client_cons_state_path.client_id;
-        let height = Height::new(
-            next_client_cons_state_path.epoch,
-            next_client_cons_state_path.height,
-        )?;
-
         let ibc_store = self.ibc_store.lock();
         let client_record =
             ibc_store
@@ -765,7 +760,7 @@ impl ValidationContext for MockContext {
 
         // Search for next state.
         for h in heights {
-            if h > height {
+            if h > *height {
                 // unwrap should never happen, as the consensus state for h must exist
                 return Ok(Some(
                     client_record.consensus_states.get(&h).unwrap().clone(),
@@ -777,14 +772,9 @@ impl ValidationContext for MockContext {
 
     fn prev_consensus_state(
         &self,
-        prev_client_cons_state_path: &ClientConsensusStatePath,
+        client_id: &ClientId,
+        height: &Height,
     ) -> Result<Option<Box<dyn ConsensusState>>, ContextError> {
-        let client_id = &prev_client_cons_state_path.client_id;
-        let height = Height::new(
-            prev_client_cons_state_path.epoch,
-            prev_client_cons_state_path.height,
-        )?;
-
         let ibc_store = self.ibc_store.lock();
         let client_record =
             ibc_store
@@ -800,7 +790,7 @@ impl ValidationContext for MockContext {
 
         // Search for previous state.
         for h in heights {
-            if h < height {
+            if h < *height {
                 // unwrap should never happen, as the consensus state for h must exist
                 return Ok(Some(
                     client_record.consensus_states.get(&h).unwrap().clone(),


### PR DESCRIPTION

Reverts changes in #419 made to `ValidationContext::{next,prev}_consensus_state()`

## Description

for these 2 methods, a `Path` argument doesn’t make sense. We don’t know the exact path that we are querying; *e.g.* we are asking the host to give us the consensus state after a certain height.
