### PR TITLE
Update send packet/transfer

### DIFF
--- a/.changelog/unreleased/breaking-changes/442-send-packet-transfer.md
+++ b/.changelog/unreleased/breaking-changes/442-send-packet-transfer.md
@@ -1,0 +1,2 @@
+- Update send_packet/transfer(), and related contexts
+  ([#442](https://github.com/cosmos/ibc-rs/issues/442))

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -55,6 +55,30 @@ pub trait TokenTransferKeeper: BankKeeper {
     ) -> Result<(), ContextError>;
 }
 
+pub trait TokenTransferExecutionContext: TokenTransferValidationContext + ExecutionContext {
+    /// This function should enable sending ibc fungible tokens from one account to another
+    fn send_coins(
+        &mut self,
+        from: &Self::AccountId,
+        to: &Self::AccountId,
+        amt: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
+    /// This function to enable minting ibc tokens to a user account
+    fn mint_coins(
+        &mut self,
+        account: &Self::AccountId,
+        amt: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
+    /// This function should enable burning of minted tokens in a user account
+    fn burn_coins(
+        &mut self,
+        account: &Self::AccountId,
+        amt: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+}
+
 pub trait TokenTransferValidationContext: ValidationContext {
     type AccountId: TryFrom<Signer>;
 

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -18,7 +18,7 @@ use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 use crate::core::ics24_host::path::{CommitmentPath, SeqSendPath};
 use crate::core::ics26_routing::context::ModuleOutputBuilder;
-use crate::core::{ContextError, ExecutionContext};
+use crate::core::{ContextError, ExecutionContext, ValidationContext};
 use crate::prelude::*;
 use crate::signer::Signer;
 
@@ -53,6 +53,32 @@ pub trait TokenTransferKeeper: BankKeeper {
         channel_id: ChannelId,
         seq: Sequence,
     ) -> Result<(), ContextError>;
+}
+
+pub trait TokenTransferValidationContext: ValidationContext {
+    type AccountId: TryFrom<Signer>;
+
+    /// get_port returns the portID for the transfer module.
+    fn get_port(&self) -> Result<PortId, TokenTransferError>;
+
+    /// Returns the escrow account id for a port and channel combination
+    fn get_channel_escrow_address(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<Self::AccountId, TokenTransferError>;
+
+    /// Returns true iff send is enabled.
+    fn is_send_enabled(&self) -> bool;
+
+    /// Returns true iff receive is enabled.
+    fn is_receive_enabled(&self) -> bool;
+
+    /// Returns a hash of the prefixed denom.
+    /// Implement only if the host chain supports hashed denominations.
+    fn denom_hash_string(&self, _denom: &PrefixedDenom) -> Option<String> {
+        None
+    }
 }
 
 pub trait TokenTransferReader: SendPacketReader {

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 use sha2::{Digest, Sha256};
 
 use super::error::TokenTransferError;
@@ -6,56 +8,21 @@ use crate::applications::transfer::events::{AckEvent, AckStatusEvent, RecvEvent,
 use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::relay::on_recv_packet::process_recv_packet;
 use crate::applications::transfer::relay::refund_packet_token;
+use crate::applications::transfer::relay::{
+    on_recv_packet::process_recv_packet_execute, refund_packet_token_validate,
+};
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
-use crate::core::ics04_channel::commitment::PacketCommitment;
 use crate::core::ics04_channel::context::{
     SendPacketExecutionContext, SendPacketValidationContext,
 };
-use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
-use crate::core::ics04_channel::packet::{Packet, Sequence};
+use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
-use crate::core::ics24_host::path::{CommitmentPath, SeqSendPath};
 use crate::core::ics26_routing::context::ModuleOutputBuilder;
-use crate::core::{ContextError, ExecutionContext};
-use crate::prelude::*;
 use crate::signer::Signer;
-
-pub trait TokenTransferKeeper: BankKeeper {
-    fn store_send_packet_result(&mut self, result: SendPacketResult) -> Result<(), ContextError> {
-        self.store_next_sequence_send(
-            result.port_id.clone(),
-            result.channel_id.clone(),
-            result.seq_number,
-        )?;
-
-        self.store_packet_commitment(
-            result.port_id,
-            result.channel_id,
-            result.seq,
-            result.commitment,
-        )?;
-        Ok(())
-    }
-
-    fn store_packet_commitment(
-        &mut self,
-        port_id: PortId,
-        channel_id: ChannelId,
-        sequence: Sequence,
-        commitment: PacketCommitment,
-    ) -> Result<(), ContextError>;
-
-    fn store_next_sequence_send(
-        &mut self,
-        port_id: PortId,
-        channel_id: ChannelId,
-        seq: Sequence,
-    ) -> Result<(), ContextError>;
-}
 
 pub trait TokenTransferExecutionContext:
     TokenTransferValidationContext + SendPacketExecutionContext
@@ -109,64 +76,6 @@ pub trait TokenTransferValidationContext: SendPacketValidationContext {
     }
 }
 
-pub trait TokenTransferReader: SendPacketValidationContext {
-    type AccountId: TryFrom<Signer>;
-
-    /// get_port returns the portID for the transfer module.
-    fn get_port(&self) -> Result<PortId, TokenTransferError>;
-
-    /// Returns the escrow account id for a port and channel combination
-    fn get_channel_escrow_address(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<<Self as TokenTransferReader>::AccountId, TokenTransferError>;
-
-    /// Returns true iff send is enabled.
-    fn is_send_enabled(&self) -> bool;
-
-    /// Returns true iff receive is enabled.
-    fn is_receive_enabled(&self) -> bool;
-
-    /// Returns a hash of the prefixed denom.
-    /// Implement only if the host chain supports hashed denominations.
-    fn denom_hash_string(&self, _denom: &PrefixedDenom) -> Option<String> {
-        None
-    }
-}
-
-impl<T> TokenTransferKeeper for T
-where
-    T: ExecutionContext + BankKeeper,
-{
-    fn store_packet_commitment(
-        &mut self,
-        port_id: PortId,
-        channel_id: ChannelId,
-        sequence: Sequence,
-        commitment: PacketCommitment,
-    ) -> Result<(), ContextError> {
-        let commitment_path = CommitmentPath {
-            port_id,
-            channel_id,
-            sequence,
-        };
-
-        self.store_packet_commitment(&commitment_path, commitment)
-    }
-
-    fn store_next_sequence_send(
-        &mut self,
-        port_id: PortId,
-        channel_id: ChannelId,
-        seq: Sequence,
-    ) -> Result<(), ContextError> {
-        let seq_send_path = SeqSendPath(port_id, channel_id);
-
-        self.store_next_sequence_send(&seq_send_path, seq)
-    }
-}
-
 // https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-028-public-key-addresses.md
 pub fn cosmos_adr028_escrow_address(port_id: &PortId, channel_id: &ChannelId) -> Vec<u8> {
     let contents = format!("{port_id}/{channel_id}");
@@ -181,141 +90,7 @@ pub fn cosmos_adr028_escrow_address(port_id: &PortId, channel_id: &ChannelId) ->
     hash
 }
 
-pub trait BankKeeper {
-    type AccountId;
-
-    /// This function should enable sending ibc fungible tokens from one account to another
-    fn send_coins(
-        &mut self,
-        from: &Self::AccountId,
-        to: &Self::AccountId,
-        amt: &PrefixedCoin,
-    ) -> Result<(), TokenTransferError>;
-
-    /// This function to enable minting ibc tokens to a user account
-    fn mint_coins(
-        &mut self,
-        account: &Self::AccountId,
-        amt: &PrefixedCoin,
-    ) -> Result<(), TokenTransferError>;
-
-    /// This function should enable burning of minted tokens in a user account
-    fn burn_coins(
-        &mut self,
-        account: &Self::AccountId,
-        amt: &PrefixedCoin,
-    ) -> Result<(), TokenTransferError>;
-}
-
-/// Captures all the dependencies which the ICS20 module requires to be able to dispatch and
-/// process IBC messages.
-pub trait TokenTransferContext:
-    TokenTransferKeeper<AccountId = <Self as TokenTransferContext>::AccountId>
-    + TokenTransferReader<AccountId = <Self as TokenTransferContext>::AccountId>
-{
-    type AccountId: TryFrom<Signer>;
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn on_chan_open_init(
-    ctx: &mut impl TokenTransferContext,
-    order: Order,
-    _connection_hops: &[ConnectionId],
-    port_id: &PortId,
-    _channel_id: &ChannelId,
-    _counterparty: &Counterparty,
-    version: &Version,
-) -> Result<(ModuleExtras, Version), TokenTransferError> {
-    if order != Order::Unordered {
-        return Err(TokenTransferError::ChannelNotUnordered {
-            expect_order: Order::Unordered,
-            got_order: order,
-        });
-    }
-    let bound_port = ctx.get_port()?;
-    if port_id != &bound_port {
-        return Err(TokenTransferError::InvalidPort {
-            port_id: port_id.clone(),
-            exp_port_id: bound_port,
-        });
-    }
-
-    if !version.is_empty() && version != &Version::new(VERSION.to_string()) {
-        return Err(TokenTransferError::InvalidVersion {
-            expect_version: Version::new(VERSION.to_string()),
-            got_version: version.clone(),
-        });
-    }
-
-    Ok((ModuleExtras::empty(), Version::new(VERSION.to_string())))
-}
-#[allow(clippy::too_many_arguments)]
-pub fn on_chan_open_try(
-    _ctx: &mut impl TokenTransferContext,
-    order: Order,
-    _connection_hops: &[ConnectionId],
-    _port_id: &PortId,
-    _channel_id: &ChannelId,
-    _counterparty: &Counterparty,
-    counterparty_version: &Version,
-) -> Result<(ModuleExtras, Version), TokenTransferError> {
-    if order != Order::Unordered {
-        return Err(TokenTransferError::ChannelNotUnordered {
-            expect_order: Order::Unordered,
-            got_order: order,
-        });
-    }
-    if counterparty_version != &Version::new(VERSION.to_string()) {
-        return Err(TokenTransferError::InvalidCounterpartyVersion {
-            expect_version: Version::new(VERSION.to_string()),
-            got_version: counterparty_version.clone(),
-        });
-    }
-
-    Ok((ModuleExtras::empty(), Version::new(VERSION.to_string())))
-}
-
-pub fn on_chan_open_ack(
-    _ctx: &mut impl TokenTransferContext,
-    _port_id: &PortId,
-    _channel_id: &ChannelId,
-    counterparty_version: &Version,
-) -> Result<ModuleExtras, TokenTransferError> {
-    if counterparty_version != &Version::new(VERSION.to_string()) {
-        return Err(TokenTransferError::InvalidCounterpartyVersion {
-            expect_version: Version::new(VERSION.to_string()),
-            got_version: counterparty_version.clone(),
-        });
-    }
-
-    Ok(ModuleExtras::empty())
-}
-
-pub fn on_chan_open_confirm(
-    _ctx: &mut impl TokenTransferContext,
-    _port_id: &PortId,
-    _channel_id: &ChannelId,
-) -> Result<ModuleExtras, TokenTransferError> {
-    Ok(ModuleExtras::empty())
-}
-
-pub fn on_chan_close_init(
-    _ctx: &mut impl TokenTransferContext,
-    _port_id: &PortId,
-    _channel_id: &ChannelId,
-) -> Result<ModuleExtras, TokenTransferError> {
-    Err(TokenTransferError::CantCloseChannel)
-}
-
-pub fn on_chan_close_confirm(
-    _ctx: &mut impl TokenTransferContext,
-    _port_id: &PortId,
-    _channel_id: &ChannelId,
-) -> Result<ModuleExtras, TokenTransferError> {
-    Ok(ModuleExtras::empty())
-}
-
-pub fn on_recv_packet<Ctx: 'static + TokenTransferContext>(
+pub fn on_recv_packet<Ctx: 'static + TokenTransferExecutionContext>(
     ctx: &mut Ctx,
     output: &mut ModuleOutputBuilder,
     packet: &Packet,
@@ -348,66 +123,9 @@ pub fn on_recv_packet<Ctx: 'static + TokenTransferContext>(
     ack.into()
 }
 
-pub fn on_acknowledgement_packet(
-    ctx: &mut impl TokenTransferContext,
-    output: &mut ModuleOutputBuilder,
-    packet: &Packet,
-    acknowledgement: &Acknowledgement,
-    _relayer: &Signer,
-) -> Result<(), TokenTransferError> {
-    let data = serde_json::from_slice::<PacketData>(&packet.data)
-        .map_err(|_| TokenTransferError::PacketDataDeserialization)?;
-
-    let acknowledgement =
-        serde_json::from_slice::<TokenTransferAcknowledgement>(acknowledgement.as_ref())
-            .map_err(|_| TokenTransferError::AckDeserialization)?;
-
-    if !acknowledgement.is_successful() {
-        refund_packet_token(ctx, packet, &data)?;
-    }
-
-    let ack_event = AckEvent {
-        receiver: data.receiver,
-        denom: data.token.denom,
-        amount: data.token.amount,
-        acknowledgement: acknowledgement.clone(),
-    };
-    output.emit(ack_event.into());
-    output.emit(AckStatusEvent { acknowledgement }.into());
-
-    Ok(())
-}
-
-pub fn on_timeout_packet(
-    ctx: &mut impl TokenTransferContext,
-    output: &mut ModuleOutputBuilder,
-    packet: &Packet,
-    _relayer: &Signer,
-) -> Result<(), TokenTransferError> {
-    let data = serde_json::from_slice::<PacketData>(&packet.data)
-        .map_err(|_| TokenTransferError::PacketDataDeserialization)?;
-
-    refund_packet_token(ctx, packet, &data)?;
-
-    let timeout_event = TimeoutEvent {
-        refund_receiver: data.sender,
-        refund_denom: data.token.denom,
-        refund_amount: data.token.amount,
-    };
-    output.emit(timeout_event.into());
-
-    Ok(())
-}
-
-use crate::applications::transfer::relay::{
-    on_recv_packet::process_recv_packet_execute, refund_packet_token_validate,
-};
-
-pub use super::*;
-
 #[allow(clippy::too_many_arguments)]
 pub fn on_chan_open_init_validate(
-    ctx: &impl TokenTransferContext,
+    ctx: &impl TokenTransferValidationContext,
     order: Order,
     _connection_hops: &[ConnectionId],
     port_id: &PortId,
@@ -441,7 +159,7 @@ pub fn on_chan_open_init_validate(
 
 #[allow(clippy::too_many_arguments)]
 pub fn on_chan_open_init_execute(
-    _ctx: &mut impl TokenTransferContext,
+    _ctx: &mut impl TokenTransferExecutionContext,
     _order: Order,
     _connection_hops: &[ConnectionId],
     _port_id: &PortId,
@@ -454,7 +172,7 @@ pub fn on_chan_open_init_execute(
 
 #[allow(clippy::too_many_arguments)]
 pub fn on_chan_open_try_validate(
-    _ctx: &impl TokenTransferContext,
+    _ctx: &impl TokenTransferValidationContext,
     order: Order,
     _connection_hops: &[ConnectionId],
     _port_id: &PortId,
@@ -480,7 +198,7 @@ pub fn on_chan_open_try_validate(
 
 #[allow(clippy::too_many_arguments)]
 pub fn on_chan_open_try_execute(
-    _ctx: &mut impl TokenTransferContext,
+    _ctx: &mut impl TokenTransferExecutionContext,
     _order: Order,
     _connection_hops: &[ConnectionId],
     _port_id: &PortId,
@@ -492,7 +210,7 @@ pub fn on_chan_open_try_execute(
 }
 
 pub fn on_chan_open_ack_validate(
-    _ctx: &impl TokenTransferContext,
+    _ctx: &impl TokenTransferValidationContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
     counterparty_version: &Version,
@@ -508,7 +226,7 @@ pub fn on_chan_open_ack_validate(
 }
 
 pub fn on_chan_open_ack_execute(
-    _ctx: &mut impl TokenTransferContext,
+    _ctx: &mut impl TokenTransferExecutionContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
     _counterparty_version: &Version,
@@ -517,7 +235,7 @@ pub fn on_chan_open_ack_execute(
 }
 
 pub fn on_chan_open_confirm_validate(
-    _ctx: &impl TokenTransferContext,
+    _ctx: &impl TokenTransferValidationContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
 ) -> Result<(), TokenTransferError> {
@@ -525,7 +243,7 @@ pub fn on_chan_open_confirm_validate(
 }
 
 pub fn on_chan_open_confirm_execute(
-    _ctx: &mut impl TokenTransferContext,
+    _ctx: &mut impl TokenTransferExecutionContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
 ) -> Result<ModuleExtras, TokenTransferError> {
@@ -533,14 +251,14 @@ pub fn on_chan_open_confirm_execute(
 }
 
 pub fn on_chan_close_init_validate(
-    _ctx: &impl TokenTransferContext,
+    _ctx: &impl TokenTransferValidationContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
 ) -> Result<(), TokenTransferError> {
     Err(TokenTransferError::CantCloseChannel)
 }
 pub fn on_chan_close_init_execute(
-    _ctx: &mut impl TokenTransferContext,
+    _ctx: &mut impl TokenTransferExecutionContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
 ) -> Result<ModuleExtras, TokenTransferError> {
@@ -548,7 +266,7 @@ pub fn on_chan_close_init_execute(
 }
 
 pub fn on_chan_close_confirm_validate(
-    _ctx: &impl TokenTransferContext,
+    _ctx: &impl TokenTransferValidationContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
 ) -> Result<(), TokenTransferError> {
@@ -556,7 +274,7 @@ pub fn on_chan_close_confirm_validate(
 }
 
 pub fn on_chan_close_confirm_execute(
-    _ctx: &mut impl TokenTransferContext,
+    _ctx: &mut impl TokenTransferExecutionContext,
     _port_id: &PortId,
     _channel_id: &ChannelId,
 ) -> Result<ModuleExtras, TokenTransferError> {
@@ -564,7 +282,7 @@ pub fn on_chan_close_confirm_execute(
 }
 
 pub fn on_recv_packet_execute(
-    ctx: &mut impl TokenTransferContext,
+    ctx: &mut impl TokenTransferExecutionContext,
     packet: &Packet,
 ) -> (ModuleExtras, Acknowledgement) {
     let data = match serde_json::from_slice::<PacketData>(&packet.data) {
@@ -600,7 +318,7 @@ pub fn on_acknowledgement_packet_validate<Ctx>(
     _relayer: &Signer,
 ) -> Result<(), TokenTransferError>
 where
-    Ctx: TokenTransferContext,
+    Ctx: TokenTransferValidationContext,
 {
     let data = serde_json::from_slice::<PacketData>(&packet.data)
         .map_err(|_| TokenTransferError::PacketDataDeserialization)?;
@@ -617,7 +335,7 @@ where
 }
 
 pub fn on_acknowledgement_packet_execute(
-    ctx: &mut impl TokenTransferContext,
+    ctx: &mut impl TokenTransferExecutionContext,
     packet: &Packet,
     acknowledgement: &Acknowledgement,
     _relayer: &Signer,
@@ -670,7 +388,7 @@ pub fn on_timeout_packet_validate<Ctx>(
     _relayer: &Signer,
 ) -> Result<(), TokenTransferError>
 where
-    Ctx: TokenTransferContext,
+    Ctx: TokenTransferValidationContext,
 {
     let data = serde_json::from_slice::<PacketData>(&packet.data)
         .map_err(|_| TokenTransferError::PacketDataDeserialization)?;
@@ -681,7 +399,7 @@ where
 }
 
 pub fn on_timeout_packet_execute(
-    ctx: &mut impl TokenTransferContext,
+    ctx: &mut impl TokenTransferExecutionContext,
     packet: &Packet,
     _relayer: &Signer,
 ) -> (ModuleExtras, Result<(), TokenTransferError>) {
@@ -718,7 +436,7 @@ pub(crate) mod test {
     use super::*;
     use subtle_encoding::bech32;
 
-    use crate::applications::transfer::context::{cosmos_adr028_escrow_address, on_chan_open_try};
+    use crate::applications::transfer::context::cosmos_adr028_escrow_address;
     use crate::applications::transfer::error::TokenTransferError;
     use crate::applications::transfer::msgs::transfer::MsgTransfer;
     use crate::applications::transfer::relay::send_transfer::send_transfer;
@@ -727,17 +445,13 @@ pub(crate) mod test {
     use crate::core::ics04_channel::error::ChannelError;
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
-    use crate::handler::HandlerOutputBuilder;
     use crate::test_utils::{get_dummy_transfer_module, DummyTransferModule};
-
-    use super::on_chan_open_init;
 
     pub(crate) fn deliver(
         ctx: &mut DummyTransferModule,
-        output: &mut HandlerOutputBuilder<()>,
         msg: MsgTransfer<PrefixedCoin>,
     ) -> Result<(), ChannelError> {
-        send_transfer(ctx, output, msg).map_err(|e: TokenTransferError| ChannelError::AppModule {
+        send_transfer(ctx, msg).map_err(|e: TokenTransferError| ChannelError::AppModule {
             description: e.to_string(),
         })
     }
@@ -805,7 +519,7 @@ pub(crate) mod test {
 
         let in_version = Version::new("".to_string());
 
-        let (_, out_version) = on_chan_open_init(
+        let (_, out_version) = on_chan_open_init_execute(
             &mut ctx,
             order,
             &connection_hops,
@@ -825,7 +539,7 @@ pub(crate) mod test {
         let (mut ctx, order, connection_hops, port_id, channel_id, counterparty) = get_defaults();
 
         let in_version = Version::new(VERSION.to_string());
-        let (_, out_version) = on_chan_open_init(
+        let (_, out_version) = on_chan_open_init_execute(
             &mut ctx,
             order,
             &connection_hops,
@@ -842,11 +556,11 @@ pub(crate) mod test {
     /// If the relayer passed in an unsupported version, then fail
     #[test]
     fn test_on_chan_open_init_incorrect_version() {
-        let (mut ctx, order, connection_hops, port_id, channel_id, counterparty) = get_defaults();
+        let (ctx, order, connection_hops, port_id, channel_id, counterparty) = get_defaults();
 
         let in_version = Version::new("some-unsupported-version".to_string());
-        let res = on_chan_open_init(
-            &mut ctx,
+        let res = on_chan_open_init_validate(
+            &ctx,
             order,
             &connection_hops,
             &port_id,
@@ -865,7 +579,7 @@ pub(crate) mod test {
 
         let counterparty_version = Version::new(VERSION.to_string());
 
-        let (_, out_version) = on_chan_open_try(
+        let (_, out_version) = on_chan_open_try_execute(
             &mut ctx,
             order,
             &connection_hops,
@@ -882,12 +596,12 @@ pub(crate) mod test {
     /// If the counterparty doesn't support ics20, then fail
     #[test]
     fn test_on_chan_open_try_counterparty_incorrect_version() {
-        let (mut ctx, order, connection_hops, port_id, channel_id, counterparty) = get_defaults();
+        let (ctx, order, connection_hops, port_id, channel_id, counterparty) = get_defaults();
 
         let counterparty_version = Version::new("some-unsupported-version".to_string());
 
-        let res = on_chan_open_try(
-            &mut ctx,
+        let res = on_chan_open_try_validate(
+            &ctx,
             order,
             &connection_hops,
             &port_id,

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -9,7 +9,7 @@ use crate::applications::transfer::relay::refund_packet_token;
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
 use crate::core::ics04_channel::commitment::PacketCommitment;
-use crate::core::ics04_channel::context::SendPacketReader;
+use crate::core::ics04_channel::context::SendPacketValidationContext;
 use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
@@ -105,7 +105,7 @@ pub trait TokenTransferValidationContext: ValidationContext {
     }
 }
 
-pub trait TokenTransferReader: SendPacketReader {
+pub trait TokenTransferReader: SendPacketValidationContext {
     type AccountId: TryFrom<Signer>;
 
     /// get_port returns the portID for the transfer module.

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -9,7 +9,9 @@ use crate::applications::transfer::relay::refund_packet_token;
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
 use crate::core::ics04_channel::commitment::PacketCommitment;
-use crate::core::ics04_channel::context::SendPacketValidationContext;
+use crate::core::ics04_channel::context::{
+    SendPacketExecutionContext, SendPacketValidationContext,
+};
 use crate::core::ics04_channel::handler::send_packet::SendPacketResult;
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
@@ -18,7 +20,7 @@ use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 use crate::core::ics24_host::path::{CommitmentPath, SeqSendPath};
 use crate::core::ics26_routing::context::ModuleOutputBuilder;
-use crate::core::{ContextError, ExecutionContext, ValidationContext};
+use crate::core::{ContextError, ExecutionContext};
 use crate::prelude::*;
 use crate::signer::Signer;
 
@@ -55,7 +57,9 @@ pub trait TokenTransferKeeper: BankKeeper {
     ) -> Result<(), ContextError>;
 }
 
-pub trait TokenTransferExecutionContext: TokenTransferValidationContext + ExecutionContext {
+pub trait TokenTransferExecutionContext:
+    TokenTransferValidationContext + SendPacketExecutionContext
+{
     /// This function should enable sending ibc fungible tokens from one account to another
     fn send_coins(
         &mut self,
@@ -79,7 +83,7 @@ pub trait TokenTransferExecutionContext: TokenTransferValidationContext + Execut
     ) -> Result<(), TokenTransferError>;
 }
 
-pub trait TokenTransferValidationContext: ValidationContext {
+pub trait TokenTransferValidationContext: SendPacketValidationContext {
     type AccountId: TryFrom<Signer>;
 
     /// get_port returns the portID for the transfer module.

--- a/crates/ibc/src/applications/transfer/relay.rs
+++ b/crates/ibc/src/applications/transfer/relay.rs
@@ -1,16 +1,17 @@
 //! This module implements the processing logic for ICS20 (token transfer) message.
-use crate::applications::transfer::context::TokenTransferContext;
 use crate::applications::transfer::error::TokenTransferError;
 use crate::applications::transfer::is_sender_chain_source;
 use crate::applications::transfer::packet::PacketData;
 use crate::core::ics04_channel::packet::Packet;
 use crate::prelude::*;
 
+use super::context::{TokenTransferExecutionContext, TokenTransferValidationContext};
+
 pub mod on_recv_packet;
 pub mod send_transfer;
 
 pub fn refund_packet_token(
-    ctx: &mut impl TokenTransferContext,
+    ctx: &mut impl TokenTransferExecutionContext,
     packet: &Packet,
     data: &PacketData,
 ) -> Result<(), TokenTransferError> {
@@ -37,10 +38,11 @@ pub fn refund_packet_token(
     }
 }
 
-pub fn refund_packet_token_validate<Ctx: TokenTransferContext>(
-    data: &PacketData,
-) -> Result<(), TokenTransferError> {
-    let _sender: <Ctx as TokenTransferContext>::AccountId = data
+pub fn refund_packet_token_validate<Ctx>(data: &PacketData) -> Result<(), TokenTransferError>
+where
+    Ctx: TokenTransferValidationContext,
+{
+    let _sender: Ctx::AccountId = data
         .sender
         .clone()
         .try_into()

--- a/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
@@ -5,63 +5,7 @@ use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::{is_receiver_chain_source, TracePrefix};
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::packet::Packet;
-use crate::core::ics26_routing::context::ModuleOutputBuilder;
 use crate::prelude::*;
-
-// TODO: REMOVE BEFORE MERGE
-pub fn process_recv_packet<Ctx: 'static + TokenTransferExecutionContext>(
-    ctx: &mut Ctx,
-    output: &mut ModuleOutputBuilder,
-    packet: &Packet,
-    data: PacketData,
-) -> Result<(), TokenTransferError> {
-    if !ctx.is_receive_enabled() {
-        return Err(TokenTransferError::ReceiveDisabled);
-    }
-
-    let receiver_account = data
-        .receiver
-        .clone()
-        .try_into()
-        .map_err(|_| TokenTransferError::ParseAccountFailure)?;
-
-    if is_receiver_chain_source(
-        packet.port_on_a.clone(),
-        packet.chan_on_a.clone(),
-        &data.token.denom,
-    ) {
-        // sender chain is not the source, unescrow tokens
-        let prefix = TracePrefix::new(packet.port_on_a.clone(), packet.chan_on_a.clone());
-        let coin = {
-            let mut c = data.token;
-            c.denom.remove_trace_prefix(&prefix);
-            c
-        };
-
-        let escrow_address =
-            ctx.get_channel_escrow_address(&packet.port_on_b, &packet.chan_on_b)?;
-
-        ctx.send_coins(&escrow_address, &receiver_account, &coin)?;
-    } else {
-        // sender chain is the source, mint vouchers
-        let prefix = TracePrefix::new(packet.port_on_b.clone(), packet.chan_on_b.clone());
-        let coin = {
-            let mut c = data.token;
-            c.denom.add_trace_prefix(prefix);
-            c
-        };
-
-        let denom_trace_event = DenomTraceEvent {
-            trace_hash: ctx.denom_hash_string(&coin.denom),
-            denom: coin.denom.clone(),
-        };
-        output.emit(denom_trace_event.into());
-
-        ctx.mint_coins(&receiver_account, &coin)?;
-    }
-
-    Ok(())
-}
 
 pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
     ctx: &mut Ctx,

--- a/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
@@ -1,4 +1,4 @@
-use crate::applications::transfer::context::TokenTransferContext;
+use crate::applications::transfer::context::TokenTransferExecutionContext;
 use crate::applications::transfer::error::TokenTransferError;
 use crate::applications::transfer::events::DenomTraceEvent;
 use crate::applications::transfer::packet::PacketData;
@@ -8,7 +8,8 @@ use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics26_routing::context::ModuleOutputBuilder;
 use crate::prelude::*;
 
-pub fn process_recv_packet<Ctx: 'static + TokenTransferContext>(
+// TODO: REMOVE BEFORE MERGE
+pub fn process_recv_packet<Ctx: 'static + TokenTransferExecutionContext>(
     ctx: &mut Ctx,
     output: &mut ModuleOutputBuilder,
     packet: &Packet,
@@ -62,7 +63,7 @@ pub fn process_recv_packet<Ctx: 'static + TokenTransferContext>(
     Ok(())
 }
 
-pub fn process_recv_packet_execute<Ctx: TokenTransferContext>(
+pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
     ctx: &mut Ctx,
     packet: &Packet,
     data: PacketData,

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -12,6 +12,9 @@ use crate::core::ics24_host::path::{ChannelEndPath, SeqSendPath};
 use crate::events::ModuleEvent;
 use crate::prelude::*;
 
+/// This function handles the transfer sending logic.
+/// If this method returns an error, the runtime is expected to rollback all state modifications to
+/// the `Ctx` caused by all messages from the transaction that this `msg` is a part of.
 pub fn send_transfer<C, Ctx>(ctx_a: &mut Ctx, msg: MsgTransfer<C>) -> Result<(), TokenTransferError>
 where
     C: TryInto<PrefixedCoin> + Clone,

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -6,7 +6,7 @@ use crate::applications::transfer::events::TransferEvent;
 use crate::applications::transfer::msgs::transfer::MsgTransfer;
 use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::{is_sender_chain_source, Coin, PrefixedCoin};
-use crate::core::ics04_channel::handler::send_packet::send_packet;
+use crate::core::ics04_channel::handler::send_packet::{send_packet, send_packet_validate};
 use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics24_host::path::{ChannelEndPath, SeqSendPath};
 use crate::events::ModuleEvent;
@@ -139,28 +139,58 @@ where
         .channel_end(&chan_end_path_on_a)
         .map_err(TokenTransferError::ContextError)?;
 
-    let _chan_on_b = chan_end_on_a.counterparty().channel_id().ok_or_else(|| {
-        TokenTransferError::DestinationChannelNotFound {
+    let port_on_b = chan_end_on_a.counterparty().port_id().clone();
+    let chan_on_b = chan_end_on_a
+        .counterparty()
+        .channel_id()
+        .ok_or_else(|| TokenTransferError::DestinationChannelNotFound {
             port_id: msg.port_on_a.clone(),
             channel_id: msg.chan_on_a.clone(),
-        }
-    })?;
+        })?
+        .clone();
 
     let seq_send_path_on_a = SeqSendPath::new(&msg.port_on_a, &msg.chan_on_a);
-    let _sequence = ctx_a
+    let sequence = ctx_a
         .get_next_sequence_send(&seq_send_path_on_a)
         .map_err(TokenTransferError::ContextError)?;
 
-    let _token = msg
+    let token = msg
         .token
         .try_into()
         .map_err(|_| TokenTransferError::InvalidToken)?;
+    let denom = token.denom.clone();
+    let coin = Coin {
+        denom,
+        amount: token.amount,
+    };
 
     let _sender: Ctx::AccountId = msg
         .sender
         .clone()
         .try_into()
         .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+
+    let data = {
+        let data = PacketData {
+            token: coin,
+            sender: msg.sender.clone(),
+            receiver: msg.receiver.clone(),
+        };
+        serde_json::to_vec(&data).expect("PacketData's infallible Serialize impl failed")
+    };
+
+    let packet = Packet {
+        sequence,
+        port_on_a: msg.port_on_a,
+        chan_on_a: msg.chan_on_a,
+        port_on_b,
+        chan_on_b,
+        data,
+        timeout_height_on_b: msg.timeout_height_on_b,
+        timeout_timestamp_on_b: msg.timeout_timestamp_on_b,
+    };
+
+    send_packet_validate(ctx_a, packet).map_err(TokenTransferError::ContextError)?;
 
     Ok(())
 }

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -139,13 +139,12 @@ where
         .channel_end(&chan_end_path_on_a)
         .map_err(TokenTransferError::ContextError)?;
 
-    let _chan_on_b = chan_end_on_a
-        .counterparty()
-        .channel_id()
-        .ok_or_else(|| TokenTransferError::DestinationChannelNotFound {
+    let _chan_on_b = chan_end_on_a.counterparty().channel_id().ok_or_else(|| {
+        TokenTransferError::DestinationChannelNotFound {
             port_id: msg.port_on_a.clone(),
             channel_id: msg.chan_on_a.clone(),
-        })?;
+        }
+    })?;
 
     let seq_send_path_on_a = SeqSendPath::new(&msg.port_on_a, &msg.chan_on_a);
     let _sequence = ctx_a

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -1,127 +1,24 @@
 use crate::applications::transfer::context::{
-    TokenTransferContext, TokenTransferExecutionContext, TokenTransferValidationContext,
+    TokenTransferExecutionContext, TokenTransferValidationContext,
 };
 use crate::applications::transfer::error::TokenTransferError;
 use crate::applications::transfer::events::TransferEvent;
 use crate::applications::transfer::msgs::transfer::MsgTransfer;
 use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::{is_sender_chain_source, Coin, PrefixedCoin};
-use crate::core::ics04_channel::handler::send_packet::{
-    send_packet, send_packet_execute, send_packet_validate,
-};
+use crate::core::ics04_channel::handler::send_packet::{send_packet_execute, send_packet_validate};
 use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics24_host::path::{ChannelEndPath, SeqSendPath};
 use crate::events::ModuleEvent;
-use crate::handler::{HandlerOutput, HandlerOutputBuilder};
 use crate::prelude::*;
 
-/// This function handles the transfer sending logic.
-/// If this method returns an error, the runtime is expected to rollback all state modifications to
-/// the `Ctx` caused by all messages from the transaction that this `msg` is a part of.
-pub fn send_transfer<Ctx, C>(
-    ctx: &mut Ctx,
-    output: &mut HandlerOutputBuilder<()>,
-    msg: MsgTransfer<C>,
-) -> Result<(), TokenTransferError>
+pub fn send_transfer<C, Ctx>(ctx_a: &mut Ctx, msg: MsgTransfer<C>) -> Result<(), TokenTransferError>
 where
-    Ctx: TokenTransferContext,
-    C: TryInto<PrefixedCoin>,
+    C: TryInto<PrefixedCoin> + Clone,
+    Ctx: TokenTransferExecutionContext,
 {
-    if !ctx.is_send_enabled() {
-        return Err(TokenTransferError::SendDisabled);
-    }
-    let chan_end_path_on_a = ChannelEndPath::new(&msg.port_on_a, &msg.chan_on_a);
-    let chan_end_on_a = ctx
-        .channel_end(&chan_end_path_on_a)
-        .map_err(TokenTransferError::ContextError)?;
-
-    let port_on_b = chan_end_on_a.counterparty().port_id().clone();
-    let chan_on_b = chan_end_on_a
-        .counterparty()
-        .channel_id()
-        .ok_or_else(|| TokenTransferError::DestinationChannelNotFound {
-            port_id: msg.port_on_a.clone(),
-            channel_id: msg.chan_on_a.clone(),
-        })?
-        .clone();
-
-    // get the next sequence
-    let seq_send_path_on_a = SeqSendPath::new(&msg.port_on_a, &msg.chan_on_a);
-    let sequence = ctx
-        .get_next_sequence_send(&seq_send_path_on_a)
-        .map_err(TokenTransferError::ContextError)?;
-
-    let token = msg
-        .token
-        .try_into()
-        .map_err(|_| TokenTransferError::InvalidToken)?;
-    let denom = token.denom.clone();
-    let coin = Coin {
-        denom: denom.clone(),
-        amount: token.amount,
-    };
-
-    let sender = msg
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| TokenTransferError::ParseAccountFailure)?;
-
-    if is_sender_chain_source(msg.port_on_a.clone(), msg.chan_on_a.clone(), &denom) {
-        let escrow_address = ctx.get_channel_escrow_address(&msg.port_on_a, &msg.chan_on_a)?;
-        ctx.send_coins(&sender, &escrow_address, &coin)?;
-    } else {
-        ctx.burn_coins(&sender, &coin)?;
-    }
-
-    let data = {
-        let data = PacketData {
-            token: coin,
-            sender: msg.sender.clone(),
-            receiver: msg.receiver.clone(),
-        };
-        serde_json::to_vec(&data).expect("PacketData's infallible Serialize impl failed")
-    };
-
-    let packet = Packet {
-        sequence,
-        port_on_a: msg.port_on_a,
-        chan_on_a: msg.chan_on_a,
-        port_on_b,
-        chan_on_b,
-        data,
-        timeout_height_on_b: msg.timeout_height_on_b,
-        timeout_timestamp_on_b: msg.timeout_timestamp_on_b,
-    };
-
-    let HandlerOutput {
-        result,
-        log,
-        events,
-    } = send_packet(ctx, packet).map_err(TokenTransferError::ContextError)?;
-
-    ctx.store_send_packet_result(result)
-        .map_err(TokenTransferError::ContextError)?;
-
-    output.merge_output(
-        HandlerOutput::builder()
-            .with_log(log)
-            .with_events(events)
-            .with_result(()),
-    );
-
-    output.log(format!(
-        "IBC fungible token transfer: {} --({})--> {}",
-        msg.sender, token, msg.receiver
-    ));
-
-    let transfer_event = TransferEvent {
-        sender: msg.sender,
-        receiver: msg.receiver,
-    };
-    output.emit(ModuleEvent::from(transfer_event).into());
-
-    Ok(())
+    send_transfer_validate(ctx_a, msg.clone())?;
+    send_transfer_execute(ctx_a, msg)
 }
 
 pub fn send_transfer_validate<C, Ctx>(
@@ -192,7 +89,7 @@ where
         timeout_timestamp_on_b: msg.timeout_timestamp_on_b,
     };
 
-    send_packet_validate(ctx_a, packet).map_err(TokenTransferError::ContextError)?;
+    send_packet_validate(ctx_a, &packet).map_err(TokenTransferError::ContextError)?;
 
     Ok(())
 }

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -1,12 +1,14 @@
 use crate::applications::transfer::context::{
-    TokenTransferContext, TokenTransferValidationContext,
+    TokenTransferContext, TokenTransferExecutionContext, TokenTransferValidationContext,
 };
 use crate::applications::transfer::error::TokenTransferError;
 use crate::applications::transfer::events::TransferEvent;
 use crate::applications::transfer::msgs::transfer::MsgTransfer;
 use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::{is_sender_chain_source, Coin, PrefixedCoin};
-use crate::core::ics04_channel::handler::send_packet::{send_packet, send_packet_validate};
+use crate::core::ics04_channel::handler::send_packet::{
+    send_packet, send_packet_execute, send_packet_validate,
+};
 use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics24_host::path::{ChannelEndPath, SeqSendPath};
 use crate::events::ModuleEvent;
@@ -191,6 +193,96 @@ where
     };
 
     send_packet_validate(ctx_a, packet).map_err(TokenTransferError::ContextError)?;
+
+    Ok(())
+}
+
+pub fn send_transfer_execute<C, Ctx>(
+    ctx_a: &mut Ctx,
+    msg: MsgTransfer<C>,
+) -> Result<(), TokenTransferError>
+where
+    C: TryInto<PrefixedCoin>,
+    Ctx: TokenTransferExecutionContext,
+{
+    let chan_end_path_on_a = ChannelEndPath::new(&msg.port_on_a, &msg.chan_on_a);
+    let chan_end_on_a = ctx_a
+        .channel_end(&chan_end_path_on_a)
+        .map_err(TokenTransferError::ContextError)?;
+
+    let port_on_b = chan_end_on_a.counterparty().port_id().clone();
+    let chan_on_b = chan_end_on_a
+        .counterparty()
+        .channel_id()
+        .ok_or_else(|| TokenTransferError::DestinationChannelNotFound {
+            port_id: msg.port_on_a.clone(),
+            channel_id: msg.chan_on_a.clone(),
+        })?
+        .clone();
+
+    // get the next sequence
+    let seq_send_path_on_a = SeqSendPath::new(&msg.port_on_a, &msg.chan_on_a);
+    let sequence = ctx_a
+        .get_next_sequence_send(&seq_send_path_on_a)
+        .map_err(TokenTransferError::ContextError)?;
+
+    let token = msg
+        .token
+        .try_into()
+        .map_err(|_| TokenTransferError::InvalidToken)?;
+    let denom = token.denom.clone();
+    let coin = Coin {
+        denom: denom.clone(),
+        amount: token.amount,
+    };
+
+    let sender = msg
+        .sender
+        .clone()
+        .try_into()
+        .map_err(|_| TokenTransferError::ParseAccountFailure)?;
+
+    if is_sender_chain_source(msg.port_on_a.clone(), msg.chan_on_a.clone(), &denom) {
+        let escrow_address = ctx_a.get_channel_escrow_address(&msg.port_on_a, &msg.chan_on_a)?;
+        ctx_a.send_coins(&sender, &escrow_address, &coin)?;
+    } else {
+        ctx_a.burn_coins(&sender, &coin)?;
+    }
+
+    let data = {
+        let data = PacketData {
+            token: coin,
+            sender: msg.sender.clone(),
+            receiver: msg.receiver.clone(),
+        };
+        serde_json::to_vec(&data).expect("PacketData's infallible Serialize impl failed")
+    };
+
+    let packet = Packet {
+        sequence,
+        port_on_a: msg.port_on_a,
+        chan_on_a: msg.chan_on_a,
+        port_on_b,
+        chan_on_b,
+        data,
+        timeout_height_on_b: msg.timeout_height_on_b,
+        timeout_timestamp_on_b: msg.timeout_timestamp_on_b,
+    };
+
+    send_packet_execute(ctx_a, packet).map_err(TokenTransferError::ContextError)?;
+
+    {
+        ctx_a.log_message(format!(
+            "IBC fungible token transfer: {} --({})--> {}",
+            msg.sender, token, msg.receiver
+        ));
+
+        let transfer_event = TransferEvent {
+            sender: msg.sender,
+            receiver: msg.receiver,
+        };
+        ctx_a.emit_ibc_event(ModuleEvent::from(transfer_event).into());
+    }
 
     Ok(())
 }

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -356,7 +356,7 @@ pub trait ValidationContext: Router {
     /// `{revision_number: 0, revision_height: 0}` to be consistent with ibc-go,
     /// where this value is used to mean "no timeout height":
     /// <https://github.com/cosmos/ibc-go/blob/04791984b3d6c83f704c4f058e6ca0038d155d91/modules/core/04-channel/keeper/packet.go#L206>
-    fn packet_commitment(
+    fn compute_packet_commitment(
         &self,
         packet_data: &[u8],
         timeout_height: &TimeoutHeight,

--- a/crates/ibc/src/core/context/acknowledgement.rs
+++ b/crates/ibc/src/core/context/acknowledgement.rs
@@ -165,7 +165,7 @@ mod tests {
 
         let packet = msg.packet.clone();
 
-        let packet_commitment = ctx.packet_commitment(
+        let packet_commitment = ctx.compute_packet_commitment(
             &msg.packet.data,
             &msg.packet.timeout_height_on_b,
             &msg.packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/context/timeout.rs
+++ b/crates/ibc/src/core/context/timeout.rs
@@ -200,7 +200,7 @@ mod tests {
 
         let packet = msg.packet.clone();
 
-        let packet_commitment = ctx.packet_commitment(
+        let packet_commitment = ctx.compute_packet_commitment(
             &msg.packet.data,
             &msg.packet.timeout_height_on_b,
             &msg.packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -85,7 +85,6 @@ mod tests {
     use crate::core::ics26_routing::msgs::MsgEnvelope;
     use crate::core::{dispatch, ValidationContext};
     use crate::events::IbcEvent;
-    use crate::handler::HandlerOutputBuilder;
     use crate::mock::client_state::MockClientState;
     use crate::mock::consensus_state::MockConsensusState;
     use crate::mock::context::MockContext;
@@ -477,7 +476,6 @@ mod tests {
                             .as_any_mut()
                             .downcast_mut::<DummyTransferModule>()
                             .unwrap(),
-                        &mut HandlerOutputBuilder::new(),
                         msg,
                     )
                     .map(|_| ())

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -1,8 +1,11 @@
 //! ICS4 (channel) context.
 
 use crate::core::ics02_client::client_state::ClientState;
-use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath, SeqSendPath};
-use crate::core::{ContextError, ValidationContext};
+use crate::core::ics24_host::path::{
+    ChannelEndPath, ClientConsensusStatePath, CommitmentPath, SeqSendPath,
+};
+use crate::core::{ContextError, ExecutionContext, ValidationContext};
+use crate::events::IbcEvent;
 use crate::prelude::*;
 use core::time::Duration;
 use num_traits::float::FloatCore;
@@ -87,6 +90,55 @@ where
         timeout_timestamp: &Timestamp,
     ) -> PacketCommitment {
         self.compute_packet_commitment(packet_data, timeout_height, timeout_timestamp)
+    }
+}
+
+pub trait SendPacketExecutionContext: SendPacketValidationContext {
+    fn store_next_sequence_send(
+        &mut self,
+        seq_send_path: &SeqSendPath,
+        seq: Sequence,
+    ) -> Result<(), ContextError>;
+
+    fn store_packet_commitment(
+        &mut self,
+        commitment_path: &CommitmentPath,
+        commitment: PacketCommitment,
+    ) -> Result<(), ContextError>;
+
+    /// Ibc events
+    fn emit_ibc_event(&mut self, event: IbcEvent);
+
+    /// Logging facility
+    fn log_message(&mut self, message: String);
+}
+
+impl<T> SendPacketExecutionContext for T
+where
+    T: ExecutionContext,
+{
+    fn store_next_sequence_send(
+        &mut self,
+        seq_send_path: &SeqSendPath,
+        seq: Sequence,
+    ) -> Result<(), ContextError> {
+        self.store_next_sequence_send(seq_send_path, seq)
+    }
+
+    fn store_packet_commitment(
+        &mut self,
+        commitment_path: &CommitmentPath,
+        commitment: PacketCommitment,
+    ) -> Result<(), ContextError> {
+        self.store_packet_commitment(commitment_path, commitment)
+    }
+
+    fn emit_ibc_event(&mut self, event: IbcEvent) {
+        self.emit_ibc_event(event)
+    }
+
+    fn log_message(&mut self, message: String) {
+        self.log_message(message)
     }
 }
 

--- a/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
@@ -61,7 +61,7 @@ where
     };
 
     if commitment_on_a
-        != ctx_a.packet_commitment(
+        != ctx_a.compute_packet_commitment(
             &packet.data,
             &packet.timeout_height_on_b,
             &packet.timeout_timestamp_on_b,
@@ -168,7 +168,7 @@ mod tests {
         .unwrap();
         let packet = msg.packet.clone();
 
-        let packet_commitment = context.packet_commitment(
+        let packet_commitment = context.compute_packet_commitment(
             &packet.data,
             &packet.timeout_height_on_b,
             &packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
@@ -79,7 +79,7 @@ where
             ClientConsensusStatePath::new(client_id_on_b, &msg.proof_height_on_a);
         let consensus_state_of_a_on_b = ctx_b.consensus_state(&client_cons_state_path_on_b)?;
 
-        let expected_commitment_on_a = ctx_b.packet_commitment(
+        let expected_commitment_on_a = ctx_b.compute_packet_commitment(
             &msg.packet.data,
             &msg.packet.timeout_height_on_b,
             &msg.packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -3,7 +3,7 @@ use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::commitment::PacketCommitment;
 use crate::core::ics04_channel::events::SendPacket;
 use crate::core::ics04_channel::packet::Sequence;
-use crate::core::ics04_channel::{context::SendPacketReader, error::PacketError, packet::Packet};
+use crate::core::ics04_channel::{context::SendPacketValidationContext, error::PacketError, packet::Packet};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
 use crate::core::ics24_host::path::ChannelEndPath;
 use crate::core::ics24_host::path::ClientConsensusStatePath;
@@ -29,7 +29,7 @@ pub struct SendPacketResult {
 // TODO BEFORE MERGE: send_packet() should now call validate() and execute()
 
 pub fn send_packet(
-    ctx_a: &impl SendPacketReader,
+    ctx_a: &impl SendPacketValidationContext,
     packet: Packet,
 ) -> HandlerResult<SendPacketResult, ContextError> {
     let mut output = HandlerOutput::builder();
@@ -105,7 +105,7 @@ pub fn send_packet(
         channel_id: packet.chan_on_a.clone(),
         seq: packet.sequence,
         seq_number: next_seq_send_on_a.increment(),
-        commitment: ctx_a.packet_commitment(
+        commitment: ctx_a.compute_packet_commitment(
             &packet.data,
             &packet.timeout_height_on_b,
             &packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -1,139 +1,39 @@
 use crate::core::ics04_channel::channel::Counterparty;
 use crate::core::ics04_channel::channel::State;
-use crate::core::ics04_channel::commitment::PacketCommitment;
 use crate::core::ics04_channel::context::SendPacketExecutionContext;
 use crate::core::ics04_channel::events::SendPacket;
-use crate::core::ics04_channel::packet::Sequence;
 use crate::core::ics04_channel::{
     context::SendPacketValidationContext, error::PacketError, packet::Packet,
 };
-use crate::core::ics24_host::identifier::{ChannelId, PortId};
 use crate::core::ics24_host::path::ChannelEndPath;
 use crate::core::ics24_host::path::ClientConsensusStatePath;
 use crate::core::ics24_host::path::CommitmentPath;
 use crate::core::ics24_host::path::SeqSendPath;
 use crate::core::ContextError;
 use crate::events::IbcEvent;
-use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 use crate::timestamp::Expiry;
 
-// TODO BEFORE MERGE: REMOVE
-#[derive(Clone, Debug)]
-pub struct SendPacketResult {
-    pub port_id: PortId,
-    pub channel_id: ChannelId,
-    pub seq: Sequence,
-    pub seq_number: Sequence,
-    pub commitment: PacketCommitment,
-}
-
-// TODO BEFORE MERGE: send_packet() should now call validate() and execute()
-
+/// Per our convention, this message is processed on chain A.
 pub fn send_packet(
-    ctx_a: &impl SendPacketValidationContext,
+    ctx_a: &mut impl SendPacketExecutionContext,
     packet: Packet,
-) -> HandlerResult<SendPacketResult, ContextError> {
-    let mut output = HandlerOutput::builder();
-
-    let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
-    let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
-
-    if chan_end_on_a.state_matches(&State::Closed) {
-        return Err(PacketError::ChannelClosed {
-            channel_id: packet.chan_on_a,
-        }
-        .into());
-    }
-
-    let counterparty = Counterparty::new(packet.port_on_b.clone(), Some(packet.chan_on_b.clone()));
-
-    if !chan_end_on_a.counterparty_matches(&counterparty) {
-        return Err(PacketError::InvalidPacketCounterparty {
-            port_id: packet.port_on_b.clone(),
-            channel_id: packet.chan_on_b,
-        }
-        .into());
-    }
-    let conn_id_on_a = &chan_end_on_a.connection_hops()[0];
-    let conn_end_on_a = ctx_a.connection_end(conn_id_on_a)?;
-
-    let client_id_on_a = conn_end_on_a.client_id();
-
-    let client_state_of_b_on_a = ctx_a.client_state(client_id_on_a)?;
-
-    // prevent accidental sends with clients that cannot be updated
-    if client_state_of_b_on_a.is_frozen() {
-        return Err(PacketError::FrozenClient {
-            client_id: conn_end_on_a.client_id().clone(),
-        }
-        .into());
-    }
-
-    let latest_height_on_a = client_state_of_b_on_a.latest_height();
-
-    if packet.timeout_height_on_b.has_expired(latest_height_on_a) {
-        return Err(PacketError::LowPacketHeight {
-            chain_height: latest_height_on_a,
-            timeout_height: packet.timeout_height_on_b,
-        }
-        .into());
-    }
-
-    let client_cons_state_path_on_a =
-        ClientConsensusStatePath::new(client_id_on_a, &latest_height_on_a);
-    let consensus_state_of_b_on_a = ctx_a.client_consensus_state(&client_cons_state_path_on_a)?;
-    let latest_timestamp = consensus_state_of_b_on_a.timestamp();
-    let packet_timestamp = packet.timeout_timestamp_on_b;
-    if let Expiry::Expired = latest_timestamp.check_expiry(&packet_timestamp) {
-        return Err(PacketError::LowPacketTimestamp.into());
-    }
-
-    let seq_send_path_on_a = SeqSendPath::new(&packet.port_on_a, &packet.chan_on_a);
-    let next_seq_send_on_a = ctx_a.get_next_sequence_send(&seq_send_path_on_a)?;
-
-    if packet.sequence != next_seq_send_on_a {
-        return Err(PacketError::InvalidPacketSequence {
-            given_sequence: packet.sequence,
-            next_sequence: next_seq_send_on_a,
-        }
-        .into());
-    }
-
-    output.log("success: packet send ");
-
-    let result = SendPacketResult {
-        port_id: packet.port_on_a.clone(),
-        channel_id: packet.chan_on_a.clone(),
-        seq: packet.sequence,
-        seq_number: next_seq_send_on_a.increment(),
-        commitment: ctx_a.compute_packet_commitment(
-            &packet.data,
-            &packet.timeout_height_on_b,
-            &packet.timeout_timestamp_on_b,
-        ),
-    };
-
-    output.emit(IbcEvent::SendPacket(SendPacket::new(
-        packet,
-        chan_end_on_a.ordering,
-        conn_id_on_a.clone(),
-    )));
-
-    Ok(output.with_result(result))
+) -> Result<(), ContextError> {
+    send_packet_validate(ctx_a, &packet)?;
+    send_packet_execute(ctx_a, packet)
 }
 
 /// Per our convention, this message is processed on chain A.
 pub fn send_packet_validate(
     ctx_a: &impl SendPacketValidationContext,
-    packet: Packet,
+    packet: &Packet,
 ) -> Result<(), ContextError> {
     let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
 
     if chan_end_on_a.state_matches(&State::Closed) {
         return Err(PacketError::ChannelClosed {
-            channel_id: packet.chan_on_a,
+            channel_id: packet.chan_on_a.clone(),
         }
         .into());
     }
@@ -143,7 +43,7 @@ pub fn send_packet_validate(
     if !chan_end_on_a.counterparty_matches(&counterparty) {
         return Err(PacketError::InvalidPacketCounterparty {
             port_id: packet.port_on_b.clone(),
-            channel_id: packet.chan_on_b,
+            channel_id: packet.chan_on_b.clone(),
         }
         .into());
     }
@@ -389,11 +289,11 @@ mod tests {
         .into_iter()
         .collect();
 
-        for test in tests {
-            let res = send_packet(&test.ctx, test.packet.clone());
+        for mut test in tests {
+            let res = send_packet(&mut test.ctx, test.packet.clone());
             // Additionally check the events and the output objects in the result.
             match res {
-                Ok(proto_output) => {
+                Ok(()) => {
                     assert!(
                         test.want_pass,
                         "send_packet: test passed but was supposed to fail for test: {}, \nparams {:?} {:?}",
@@ -402,10 +302,10 @@ mod tests {
                         test.ctx.clone()
                     );
 
-                    assert!(!proto_output.events.is_empty()); // Some events must exist.
+                    assert!(!test.ctx.events.is_empty()); // Some events must exist.
 
                     // TODO: The object in the output is a PacketResult what can we check on it?
-                    for e in proto_output.events.iter() {
+                    for e in test.ctx.events.iter() {
                         assert!(matches!(e, &IbcEvent::SendPacket(_)));
                     }
                 }

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -1,16 +1,18 @@
 use crate::core::ics04_channel::channel::Counterparty;
 use crate::core::ics04_channel::channel::State;
 use crate::core::ics04_channel::commitment::PacketCommitment;
+use crate::core::ics04_channel::context::SendPacketExecutionContext;
 use crate::core::ics04_channel::events::SendPacket;
 use crate::core::ics04_channel::packet::Sequence;
-use crate::core::ics04_channel::{context::SendPacketValidationContext, error::PacketError, packet::Packet};
+use crate::core::ics04_channel::{
+    context::SendPacketValidationContext, error::PacketError, packet::Packet,
+};
 use crate::core::ics24_host::identifier::{ChannelId, PortId};
 use crate::core::ics24_host::path::ChannelEndPath;
 use crate::core::ics24_host::path::ClientConsensusStatePath;
 use crate::core::ics24_host::path::CommitmentPath;
 use crate::core::ics24_host::path::SeqSendPath;
 use crate::core::ContextError;
-use crate::core::ExecutionContext;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
@@ -195,7 +197,7 @@ pub fn send_packet_validate(
 
 /// Per our convention, this message is processed on chain A.
 pub fn send_packet_execute(
-    ctx_a: &mut impl ExecutionContext,
+    ctx_a: &mut impl SendPacketExecutionContext,
     packet: Packet,
 ) -> Result<(), ContextError> {
     {

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -11,12 +11,12 @@ use crate::core::ics24_host::path::CommitmentPath;
 use crate::core::ics24_host::path::SeqSendPath;
 use crate::core::ContextError;
 use crate::core::ExecutionContext;
-use crate::core::ValidationContext;
 use crate::events::IbcEvent;
 use crate::handler::{HandlerOutput, HandlerResult};
 use crate::prelude::*;
 use crate::timestamp::Expiry;
 
+// TODO BEFORE MERGE: REMOVE
 #[derive(Clone, Debug)]
 pub struct SendPacketResult {
     pub port_id: PortId,
@@ -123,7 +123,7 @@ pub fn send_packet(
 
 /// Per our convention, this message is processed on chain A.
 pub fn send_packet_validate(
-    ctx_a: &impl ValidationContext,
+    ctx_a: &impl SendPacketValidationContext,
     packet: Packet,
 ) -> Result<(), ContextError> {
     let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -108,11 +108,7 @@ pub fn send_packet_execute(
     }
 
     ctx_a.store_packet_commitment(
-        &CommitmentPath {
-            port_id: packet.port_on_a.clone(),
-            channel_id: packet.chan_on_a.clone(),
-            sequence: packet.sequence,
-        },
+        &CommitmentPath::new(&packet.port_on_a, &packet.chan_on_a, packet.sequence),
         ctx_a.compute_packet_commitment(
             &packet.data,
             &packet.timeout_height_on_b,

--- a/crates/ibc/src/core/ics04_channel/handler/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout.rs
@@ -59,7 +59,7 @@ where
         Err(_) => return Ok(()),
     };
 
-    let expected_commitment_on_a = ctx_a.packet_commitment(
+    let expected_commitment_on_a = ctx_a.compute_packet_commitment(
         &msg.packet.data,
         &msg.packet.timeout_height_on_b,
         &msg.packet.timeout_timestamp_on_b,
@@ -196,7 +196,7 @@ mod tests {
         .unwrap();
         let packet = msg.packet.clone();
 
-        let packet_commitment = context.packet_commitment(
+        let packet_commitment = context.compute_packet_commitment(
             &msg.packet.data,
             &msg.packet.timeout_height_on_b,
             &msg.packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -44,7 +44,7 @@ where
         Err(_) => return Ok(()),
     };
 
-    let expected_commitment_on_a = ctx_a.packet_commitment(
+    let expected_commitment_on_a = ctx_a.compute_packet_commitment(
         &packet.data,
         &packet.timeout_height_on_b,
         &packet.timeout_timestamp_on_b,
@@ -204,7 +204,7 @@ mod tests {
 
         let packet = msg.packet.clone();
 
-        let packet_commitment = context.packet_commitment(
+        let packet_commitment = context.compute_packet_commitment(
             &msg.packet.data,
             &msg.packet.timeout_height_on_b,
             &msg.packet.timeout_timestamp_on_b,

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -89,17 +89,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
     ) -> Result<(ModuleExtras, Version), ChannelError>;
 
     #[allow(clippy::too_many_arguments)]
-    fn on_chan_open_init(
-        &mut self,
-        order: Order,
-        connection_hops: &[ConnectionId],
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        counterparty: &Counterparty,
-        version: &Version,
-    ) -> Result<(ModuleExtras, Version), ChannelError>;
-
-    #[allow(clippy::too_many_arguments)]
     fn on_chan_open_try_validate(
         &self,
         order: Order,
@@ -112,17 +101,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
 
     #[allow(clippy::too_many_arguments)]
     fn on_chan_open_try_execute(
-        &mut self,
-        order: Order,
-        connection_hops: &[ConnectionId],
-        port_id: &PortId,
-        channel_id: &ChannelId,
-        counterparty: &Counterparty,
-        counterparty_version: &Version,
-    ) -> Result<(ModuleExtras, Version), ChannelError>;
-
-    #[allow(clippy::too_many_arguments)]
-    fn on_chan_open_try(
         &mut self,
         order: Order,
         connection_hops: &[ConnectionId],
@@ -150,15 +128,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
         Ok(ModuleExtras::empty())
     }
 
-    fn on_chan_open_ack(
-        &mut self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty_version: &Version,
-    ) -> Result<ModuleExtras, ChannelError> {
-        Ok(ModuleExtras::empty())
-    }
-
     fn on_chan_open_confirm_validate(
         &self,
         _port_id: &PortId,
@@ -168,14 +137,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
     }
 
     fn on_chan_open_confirm_execute(
-        &mut self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-    ) -> Result<ModuleExtras, ChannelError> {
-        Ok(ModuleExtras::empty())
-    }
-
-    fn on_chan_open_confirm(
         &mut self,
         _port_id: &PortId,
         _channel_id: &ChannelId,
@@ -199,14 +160,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
         Ok(ModuleExtras::empty())
     }
 
-    fn on_chan_close_init(
-        &mut self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-    ) -> Result<ModuleExtras, ChannelError> {
-        Ok(ModuleExtras::empty())
-    }
-
     fn on_chan_close_confirm_validate(
         &self,
         _port_id: &PortId,
@@ -216,14 +169,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
     }
 
     fn on_chan_close_confirm_execute(
-        &mut self,
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-    ) -> Result<ModuleExtras, ChannelError> {
-        Ok(ModuleExtras::empty())
-    }
-
-    fn on_chan_close_confirm(
         &mut self,
         _port_id: &PortId,
         _channel_id: &ChannelId,

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -14,8 +14,6 @@ use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
-use crate::events::ModuleEvent;
-use crate::handler::HandlerOutputBuilder;
 use crate::signer::Signer;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -66,8 +64,6 @@ impl Borrow<str> for ModuleId {
         self.0.as_str()
     }
 }
-
-pub type ModuleOutputBuilder = HandlerOutputBuilder<(), ModuleEvent>;
 
 pub trait Module: Send + Sync + AsAnyMut + Debug {
     #[allow(clippy::too_many_arguments)]
@@ -255,16 +251,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
         _relayer: &Signer,
     ) -> (ModuleExtras, Result<(), PacketError>);
 
-    fn on_acknowledgement_packet(
-        &mut self,
-        _output: &mut ModuleOutputBuilder,
-        _packet: &Packet,
-        _acknowledgement: &Acknowledgement,
-        _relayer: &Signer,
-    ) -> Result<(), PacketError> {
-        Ok(())
-    }
-
     /// Note: `MsgTimeout` and `MsgTimeoutOnClose` use the same callback
 
     fn on_timeout_packet_validate(
@@ -280,15 +266,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
         packet: &Packet,
         relayer: &Signer,
     ) -> (ModuleExtras, Result<(), PacketError>);
-
-    fn on_timeout_packet(
-        &mut self,
-        _output: &mut ModuleOutputBuilder,
-        _packet: &Packet,
-        _relayer: &Signer,
-    ) -> Result<(), PacketError> {
-        Ok(())
-    }
 }
 
 pub trait AsAnyMut: Any {

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -241,13 +241,6 @@ pub trait Module: Send + Sync + AsAnyMut + Debug {
         relayer: &Signer,
     ) -> (ModuleExtras, Acknowledgement);
 
-    fn on_recv_packet(
-        &mut self,
-        _output: &mut ModuleOutputBuilder,
-        _packet: &Packet,
-        _relayer: &Signer,
-    ) -> Acknowledgement;
-
     fn on_acknowledgement_packet_validate(
         &self,
         _packet: &Packet,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1407,7 +1407,7 @@ mod tests {
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::ChainId;
     use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
-    use crate::core::ics26_routing::context::{Module, ModuleId, ModuleOutputBuilder};
+    use crate::core::ics26_routing::context::{Module, ModuleId};
     use crate::mock::context::MockContext;
     use crate::mock::host::HostType;
     use crate::signer::Signer;
@@ -1646,17 +1646,6 @@ mod tests {
                 )
             }
 
-            fn on_recv_packet(
-                &mut self,
-                _output: &mut ModuleOutputBuilder,
-                _packet: &Packet,
-                _relayer: &Signer,
-            ) -> Acknowledgement {
-                self.counter += 1;
-
-                Acknowledgement::try_from(vec![1u8]).unwrap()
-            }
-
             fn on_timeout_packet_validate(
                 &self,
                 _packet: &Packet,
@@ -1779,15 +1768,6 @@ mod tests {
                 )
             }
 
-            fn on_recv_packet(
-                &mut self,
-                _output: &mut ModuleOutputBuilder,
-                _packet: &Packet,
-                _relayer: &Signer,
-            ) -> Acknowledgement {
-                Acknowledgement::try_from(vec![1u8]).unwrap()
-            }
-
             fn on_timeout_packet_validate(
                 &self,
                 _packet: &Packet,
@@ -1837,8 +1817,7 @@ mod tests {
         let mut on_recv_packet_result = |module_id: &'static str| {
             let module_id = ModuleId::from_str(module_id).unwrap();
             let m = ctx.get_route_mut(&module_id).unwrap();
-            let result = m.on_recv_packet(
-                &mut ModuleOutputBuilder::new(),
+            let result = m.on_recv_packet_execute(
                 &Packet::default(),
                 &get_dummy_bech32_account().parse().unwrap(),
             );

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1585,18 +1585,6 @@ mod tests {
                 Ok((ModuleExtras::empty(), version.clone()))
             }
 
-            fn on_chan_open_init(
-                &mut self,
-                _order: Order,
-                _connection_hops: &[ConnectionId],
-                _port_id: &PortId,
-                _channel_id: &ChannelId,
-                _counterparty: &Counterparty,
-                version: &Version,
-            ) -> Result<(ModuleExtras, Version), ChannelError> {
-                Ok((ModuleExtras::empty(), version.clone()))
-            }
-
             fn on_chan_open_try_validate(
                 &self,
                 _order: Order,
@@ -1610,18 +1598,6 @@ mod tests {
             }
 
             fn on_chan_open_try_execute(
-                &mut self,
-                _order: Order,
-                _connection_hops: &[ConnectionId],
-                _port_id: &PortId,
-                _channel_id: &ChannelId,
-                _counterparty: &Counterparty,
-                counterparty_version: &Version,
-            ) -> Result<(ModuleExtras, Version), ChannelError> {
-                Ok((ModuleExtras::empty(), counterparty_version.clone()))
-            }
-
-            fn on_chan_open_try(
                 &mut self,
                 _order: Order,
                 _connection_hops: &[ConnectionId],
@@ -1709,18 +1685,6 @@ mod tests {
                 Ok((ModuleExtras::empty(), version.clone()))
             }
 
-            fn on_chan_open_init(
-                &mut self,
-                _order: Order,
-                _connection_hops: &[ConnectionId],
-                _port_id: &PortId,
-                _channel_id: &ChannelId,
-                _counterparty: &Counterparty,
-                version: &Version,
-            ) -> Result<(ModuleExtras, Version), ChannelError> {
-                Ok((ModuleExtras::empty(), version.clone()))
-            }
-
             fn on_chan_open_try_validate(
                 &self,
                 _order: Order,
@@ -1734,18 +1698,6 @@ mod tests {
             }
 
             fn on_chan_open_try_execute(
-                &mut self,
-                _order: Order,
-                _connection_hops: &[ConnectionId],
-                _port_id: &PortId,
-                _channel_id: &ChannelId,
-                _counterparty: &Counterparty,
-                counterparty_version: &Version,
-            ) -> Result<(ModuleExtras, Version), ChannelError> {
-                Ok((ModuleExtras::empty(), counterparty_version.clone()))
-            }
-
-            fn on_chan_open_try(
                 &mut self,
                 _order: Order,
                 _connection_hops: &[ConnectionId],

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -109,24 +109,6 @@ impl Module for DummyTransferModule {
         Ok((ModuleExtras::empty(), version.clone()))
     }
 
-    fn on_chan_open_init(
-        &mut self,
-        _order: Order,
-        _connection_hops: &[ConnectionId],
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty: &Counterparty,
-        version: &Version,
-    ) -> Result<(ModuleExtras, Version), ChannelError> {
-        Ok((
-            ModuleExtras {
-                events: Vec::new(),
-                log: Vec::new(),
-            },
-            version.clone(),
-        ))
-    }
-
     fn on_chan_open_try_validate(
         &self,
         _order: Order,
@@ -149,24 +131,6 @@ impl Module for DummyTransferModule {
         counterparty_version: &Version,
     ) -> Result<(ModuleExtras, Version), ChannelError> {
         Ok((ModuleExtras::empty(), counterparty_version.clone()))
-    }
-
-    fn on_chan_open_try(
-        &mut self,
-        _order: Order,
-        _connection_hops: &[ConnectionId],
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty: &Counterparty,
-        counterparty_version: &Version,
-    ) -> Result<(ModuleExtras, Version), ChannelError> {
-        Ok((
-            ModuleExtras {
-                events: Vec::new(),
-                log: Vec::new(),
-            },
-            counterparty_version.clone(),
-        ))
     }
 
     fn on_recv_packet_execute(

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -5,8 +5,7 @@ use subtle_encoding::bech32;
 use tendermint::{block, consensus, evidence, public_key::Algorithm};
 
 use crate::applications::transfer::context::{
-    cosmos_adr028_escrow_address, BankKeeper, TokenTransferContext, TokenTransferKeeper,
-    TokenTransferReader,
+    cosmos_adr028_escrow_address, TokenTransferExecutionContext, TokenTransferValidationContext,
 };
 use crate::applications::transfer::{error::TokenTransferError, PrefixedCoin};
 use crate::core::ics02_client::client_state::ClientState;
@@ -16,16 +15,21 @@ use crate::core::ics03_connection::connection::ConnectionEnd;
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, Order};
 use crate::core::ics04_channel::commitment::PacketCommitment;
-use crate::core::ics04_channel::context::SendPacketValidationContext;
+use crate::core::ics04_channel::context::{
+    SendPacketExecutionContext, SendPacketValidationContext,
+};
 use crate::core::ics04_channel::error::{ChannelError, PacketError};
 use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::msgs::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::packet::{Packet, Sequence};
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId};
-use crate::core::ics24_host::path::{ChannelEndPath, ClientConsensusStatePath, SeqSendPath};
+use crate::core::ics24_host::path::{
+    ChannelEndPath, ClientConsensusStatePath, CommitmentPath, SeqSendPath,
+};
 use crate::core::ics26_routing::context::{Module, ModuleOutputBuilder};
 use crate::core::ContextError;
+use crate::events::IbcEvent;
 use crate::mock::context::MockIbcStore;
 use crate::prelude::*;
 use crate::signer::Signer;
@@ -220,44 +224,32 @@ impl Module for DummyTransferModule {
     }
 }
 
-impl TokenTransferKeeper for DummyTransferModule {
-    fn store_packet_commitment(
-        &mut self,
-        port_id: PortId,
-        channel_id: ChannelId,
-        seq: Sequence,
-        commitment: PacketCommitment,
-    ) -> Result<(), ContextError> {
-        self.ibc_store
-            .lock()
-            .packet_commitment
-            .entry(port_id)
-            .or_default()
-            .entry(channel_id)
-            .or_default()
-            .insert(seq, commitment);
-        Ok(())
+impl TokenTransferValidationContext for DummyTransferModule {
+    type AccountId = Signer;
+
+    fn get_port(&self) -> Result<PortId, TokenTransferError> {
+        Ok(PortId::transfer())
     }
 
-    fn store_next_sequence_send(
-        &mut self,
-        port_id: PortId,
-        channel_id: ChannelId,
-        seq: Sequence,
-    ) -> Result<(), ContextError> {
-        self.ibc_store
-            .lock()
-            .next_sequence_send
-            .entry(port_id)
-            .or_default()
-            .insert(channel_id, seq);
-        Ok(())
+    fn get_channel_escrow_address(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<Self::AccountId, TokenTransferError> {
+        let addr = cosmos_adr028_escrow_address(port_id, channel_id);
+        Ok(bech32::encode("cosmos", addr).parse().unwrap())
+    }
+
+    fn is_send_enabled(&self) -> bool {
+        true
+    }
+
+    fn is_receive_enabled(&self) -> bool {
+        true
     }
 }
 
-impl BankKeeper for DummyTransferModule {
-    type AccountId = Signer;
-
+impl TokenTransferExecutionContext for DummyTransferModule {
     fn send_coins(
         &mut self,
         _from: &Self::AccountId,
@@ -281,31 +273,6 @@ impl BankKeeper for DummyTransferModule {
         _amt: &PrefixedCoin,
     ) -> Result<(), TokenTransferError> {
         Ok(())
-    }
-}
-
-impl TokenTransferReader for DummyTransferModule {
-    type AccountId = Signer;
-
-    fn get_port(&self) -> Result<PortId, TokenTransferError> {
-        Ok(PortId::transfer())
-    }
-
-    fn get_channel_escrow_address(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<<Self as TokenTransferReader>::AccountId, TokenTransferError> {
-        let addr = cosmos_adr028_escrow_address(port_id, channel_id);
-        Ok(bech32::encode("cosmos", addr).parse().unwrap())
-    }
-
-    fn is_send_enabled(&self) -> bool {
-        true
-    }
-
-    fn is_receive_enabled(&self) -> bool {
-        true
     }
 }
 
@@ -431,6 +398,45 @@ impl SendPacketValidationContext for DummyTransferModule {
     }
 }
 
-impl TokenTransferContext for DummyTransferModule {
-    type AccountId = Signer;
+impl SendPacketExecutionContext for DummyTransferModule {
+    fn store_packet_commitment(
+        &mut self,
+        commitment_path: &CommitmentPath,
+        commitment: PacketCommitment,
+    ) -> Result<(), ContextError> {
+        let port_id = commitment_path.port_id.clone();
+        let channel_id = commitment_path.channel_id.clone();
+        let seq = commitment_path.sequence;
+
+        self.ibc_store
+            .lock()
+            .packet_commitment
+            .entry(port_id)
+            .or_default()
+            .entry(channel_id)
+            .or_default()
+            .insert(seq, commitment);
+        Ok(())
+    }
+
+    fn store_next_sequence_send(
+        &mut self,
+        seq_send_path: &SeqSendPath,
+        seq: Sequence,
+    ) -> Result<(), ContextError> {
+        let port_id = seq_send_path.0.clone();
+        let channel_id = seq_send_path.1.clone();
+
+        self.ibc_store
+            .lock()
+            .next_sequence_send
+            .entry(port_id)
+            .or_default()
+            .insert(channel_id, seq);
+        Ok(())
+    }
+
+    fn emit_ibc_event(&mut self, _event: IbcEvent) {}
+
+    fn log_message(&mut self, _message: String) {}
 }

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -27,7 +27,7 @@ use crate::core::ics24_host::identifier::{ChannelId, ClientId, ConnectionId, Por
 use crate::core::ics24_host::path::{
     ChannelEndPath, ClientConsensusStatePath, CommitmentPath, SeqSendPath,
 };
-use crate::core::ics26_routing::context::{Module, ModuleOutputBuilder};
+use crate::core::ics26_routing::context::Module;
 use crate::core::ContextError;
 use crate::events::IbcEvent;
 use crate::mock::context::MockIbcStore;
@@ -178,15 +178,6 @@ impl Module for DummyTransferModule {
             ModuleExtras::empty(),
             Acknowledgement::try_from(vec![1u8]).unwrap(),
         )
-    }
-
-    fn on_recv_packet(
-        &mut self,
-        _output: &mut ModuleOutputBuilder,
-        _packet: &Packet,
-        _relayer: &Signer,
-    ) -> Acknowledgement {
-        Acknowledgement::try_from(vec![1u8]).unwrap()
     }
 
     fn on_timeout_packet_validate(


### PR DESCRIPTION
Closes: #442

+ Separates `send_{packet,transfer}()` into `*_validation()` and `*_execution()`
+ Removes old `ModuleOutput`/`ModuleOutputBuilder` structs
+ Removes unused callback methods in `Module`

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
