### PR TITLE
Allow for non-'static `Module`

### DIFF
--- a/.changelog/unreleased/breaking-changes/490-module-static.md
+++ b/.changelog/unreleased/breaking-changes/490-module-static.md
@@ -1,0 +1,2 @@
+- Allow for non-'static bound Modules ([#490](https://github.com/cosmos/ibc-
+  rs/issues/490))

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -402,34 +402,20 @@ pub(crate) mod test {
     use subtle_encoding::bech32;
 
     use crate::applications::transfer::context::cosmos_adr028_escrow_address;
-    use crate::applications::transfer::error::TokenTransferError;
-    use crate::applications::transfer::msgs::transfer::MsgTransfer;
-    use crate::applications::transfer::relay::send_transfer::send_transfer;
-    use crate::applications::transfer::PrefixedCoin;
     use crate::core::ics04_channel::channel::{Counterparty, Order};
-    use crate::core::ics04_channel::error::ChannelError;
     use crate::core::ics04_channel::Version;
     use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
-    use crate::test_utils::{get_dummy_transfer_module, DummyTransferModule};
-
-    pub(crate) fn deliver(
-        ctx: &mut DummyTransferModule,
-        msg: MsgTransfer<PrefixedCoin>,
-    ) -> Result<(), ChannelError> {
-        send_transfer(ctx, msg).map_err(|e: TokenTransferError| ChannelError::AppModule {
-            description: e.to_string(),
-        })
-    }
+    use crate::test_utils::{get_dummy_transfer_context, DummyTransferContext};
 
     fn get_defaults() -> (
-        DummyTransferModule,
+        DummyTransferContext,
         Order,
         Vec<ConnectionId>,
         PortId,
         ChannelId,
         Counterparty,
     ) {
-        let ctx = get_dummy_transfer_module();
+        let ctx = get_dummy_transfer_context();
         let order = Order::Unordered;
         let connection_hops = vec![ConnectionId::new(1)];
         let port_id = PortId::transfer();

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -387,7 +387,7 @@ impl Ics2ClientState for ClientState {
 
     fn check_misbehaviour_and_update_state(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         client_id: ClientId,
         misbehaviour: Any,
     ) -> Result<Box<dyn Ics2ClientState>, ContextError> {
@@ -456,12 +456,12 @@ impl Ics2ClientState for ClientState {
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         client_id: ClientId,
         header: Any,
     ) -> Result<UpdatedState, ClientError> {
         fn maybe_consensus_state(
-            ctx: &dyn ValidationContext,
+            ctx: &dyn ValidationContext<'_>,
             client_cons_state_path: &ClientConsensusStatePath,
         ) -> Result<Option<Box<dyn ConsensusState>>, ClientError> {
             match ctx.consensus_state(client_cons_state_path) {
@@ -887,7 +887,7 @@ impl Ics2ClientState for ClientState {
 
     fn verify_packet_data(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -911,7 +911,7 @@ impl Ics2ClientState for ClientState {
 
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -936,7 +936,7 @@ impl Ics2ClientState for ClientState {
     #[allow(clippy::too_many_arguments)]
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -966,7 +966,7 @@ impl Ics2ClientState for ClientState {
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -1029,7 +1029,7 @@ fn verify_non_membership(
 }
 
 fn verify_delay_passed(
-    ctx: &dyn ValidationContext,
+    ctx: &dyn ValidationContext<'_>,
     height: Height,
     connection_end: &ConnectionEnd,
 ) -> Result<(), ClientError> {

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -120,12 +120,12 @@ impl std::error::Error for ContextError {
     }
 }
 
-pub trait Router {
+pub trait Router<'m> {
     /// Returns a reference to a `Module` registered against the specified `ModuleId`
-    fn get_route(&self, module_id: &ModuleId) -> Option<&dyn Module>;
+    fn get_route(&self, module_id: &ModuleId) -> Option<&(dyn Module + 'm)>;
 
     /// Returns a mutable reference to a `Module` registered against the specified `ModuleId`
-    fn get_route_mut(&mut self, module_id: &ModuleId) -> Option<&mut dyn Module>;
+    fn get_route_mut(&mut self, module_id: &ModuleId) -> Option<&mut (dyn Module + 'm)>;
 
     /// Returns true if the `Router` has a `Module` registered against the specified `ModuleId`
     fn has_route(&self, module_id: &ModuleId) -> bool;
@@ -166,7 +166,7 @@ pub trait Router {
     }
 }
 
-pub trait ValidationContext: Router {
+pub trait ValidationContext<'m>: Router<'m> {
     /// Validation entrypoint.
     fn validate(&self, msg: MsgEnvelope) -> Result<(), RouterError>
     where
@@ -407,7 +407,7 @@ pub trait ValidationContext: Router {
     }
 }
 
-pub trait ExecutionContext: ValidationContext {
+pub trait ExecutionContext<'m>: ValidationContext<'m> {
     /// Execution entrypoint
     fn execute(&mut self, msg: MsgEnvelope) -> Result<(), RouterError>
     where

--- a/crates/ibc/src/core/context/acknowledgement.rs
+++ b/crates/ibc/src/core/context/acknowledgement.rs
@@ -14,13 +14,13 @@ use crate::{
 
 use super::{ContextError, ExecutionContext, ValidationContext};
 
-pub(super) fn acknowledgement_packet_validate<ValCtx>(
+pub(super) fn acknowledgement_packet_validate<'m, ValCtx>(
     ctx_a: &ValCtx,
     module_id: ModuleId,
     msg: MsgAcknowledgement,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     acknowledgement::validate(ctx_a, &msg)?;
 
@@ -33,13 +33,13 @@ where
         .map_err(ContextError::PacketError)
 }
 
-pub(super) fn acknowledgement_packet_execute<ExecCtx>(
+pub(super) fn acknowledgement_packet_execute<'m, ExecCtx>(
     ctx_a: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgAcknowledgement,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let chan_end_path_on_a = ChannelEndPath::new(&msg.packet.port_on_a, &msg.packet.chan_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
@@ -140,7 +140,7 @@ mod tests {
     };
 
     struct Fixture {
-        ctx: MockContext,
+        ctx: MockContext<'static>,
         module_id: ModuleId,
         msg: MsgAcknowledgement,
         packet_commitment: PacketCommitment,

--- a/crates/ibc/src/core/context/chan_close_confirm.rs
+++ b/crates/ibc/src/core/context/chan_close_confirm.rs
@@ -11,13 +11,13 @@ use crate::events::IbcEvent;
 
 use super::{ContextError, ExecutionContext, ValidationContext};
 
-pub(super) fn chan_close_confirm_validate<ValCtx>(
+pub(super) fn chan_close_confirm_validate<'m, ValCtx>(
     ctx_b: &ValCtx,
     module_id: ModuleId,
     msg: MsgChannelCloseConfirm,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     chan_close_confirm::validate(ctx_b, &msg)?;
 
@@ -29,13 +29,13 @@ where
     Ok(())
 }
 
-pub(super) fn chan_close_confirm_execute<ExecCtx>(
+pub(super) fn chan_close_confirm_execute<'m, ExecCtx>(
     ctx_b: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgChannelCloseConfirm,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let module = ctx_b
         .get_route_mut(&module_id)

--- a/crates/ibc/src/core/context/chan_close_init.rs
+++ b/crates/ibc/src/core/context/chan_close_init.rs
@@ -10,13 +10,13 @@ use crate::core::ics26_routing::context::ModuleId;
 use crate::events::IbcEvent;
 
 use super::{ContextError, ExecutionContext, ValidationContext};
-pub(super) fn chan_close_init_validate<ValCtx>(
+pub(super) fn chan_close_init_validate<'m, ValCtx>(
     ctx_a: &ValCtx,
     module_id: ModuleId,
     msg: MsgChannelCloseInit,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     chan_close_init::validate(ctx_a, &msg)?;
 
@@ -28,13 +28,13 @@ where
     Ok(())
 }
 
-pub(super) fn chan_close_init_execute<ExecCtx>(
+pub(super) fn chan_close_init_execute<'m, ExecCtx>(
     ctx_a: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgChannelCloseInit,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let module = ctx_a
         .get_route_mut(&module_id)

--- a/crates/ibc/src/core/context/chan_open_ack.rs
+++ b/crates/ibc/src/core/context/chan_open_ack.rs
@@ -12,13 +12,13 @@ use crate::events::IbcEvent;
 
 use super::{ContextError, ExecutionContext, ValidationContext};
 
-pub(super) fn chan_open_ack_validate<ValCtx>(
+pub(super) fn chan_open_ack_validate<'m, ValCtx>(
     ctx_a: &ValCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenAck,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     chan_open_ack::validate(ctx_a, &msg)?;
 
@@ -30,13 +30,13 @@ where
     Ok(())
 }
 
-pub(super) fn chan_open_ack_execute<ExecCtx>(
+pub(super) fn chan_open_ack_execute<'m, ExecCtx>(
     ctx_a: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenAck,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let module = ctx_a
         .get_route_mut(&module_id)
@@ -123,7 +123,7 @@ mod tests {
     use crate::mock::client_state::client_type as mock_client_type;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub module_id: ModuleId,
         pub msg: MsgChannelOpenAck,
         pub client_id_on_a: ClientId,

--- a/crates/ibc/src/core/context/chan_open_confirm.rs
+++ b/crates/ibc/src/core/context/chan_open_confirm.rs
@@ -11,13 +11,14 @@ use crate::events::IbcEvent;
 
 use super::{ContextError, ExecutionContext, ValidationContext};
 
-pub(super) fn chan_open_confirm_validate<ValCtx>(
+// this 'm tracks the lifetime of the (dyn `Module + m`) in the Router
+pub(super) fn chan_open_confirm_validate<'m, ValCtx>(
     ctx_b: &ValCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenConfirm,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     chan_open_confirm::validate(ctx_b, &msg)?;
 
@@ -29,13 +30,13 @@ where
     Ok(())
 }
 
-pub(super) fn chan_open_confirm_execute<ExecCtx>(
+pub(super) fn chan_open_confirm_execute<'m, ExecCtx>(
     ctx_b: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenConfirm,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let module = ctx_b
         .get_route_mut(&module_id)
@@ -129,7 +130,7 @@ mod tests {
     use crate::mock::client_state::client_type as mock_client_type;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub module_id: ModuleId,
         pub msg: MsgChannelOpenConfirm,
         pub client_id_on_b: ClientId,

--- a/crates/ibc/src/core/context/chan_open_init.rs
+++ b/crates/ibc/src/core/context/chan_open_init.rs
@@ -13,13 +13,13 @@ use crate::core::ics26_routing::context::ModuleId;
 use crate::events::IbcEvent;
 
 use super::{ContextError, ExecutionContext, ValidationContext};
-pub(super) fn chan_open_init_validate<ValCtx>(
+pub(super) fn chan_open_init_validate<'m, ValCtx>(
     ctx_a: &ValCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenInit,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     chan_open_init::validate(ctx_a, &msg)?;
     let chan_id_on_a = ChannelId::new(ctx_a.channel_counter()?);
@@ -39,13 +39,13 @@ where
     Ok(())
 }
 
-pub(super) fn chan_open_init_execute<ExecCtx>(
+pub(super) fn chan_open_init_execute<'m, ExecCtx>(
     ctx_a: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenInit,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let chan_id_on_a = ChannelId::new(ctx_a.channel_counter()?);
     let module = ctx_a
@@ -137,7 +137,7 @@ mod tests {
     use rstest::*;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub module_id: ModuleId,
         pub msg: MsgChannelOpenInit,
         pub conn_end_on_a: ConnectionEnd,

--- a/crates/ibc/src/core/context/chan_open_try.rs
+++ b/crates/ibc/src/core/context/chan_open_try.rs
@@ -12,13 +12,13 @@ use crate::events::IbcEvent;
 
 use super::{ContextError, ExecutionContext, ValidationContext};
 
-pub(super) fn chan_open_try_validate<ValCtx>(
+pub(super) fn chan_open_try_validate<'m, ValCtx>(
     ctx_b: &ValCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenTry,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     chan_open_try::validate(ctx_b, &msg)?;
     let chan_id_on_b = ChannelId::new(ctx_b.channel_counter()?);
@@ -38,13 +38,13 @@ where
     Ok(())
 }
 
-pub(super) fn chan_open_try_execute<ExecCtx>(
+pub(super) fn chan_open_try_execute<'m, ExecCtx>(
     ctx_b: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgChannelOpenTry,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let chan_id_on_b = ChannelId::new(ctx_b.channel_counter()?);
     let module = ctx_b
@@ -147,7 +147,7 @@ mod tests {
     use crate::mock::client_state::client_type as mock_client_type;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub module_id: ModuleId,
         pub msg: MsgChannelOpenTry,
         pub client_id_on_b: ClientId,

--- a/crates/ibc/src/core/context/recv_packet.rs
+++ b/crates/ibc/src/core/context/recv_packet.rs
@@ -17,12 +17,12 @@ use crate::{
 
 use super::{ContextError, ExecutionContext, ValidationContext};
 
-pub(super) fn recv_packet_validate<ValCtx>(
+pub(super) fn recv_packet_validate<'m, ValCtx>(
     ctx_b: &ValCtx,
     msg: MsgRecvPacket,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     // Note: this contains the validation for `write_acknowledgement` as well.
     recv_packet::validate(ctx_b, &msg)
@@ -30,13 +30,13 @@ where
     // nothing to validate with the module, since `onRecvPacket` cannot fail.
 }
 
-pub(super) fn recv_packet_execute<ExecCtx>(
+pub(super) fn recv_packet_execute<'m, ExecCtx>(
     ctx_b: &mut ExecCtx,
     module_id: ModuleId,
     msg: MsgRecvPacket,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let chan_end_path_on_b = ChannelEndPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
     let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
@@ -168,7 +168,7 @@ mod tests {
     };
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub module_id: ModuleId,
         pub client_height: Height,
         pub host_height: Height,

--- a/crates/ibc/src/core/context/timeout.rs
+++ b/crates/ibc/src/core/context/timeout.rs
@@ -24,13 +24,13 @@ pub(super) enum TimeoutMsgType {
     TimeoutOnClose(MsgTimeoutOnClose),
 }
 
-pub(super) fn timeout_packet_validate<ValCtx>(
+pub(super) fn timeout_packet_validate<'m, ValCtx>(
     ctx_a: &ValCtx,
     module_id: ModuleId,
     timeout_msg_type: TimeoutMsgType,
 ) -> Result<(), ContextError>
 where
-    ValCtx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     match &timeout_msg_type {
         TimeoutMsgType::Timeout(msg) => timeout::validate(ctx_a, msg),
@@ -51,13 +51,13 @@ where
         .map_err(ContextError::PacketError)
 }
 
-pub(super) fn timeout_packet_execute<ExecCtx>(
+pub(super) fn timeout_packet_execute<'m, ExecCtx>(
     ctx_a: &mut ExecCtx,
     module_id: ModuleId,
     timeout_msg_type: TimeoutMsgType,
 ) -> Result<(), ContextError>
 where
-    ExecCtx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let (packet, signer) = match timeout_msg_type {
         TimeoutMsgType::Timeout(msg) => (msg.packet, msg.signer),
@@ -171,7 +171,7 @@ mod tests {
     };
 
     struct Fixture {
-        ctx: MockContext,
+        ctx: MockContext<'static>,
         module_id: ModuleId,
         msg: MsgTimeoutOnClose,
         packet_commitment: PacketCommitment,

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -6,19 +6,13 @@ use super::{
 };
 
 /// Entrypoint which only performs message validation
-pub fn validate<'m, ValCtx>(ctx: &ValCtx, message: Any) -> Result<(), RouterError>
-where
-    ValCtx: ValidationContext<'m>,
-{
+pub fn validate<'m>(ctx: &impl ValidationContext<'m>, message: Any) -> Result<(), RouterError> {
     let envelope: MsgEnvelope = message.try_into()?;
     ctx.validate(envelope)
 }
 
 /// Entrypoint which only performs message execution
-pub fn execute<'m, Ctx>(ctx: &mut Ctx, message: Any) -> Result<(), RouterError>
-where
-    Ctx: ExecutionContext<'m>,
-{
+pub fn execute<'m>(ctx: &mut impl ExecutionContext<'m>, message: Any) -> Result<(), RouterError> {
     let envelope: MsgEnvelope = message.try_into()?;
     ctx.execute(envelope)
 }

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -78,14 +78,14 @@ pub trait ClientState:
 
     fn check_header_and_update_state(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         client_id: ClientId,
         header: Any,
     ) -> Result<UpdatedState, ClientError>;
 
     fn check_misbehaviour_and_update_state(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         client_id: ClientId,
         misbehaviour: Any,
     ) -> Result<Box<dyn ClientState>, ContextError>;
@@ -170,7 +170,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_data(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -183,7 +183,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_packet_acknowledgement(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -196,7 +196,7 @@ pub trait ClientState:
     #[allow(clippy::too_many_arguments)]
     fn verify_next_sequence_recv(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,
@@ -208,7 +208,7 @@ pub trait ClientState:
     /// Verify a `proof` that a packet has not been received.
     fn verify_packet_receipt_absence(
         &self,
-        ctx: &dyn ValidationContext,
+        ctx: &dyn ValidationContext<'_>,
         height: Height,
         connection_end: &ConnectionEnd,
         proof: &CommitmentProofBytes,

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -20,9 +20,9 @@ use crate::core::ics02_client::msgs::create_client::MsgCreateClient;
 use crate::core::ics24_host::identifier::ClientId;
 use crate::events::IbcEvent;
 
-pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgCreateClient) -> Result<(), ContextError>
+pub(crate) fn validate<'m, ValCtx>(ctx: &ValCtx, msg: MsgCreateClient) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let MsgCreateClient {
         client_state,
@@ -48,9 +48,12 @@ where
     Ok(())
 }
 
-pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgCreateClient) -> Result<(), ContextError>
+pub(crate) fn execute<'m, ExecCtx>(
+    ctx: &mut ExecCtx,
+    msg: MsgCreateClient,
+) -> Result<(), ContextError>
 where
-    Ctx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let MsgCreateClient {
         client_state,

--- a/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/handler/misbehaviour.rs
@@ -11,9 +11,12 @@ use crate::core::ics24_host::path::ClientStatePath;
 
 use crate::core::{ContextError, ExecutionContext, ValidationContext};
 
-pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgSubmitMisbehaviour) -> Result<(), ContextError>
+pub(crate) fn validate<'m, ValCtx>(
+    ctx: &ValCtx,
+    msg: MsgSubmitMisbehaviour,
+) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let MsgSubmitMisbehaviour {
         client_id,
@@ -37,9 +40,12 @@ where
     Ok(())
 }
 
-pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgSubmitMisbehaviour) -> Result<(), ContextError>
+pub(crate) fn execute<'m, ExecCtx>(
+    ctx: &mut ExecCtx,
+    msg: MsgSubmitMisbehaviour,
+) -> Result<(), ContextError>
 where
-    Ctx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let MsgSubmitMisbehaviour {
         client_id,
@@ -93,7 +99,11 @@ mod tests {
     use crate::Height;
     use crate::{downcast, prelude::*};
 
-    fn ensure_misbehaviour(ctx: &MockContext, client_id: &ClientId, client_type: &ClientType) {
+    fn ensure_misbehaviour(
+        ctx: &MockContext<'static>,
+        client_id: &ClientId,
+        client_type: &ClientType,
+    ) {
         let client_state = ctx.client_state(client_id).unwrap();
 
         assert!(client_state.is_frozen());

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -16,9 +16,9 @@ use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
 
 use crate::core::{ExecutionContext, ValidationContext};
 
-pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgUpdateClient) -> Result<(), ContextError>
+pub(crate) fn validate<'m, ValCtx>(ctx: &ValCtx, msg: MsgUpdateClient) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let MsgUpdateClient {
         client_id,
@@ -71,9 +71,12 @@ where
     Ok(())
 }
 
-pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgUpdateClient) -> Result<(), ContextError>
+pub(crate) fn execute<'m, ExecCtx>(
+    ctx: &mut ExecCtx,
+    msg: MsgUpdateClient,
+) -> Result<(), ContextError>
 where
-    Ctx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let MsgUpdateClient {
         client_id,

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -14,9 +14,9 @@ use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
 
 use crate::core::{ExecutionContext, ValidationContext};
 
-pub(crate) fn validate<Ctx>(ctx: &Ctx, msg: MsgUpgradeClient) -> Result<(), ContextError>
+pub(crate) fn validate<'m, ValCtx>(ctx: &ValCtx, msg: MsgUpgradeClient) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let MsgUpgradeClient { client_id, .. } = msg;
 
@@ -77,9 +77,12 @@ where
     Ok(())
 }
 
-pub(crate) fn execute<Ctx>(ctx: &mut Ctx, msg: MsgUpgradeClient) -> Result<(), ContextError>
+pub(crate) fn execute<'m, ExecCtx>(
+    ctx: &mut ExecCtx,
+    msg: MsgUpgradeClient,
+) -> Result<(), ContextError>
 where
-    Ctx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let MsgUpgradeClient { client_id, .. } = msg;
 
@@ -131,7 +134,7 @@ mod tests {
     use super::validate;
 
     pub struct Fixture {
-        pub ctx: MockContext,
+        pub ctx: MockContext<'static>,
         pub msg: MsgUpgradeClient,
     }
 

--- a/crates/ibc/src/core/ics03_connection/handler.rs
+++ b/crates/ibc/src/core/ics03_connection/handler.rs
@@ -20,7 +20,7 @@ pub mod test_util {
 
     #[derive(Clone, Debug)]
     pub struct Fixture<M: Debug> {
-        pub ctx: MockContext,
+        pub ctx: MockContext<'static>,
         pub msg: M,
     }
 

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_init.rs
@@ -11,9 +11,12 @@ use crate::core::ics24_host::path::{ClientConnectionPath, ConnectionPath};
 use crate::core::{ExecutionContext, ValidationContext};
 use crate::events::IbcEvent;
 
-pub(crate) fn validate<Ctx>(ctx_a: &Ctx, msg: MsgConnectionOpenInit) -> Result<(), ContextError>
+pub(crate) fn validate<'m, ValCtx>(
+    ctx_a: &ValCtx,
+    msg: MsgConnectionOpenInit,
+) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     // An IBC client running on the local (host) chain should exist.
     ctx_a.client_state(&msg.client_id_on_a)?;
@@ -27,9 +30,12 @@ where
     Ok(())
 }
 
-pub(crate) fn execute<Ctx>(ctx_a: &mut Ctx, msg: MsgConnectionOpenInit) -> Result<(), ContextError>
+pub(crate) fn execute<'m, ExecCtx>(
+    ctx_a: &mut ExecCtx,
+    msg: MsgConnectionOpenInit,
+) -> Result<(), ContextError>
 where
-    Ctx: ExecutionContext,
+    ExecCtx: ExecutionContext<'m>,
 {
     let versions = match msg.version {
         Some(version) => {
@@ -164,7 +170,7 @@ mod tests {
                     IbcEvent::OpenInitConnection(e) => e,
                     _ => unreachable!(),
                 };
-                let conn_end = <MockContext as ValidationContext>::connection_end(
+                let conn_end = <MockContext<'static> as ValidationContext>::connection_end(
                     &fxt.ctx,
                     conn_open_init_event.connection_id(),
                 )

--- a/crates/ibc/src/core/ics04_channel/context.rs
+++ b/crates/ibc/src/core/ics04_channel/context.rs
@@ -49,9 +49,9 @@ pub trait SendPacketValidationContext {
     ) -> PacketCommitment;
 }
 
-impl<T> SendPacketValidationContext for T
+impl<'m, T> SendPacketValidationContext for T
 where
-    T: ValidationContext,
+    T: ValidationContext<'m>,
 {
     fn channel_end(&self, channel_end_path: &ChannelEndPath) -> Result<ChannelEnd, ContextError> {
         self.channel_end(channel_end_path)
@@ -113,9 +113,9 @@ pub trait SendPacketExecutionContext: SendPacketValidationContext {
     fn log_message(&mut self, message: String);
 }
 
-impl<T> SendPacketExecutionContext for T
+impl<'m, T> SendPacketExecutionContext for T
 where
-    T: ExecutionContext,
+    T: ExecutionContext<'m>,
 {
     fn store_next_sequence_send(
         &mut self,

--- a/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/acknowledgement.rs
@@ -11,9 +11,9 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgAcknowledgement) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_a: &ValCtx, msg: &MsgAcknowledgement) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let packet = &msg.packet;
     let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
@@ -148,7 +148,7 @@ mod tests {
     use crate::timestamp::ZERO_DURATION;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub client_height: Height,
         pub msg: MsgAcknowledgement,
         pub packet_commitment: PacketCommitment,

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -8,9 +8,12 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgChannelCloseConfirm) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(
+    ctx_b: &ValCtx,
+    msg: &MsgChannelCloseConfirm,
+) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     // Retrieve the old channel end and validate it against the message.
     let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_init.rs
@@ -7,9 +7,9 @@ use crate::core::ics24_host::path::ChannelEndPath;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgChannelCloseInit) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_a: &ValCtx, msg: &MsgChannelCloseInit) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let chan_end_path_on_a = ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -8,9 +8,9 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgChannelOpenAck) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_a: &ValCtx, msg: &MsgChannelOpenAck) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let chan_end_path_on_a = ChannelEndPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let chan_end_on_a = ctx_a.channel_end(&chan_end_path_on_a)?;
@@ -119,7 +119,7 @@ mod tests {
     use crate::Height;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub msg: MsgChannelOpenAck,
         pub client_id_on_a: ClientId,
         pub conn_id_on_a: ConnectionId,

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -8,9 +8,9 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgChannelOpenConfirm) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_b: &ValCtx, msg: &MsgChannelOpenConfirm) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     // Unwrap the old channel end and validate it against the message.
     let chan_end_path_on_b = ChannelEndPath::new(&msg.port_id_on_b, &msg.chan_id_on_b);
@@ -120,7 +120,7 @@ mod tests {
     use crate::Height;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub msg: MsgChannelOpenConfirm,
         pub client_id_on_b: ClientId,
         pub conn_id_on_b: ConnectionId,

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_init.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_init.rs
@@ -6,9 +6,9 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgChannelOpenInit) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_a: &ValCtx, msg: &MsgChannelOpenInit) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     if msg.connection_hops_on_a.len() != 1 {
         return Err(ChannelError::InvalidConnectionHopsLength {
@@ -52,7 +52,7 @@ mod tests {
     use crate::mock::context::MockContext;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub msg: MsgChannelOpenInit,
         pub conn_end_on_a: ConnectionEnd,
     }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -9,9 +9,9 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgChannelOpenTry) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_b: &ValCtx, msg: &MsgChannelOpenTry) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     // An IBC connection running on the local (host) chain should exist.
     if msg.connection_hops_on_b.len() != 1 {
@@ -116,7 +116,7 @@ mod tests {
     use crate::Height;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub msg: MsgChannelOpenTry,
         pub client_id_on_b: ClientId,
         pub conn_id_on_b: ConnectionId,

--- a/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/recv_packet.rs
@@ -10,9 +10,9 @@ use crate::timestamp::Expiry;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_b: &Ctx, msg: &MsgRecvPacket) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_b: &ValCtx, msg: &MsgRecvPacket) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let chan_end_path_on_b = ChannelEndPath::new(&msg.packet.port_on_b, &msg.packet.chan_on_b);
     let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
@@ -145,9 +145,12 @@ where
     Ok(())
 }
 
-fn validate_write_acknowledgement<Ctx>(ctx_b: &Ctx, msg: &MsgRecvPacket) -> Result<(), ContextError>
+fn validate_write_acknowledgement<'m, ValCtx>(
+    ctx_b: &ValCtx,
+    msg: &MsgRecvPacket,
+) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let packet = msg.packet.clone();
     let ack_path_on_b = AckPath::new(&packet.port_on_b, &packet.chan_on_b, packet.sequence);
@@ -187,7 +190,7 @@ mod tests {
     use crate::timestamp::ZERO_DURATION;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub client_height: Height,
         pub host_height: Height,
         pub msg: MsgRecvPacket,

--- a/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/send_packet.rs
@@ -161,7 +161,7 @@ mod tests {
     fn send_packet_processing() {
         struct Test {
             name: String,
-            ctx: MockContext,
+            ctx: MockContext<'static>,
             packet: Packet,
             want_pass: bool,
         }

--- a/crates/ibc/src/core/ics04_channel/handler/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout.rs
@@ -11,9 +11,9 @@ use crate::timestamp::Expiry;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgTimeout) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_a: &ValCtx, msg: &MsgTimeout) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let chan_end_on_a = ctx_a.channel_end(&ChannelEndPath::new(
         &msg.packet.port_on_a,
@@ -170,7 +170,7 @@ mod tests {
     use crate::timestamp::ZERO_DURATION;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub client_height: Height,
         pub msg: MsgTimeout,
         pub packet_commitment: PacketCommitment,

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -9,9 +9,9 @@ use crate::prelude::*;
 
 use crate::core::{ContextError, ValidationContext};
 
-pub fn validate<Ctx>(ctx_a: &Ctx, msg: &MsgTimeoutOnClose) -> Result<(), ContextError>
+pub fn validate<'m, ValCtx>(ctx_a: &ValCtx, msg: &MsgTimeoutOnClose) -> Result<(), ContextError>
 where
-    Ctx: ValidationContext,
+    ValCtx: ValidationContext<'m>,
 {
     let packet = &msg.packet;
     let chan_end_path_on_a = ChannelEndPath::new(&packet.port_on_a, &packet.chan_on_a);
@@ -181,7 +181,7 @@ mod tests {
     use crate::timestamp::ZERO_DURATION;
 
     pub struct Fixture {
-        pub context: MockContext,
+        pub context: MockContext<'static>,
         pub msg: MsgTimeoutOnClose,
         pub packet_commitment: PacketCommitment,
         pub conn_end_on_a: ConnectionEnd,

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -2,7 +2,6 @@ use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::prelude::*;
 
 use alloc::borrow::{Borrow, Cow};
-use core::any::Any;
 use core::{
     fmt::{Debug, Display, Error as FmtError, Formatter},
     str::FromStr,
@@ -65,7 +64,7 @@ impl Borrow<str> for ModuleId {
     }
 }
 
-pub trait Module: AsAnyMut + Debug {
+pub trait Module: Debug {
     #[allow(clippy::too_many_arguments)]
     fn on_chan_open_init_validate(
         &self,
@@ -211,14 +210,4 @@ pub trait Module: AsAnyMut + Debug {
         packet: &Packet,
         relayer: &Signer,
     ) -> (ModuleExtras, Result<(), PacketError>);
-}
-
-pub trait AsAnyMut: Any {
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
-
-impl<M: Any + Module> AsAnyMut for M {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
 }

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -180,7 +180,7 @@ impl ClientState for MockClientState {
 
     fn check_header_and_update_state(
         &self,
-        _ctx: &dyn ValidationContext,
+        _ctx: &dyn ValidationContext<'_>,
         _client_id: ClientId,
         header: Any,
     ) -> Result<UpdatedState, ClientError> {
@@ -201,7 +201,7 @@ impl ClientState for MockClientState {
 
     fn check_misbehaviour_and_update_state(
         &self,
-        _ctx: &dyn ValidationContext,
+        _ctx: &dyn ValidationContext<'_>,
         _client_id: ClientId,
         misbehaviour: Any,
     ) -> Result<Box<dyn ClientState>, ContextError> {
@@ -314,7 +314,7 @@ impl ClientState for MockClientState {
 
     fn verify_packet_data(
         &self,
-        _ctx: &dyn ValidationContext,
+        _ctx: &dyn ValidationContext<'_>,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -327,7 +327,7 @@ impl ClientState for MockClientState {
 
     fn verify_next_sequence_recv(
         &self,
-        _ctx: &dyn ValidationContext,
+        _ctx: &dyn ValidationContext<'_>,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -340,7 +340,7 @@ impl ClientState for MockClientState {
 
     fn verify_packet_receipt_absence(
         &self,
-        _ctx: &dyn ValidationContext,
+        _ctx: &dyn ValidationContext<'_>,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,
@@ -352,7 +352,7 @@ impl ClientState for MockClientState {
 
     fn verify_packet_acknowledgement(
         &self,
-        _ctx: &dyn ValidationContext,
+        _ctx: &dyn ValidationContext<'_>,
         _height: Height,
         _connection_end: &ConnectionEnd,
         _proof: &CommitmentProofBytes,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -7,6 +7,7 @@ use crate::core::ics24_host::path::{
     SeqSendPath,
 };
 use crate::prelude::*;
+use crate::test_utils::DummyTransferContext;
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
@@ -461,6 +462,10 @@ impl MockContext {
             .insert(seq, data);
         self.ibc_store.lock().packet_commitment = packet_commitment;
         self
+    }
+
+    pub fn get_transfer_context_mut(&mut self) -> &mut DummyTransferContext {
+        todo!()
     }
 
     pub fn add_route(&mut self, module_id: ModuleId, module: impl Module) -> Result<(), String> {

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -84,6 +84,12 @@ pub struct DummyTransferContext {
     ibc_store: Arc<Mutex<MockIbcStore>>,
 }
 
+impl DummyTransferContext {
+    pub fn new(ibc_store: Arc<Mutex<MockIbcStore>>) -> Self {
+        Self { ibc_store }
+    }
+}
+
 impl TokenTransferValidationContext for DummyTransferContext {
     type AccountId = Signer;
 

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -73,113 +73,18 @@ pub fn get_dummy_transfer_module() -> DummyTransferModule {
     let ibc_store = Arc::new(Mutex::new(MockIbcStore::default()));
     DummyTransferModule { ibc_store }
 }
+
+pub fn get_dummy_transfer_context() -> DummyTransferContext {
+    let ibc_store = Arc::new(Mutex::new(MockIbcStore::default()));
+    DummyTransferContext { ibc_store }
+}
+
 #[derive(Debug)]
-pub struct DummyTransferModule {
+pub struct DummyTransferContext {
     ibc_store: Arc<Mutex<MockIbcStore>>,
 }
 
-impl DummyTransferModule {
-    pub fn new(ibc_store: Arc<Mutex<MockIbcStore>>) -> Self {
-        Self { ibc_store }
-    }
-}
-
-impl Module for DummyTransferModule {
-    fn on_chan_open_init_validate(
-        &self,
-        _order: Order,
-        _connection_hops: &[ConnectionId],
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty: &Counterparty,
-        version: &Version,
-    ) -> Result<Version, ChannelError> {
-        Ok(version.clone())
-    }
-
-    fn on_chan_open_init_execute(
-        &mut self,
-        _order: Order,
-        _connection_hops: &[ConnectionId],
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty: &Counterparty,
-        version: &Version,
-    ) -> Result<(ModuleExtras, Version), ChannelError> {
-        Ok((ModuleExtras::empty(), version.clone()))
-    }
-
-    fn on_chan_open_try_validate(
-        &self,
-        _order: Order,
-        _connection_hops: &[ConnectionId],
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty: &Counterparty,
-        counterparty_version: &Version,
-    ) -> Result<Version, ChannelError> {
-        Ok(counterparty_version.clone())
-    }
-
-    fn on_chan_open_try_execute(
-        &mut self,
-        _order: Order,
-        _connection_hops: &[ConnectionId],
-        _port_id: &PortId,
-        _channel_id: &ChannelId,
-        _counterparty: &Counterparty,
-        counterparty_version: &Version,
-    ) -> Result<(ModuleExtras, Version), ChannelError> {
-        Ok((ModuleExtras::empty(), counterparty_version.clone()))
-    }
-
-    fn on_recv_packet_execute(
-        &mut self,
-        _packet: &Packet,
-        _relayer: &Signer,
-    ) -> (ModuleExtras, Acknowledgement) {
-        (
-            ModuleExtras::empty(),
-            Acknowledgement::try_from(vec![1u8]).unwrap(),
-        )
-    }
-
-    fn on_timeout_packet_validate(
-        &self,
-        _packet: &Packet,
-        _relayer: &Signer,
-    ) -> Result<(), PacketError> {
-        Ok(())
-    }
-
-    fn on_timeout_packet_execute(
-        &mut self,
-        _packet: &Packet,
-        _relayer: &Signer,
-    ) -> (ModuleExtras, Result<(), PacketError>) {
-        (ModuleExtras::empty(), Ok(()))
-    }
-
-    fn on_acknowledgement_packet_validate(
-        &self,
-        _packet: &Packet,
-        _acknowledgement: &Acknowledgement,
-        _relayer: &Signer,
-    ) -> Result<(), PacketError> {
-        Ok(())
-    }
-
-    fn on_acknowledgement_packet_execute(
-        &mut self,
-        _packet: &Packet,
-        _acknowledgement: &Acknowledgement,
-        _relayer: &Signer,
-    ) -> (ModuleExtras, Result<(), PacketError>) {
-        (ModuleExtras::empty(), Ok(()))
-    }
-}
-
-impl TokenTransferValidationContext for DummyTransferModule {
+impl TokenTransferValidationContext for DummyTransferContext {
     type AccountId = Signer;
 
     fn get_port(&self) -> Result<PortId, TokenTransferError> {
@@ -204,7 +109,7 @@ impl TokenTransferValidationContext for DummyTransferModule {
     }
 }
 
-impl TokenTransferExecutionContext for DummyTransferModule {
+impl TokenTransferExecutionContext for DummyTransferContext {
     fn send_coins(
         &mut self,
         _from: &Self::AccountId,
@@ -231,7 +136,7 @@ impl TokenTransferExecutionContext for DummyTransferModule {
     }
 }
 
-impl SendPacketValidationContext for DummyTransferModule {
+impl SendPacketValidationContext for DummyTransferContext {
     fn channel_end(&self, chan_end_path: &ChannelEndPath) -> Result<ChannelEnd, ContextError> {
         match self
             .ibc_store
@@ -353,7 +258,7 @@ impl SendPacketValidationContext for DummyTransferModule {
     }
 }
 
-impl SendPacketExecutionContext for DummyTransferModule {
+impl SendPacketExecutionContext for DummyTransferContext {
     fn store_packet_commitment(
         &mut self,
         commitment_path: &CommitmentPath,
@@ -394,4 +299,112 @@ impl SendPacketExecutionContext for DummyTransferModule {
     fn emit_ibc_event(&mut self, _event: IbcEvent) {}
 
     fn log_message(&mut self, _message: String) {}
+}
+
+#[derive(Debug)]
+pub struct DummyTransferModule {
+    // TODO: remove
+    #[allow(unused)]
+    ibc_store: Arc<Mutex<MockIbcStore>>,
+}
+
+impl DummyTransferModule {
+    pub fn new(ibc_store: Arc<Mutex<MockIbcStore>>) -> Self {
+        Self { ibc_store }
+    }
+}
+
+impl Module for DummyTransferModule {
+    fn on_chan_open_init_validate(
+        &self,
+        _order: Order,
+        _connection_hops: &[ConnectionId],
+        _port_id: &PortId,
+        _channel_id: &ChannelId,
+        _counterparty: &Counterparty,
+        version: &Version,
+    ) -> Result<Version, ChannelError> {
+        Ok(version.clone())
+    }
+
+    fn on_chan_open_init_execute(
+        &mut self,
+        _order: Order,
+        _connection_hops: &[ConnectionId],
+        _port_id: &PortId,
+        _channel_id: &ChannelId,
+        _counterparty: &Counterparty,
+        version: &Version,
+    ) -> Result<(ModuleExtras, Version), ChannelError> {
+        Ok((ModuleExtras::empty(), version.clone()))
+    }
+
+    fn on_chan_open_try_validate(
+        &self,
+        _order: Order,
+        _connection_hops: &[ConnectionId],
+        _port_id: &PortId,
+        _channel_id: &ChannelId,
+        _counterparty: &Counterparty,
+        counterparty_version: &Version,
+    ) -> Result<Version, ChannelError> {
+        Ok(counterparty_version.clone())
+    }
+
+    fn on_chan_open_try_execute(
+        &mut self,
+        _order: Order,
+        _connection_hops: &[ConnectionId],
+        _port_id: &PortId,
+        _channel_id: &ChannelId,
+        _counterparty: &Counterparty,
+        counterparty_version: &Version,
+    ) -> Result<(ModuleExtras, Version), ChannelError> {
+        Ok((ModuleExtras::empty(), counterparty_version.clone()))
+    }
+
+    fn on_recv_packet_execute(
+        &mut self,
+        _packet: &Packet,
+        _relayer: &Signer,
+    ) -> (ModuleExtras, Acknowledgement) {
+        (
+            ModuleExtras::empty(),
+            Acknowledgement::try_from(vec![1u8]).unwrap(),
+        )
+    }
+
+    fn on_timeout_packet_validate(
+        &self,
+        _packet: &Packet,
+        _relayer: &Signer,
+    ) -> Result<(), PacketError> {
+        Ok(())
+    }
+
+    fn on_timeout_packet_execute(
+        &mut self,
+        _packet: &Packet,
+        _relayer: &Signer,
+    ) -> (ModuleExtras, Result<(), PacketError>) {
+        (ModuleExtras::empty(), Ok(()))
+    }
+
+    fn on_acknowledgement_packet_validate(
+        &self,
+        _packet: &Packet,
+        _acknowledgement: &Acknowledgement,
+        _relayer: &Signer,
+    ) -> Result<(), PacketError> {
+        Ok(())
+    }
+
+    fn on_acknowledgement_packet_execute(
+        &mut self,
+        _packet: &Packet,
+        _acknowledgement: &Acknowledgement,
+        _relayer: &Signer,
+    ) -> (ModuleExtras, Result<(), PacketError>) {
+        (ModuleExtras::empty(), Ok(()))
+    }
 }


### PR DESCRIPTION
Closes: #490

## Description

This PR removes the `'static` bound from the `Module` trait. This has a ripple effect of requiring us to track that lifetime on the `Router`, `ValidationContext`, and `ExecutionContext`.

[Associated basecoin-rs PR](https://github.com/informalsystems/basecoin-rs/pull/82).


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
