### PR TITLE
Separate the validation from the execution process for `send/mint/burn_coins` operations

### DIFF
--- a/.changelog/unreleased/breaking-changes/502-add-coins-validation-api.md
+++ b/.changelog/unreleased/breaking-changes/502-add-coins-validation-api.md
@@ -1,3 +1,3 @@
-- separate the validation from the execution process for `send/mint/burn_coins`
-  operations. 
+- Separate the validation from the execution process for `send/mint/burn_coins`
+  operations.
   ([#502](https://github.com/cosmos/ibc-rs/issues/502))

--- a/.changelog/unreleased/breaking-changes/502-add-coins-validation-api.md
+++ b/.changelog/unreleased/breaking-changes/502-add-coins-validation-api.md
@@ -1,0 +1,3 @@
+- separate the validation from the execution process for `send/mint/burn_coins`
+  operations. 
+  ([#502](https://github.com/cosmos/ibc-rs/issues/502))

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -8,7 +8,7 @@ use crate::applications::transfer::events::{AckEvent, AckStatusEvent, RecvEvent,
 use crate::applications::transfer::packet::PacketData;
 use crate::applications::transfer::relay::refund_packet_token_execute;
 use crate::applications::transfer::relay::{
-    on_recv_packet::process_recv_packet, refund_packet_token_validate,
+    on_recv_packet::process_recv_packet_execute, refund_packet_token_validate,
 };
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
@@ -268,7 +268,7 @@ pub fn on_chan_close_confirm_execute(
     Ok(ModuleExtras::empty())
 }
 
-pub fn on_recv_packet(
+pub fn on_recv_packet_execute(
     ctx: &mut impl TokenTransferExecutionContext,
     packet: &Packet,
 ) -> (ModuleExtras, Acknowledgement) {
@@ -282,7 +282,7 @@ pub fn on_recv_packet(
         }
     };
 
-    let (mut extras, ack) = match process_recv_packet(ctx, packet, data.clone()) {
+    let (mut extras, ack) = match process_recv_packet_execute(ctx, packet, data.clone()) {
         Ok(extras) => (extras, TokenTransferAcknowledgement::success()),
         Err((extras, error)) => (extras, TokenTransferAcknowledgement::from_error(error)),
     };

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -6,9 +6,9 @@ use super::error::TokenTransferError;
 use crate::applications::transfer::acknowledgement::TokenTransferAcknowledgement;
 use crate::applications::transfer::events::{AckEvent, AckStatusEvent, RecvEvent, TimeoutEvent};
 use crate::applications::transfer::packet::PacketData;
-use crate::applications::transfer::relay::refund_packet_token;
+use crate::applications::transfer::relay::refund_packet_token_execute;
 use crate::applications::transfer::relay::{
-    on_recv_packet::process_recv_packet_execute, refund_packet_token_validate,
+    on_recv_packet::process_recv_packet, refund_packet_token_validate,
 };
 use crate::applications::transfer::{PrefixedCoin, PrefixedDenom, VERSION};
 use crate::core::ics04_channel::channel::{Counterparty, Order};
@@ -21,32 +21,6 @@ use crate::core::ics04_channel::packet::Packet;
 use crate::core::ics04_channel::Version;
 use crate::core::ics24_host::identifier::{ChannelId, ConnectionId, PortId};
 use crate::signer::Signer;
-
-pub trait TokenTransferExecutionContext:
-    TokenTransferValidationContext + SendPacketExecutionContext
-{
-    /// This function should enable sending ibc fungible tokens from one account to another
-    fn send_coins(
-        &mut self,
-        from: &Self::AccountId,
-        to: &Self::AccountId,
-        amt: &PrefixedCoin,
-    ) -> Result<(), TokenTransferError>;
-
-    /// This function to enable minting ibc tokens to a user account
-    fn mint_coins(
-        &mut self,
-        account: &Self::AccountId,
-        amt: &PrefixedCoin,
-    ) -> Result<(), TokenTransferError>;
-
-    /// This function should enable burning of minted tokens in a user account
-    fn burn_coins(
-        &mut self,
-        account: &Self::AccountId,
-        amt: &PrefixedCoin,
-    ) -> Result<(), TokenTransferError>;
-}
 
 pub trait TokenTransferValidationContext: SendPacketValidationContext {
     type AccountId: TryFrom<Signer>;
@@ -67,11 +41,59 @@ pub trait TokenTransferValidationContext: SendPacketValidationContext {
     /// Returns true iff receive is enabled.
     fn is_receive_enabled(&self) -> bool;
 
+    /// This function should enable sending ibc fungible tokens from one account to another
+    fn send_coins_validate(
+        &self,
+        from_account: &Self::AccountId,
+        to_account: &Self::AccountId,
+        coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
+    /// This function to enable minting ibc tokens to a user account
+    fn mint_coins_validate(
+        &self,
+        account: &Self::AccountId,
+        coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
+    /// This function should enable burning of minted tokens in a user account
+    fn burn_coins_validate(
+        &self,
+        account: &Self::AccountId,
+        coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
     /// Returns a hash of the prefixed denom.
     /// Implement only if the host chain supports hashed denominations.
     fn denom_hash_string(&self, _denom: &PrefixedDenom) -> Option<String> {
         None
     }
+}
+
+pub trait TokenTransferExecutionContext:
+    TokenTransferValidationContext + SendPacketExecutionContext
+{
+    /// This function should enable sending ibc fungible tokens from one account to another
+    fn send_coins_execute(
+        &mut self,
+        from_account: &Self::AccountId,
+        to_account: &Self::AccountId,
+        coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
+    /// This function to enable minting ibc tokens to a user account
+    fn mint_coins_execute(
+        &mut self,
+        account: &Self::AccountId,
+        coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
+
+    /// This function should enable burning of minted tokens in a user account
+    fn burn_coins_execute(
+        &mut self,
+        account: &Self::AccountId,
+        coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError>;
 }
 
 // https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-028-public-key-addresses.md
@@ -246,7 +268,7 @@ pub fn on_chan_close_confirm_execute(
     Ok(ModuleExtras::empty())
 }
 
-pub fn on_recv_packet_execute(
+pub fn on_recv_packet(
     ctx: &mut impl TokenTransferExecutionContext,
     packet: &Packet,
 ) -> (ModuleExtras, Acknowledgement) {
@@ -260,7 +282,7 @@ pub fn on_recv_packet_execute(
         }
     };
 
-    let (mut extras, ack) = match process_recv_packet_execute(ctx, packet, data.clone()) {
+    let (mut extras, ack) = match process_recv_packet(ctx, packet, data.clone()) {
         Ok(extras) => (extras, TokenTransferAcknowledgement::success()),
         Err((extras, error)) => (extras, TokenTransferAcknowledgement::from_error(error)),
     };
@@ -277,7 +299,7 @@ pub fn on_recv_packet_execute(
 }
 
 pub fn on_acknowledgement_packet_validate<Ctx>(
-    _ctx: &Ctx,
+    ctx: &Ctx,
     packet: &Packet,
     acknowledgement: &Acknowledgement,
     _relayer: &Signer,
@@ -293,7 +315,7 @@ where
             .map_err(|_| TokenTransferError::AckDeserialization)?;
 
     if !acknowledgement.is_successful() {
-        refund_packet_token_validate::<Ctx>(&data)?;
+        refund_packet_token_validate(ctx, packet, &data)?;
     }
 
     Ok(())
@@ -327,7 +349,7 @@ pub fn on_acknowledgement_packet_execute(
         };
 
     if !acknowledgement.is_successful() {
-        if let Err(err) = refund_packet_token(ctx, packet, &data) {
+        if let Err(err) = refund_packet_token_execute(ctx, packet, &data) {
             return (ModuleExtras::empty(), Err(err));
         }
     }
@@ -348,7 +370,7 @@ pub fn on_acknowledgement_packet_execute(
 }
 
 pub fn on_timeout_packet_validate<Ctx>(
-    _ctx: &Ctx,
+    ctx: &Ctx,
     packet: &Packet,
     _relayer: &Signer,
 ) -> Result<(), TokenTransferError>
@@ -358,7 +380,7 @@ where
     let data = serde_json::from_slice::<PacketData>(&packet.data)
         .map_err(|_| TokenTransferError::PacketDataDeserialization)?;
 
-    refund_packet_token_validate::<Ctx>(&data)?;
+    refund_packet_token_validate(ctx, packet, &data)?;
 
     Ok(())
 }
@@ -378,7 +400,7 @@ pub fn on_timeout_packet_execute(
         }
     };
 
-    if let Err(err) = refund_packet_token(ctx, packet, &data) {
+    if let Err(err) = refund_packet_token_execute(ctx, packet, &data) {
         return (ModuleExtras::empty(), Err(err));
     }
 

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -41,7 +41,7 @@ pub trait TokenTransferValidationContext: SendPacketValidationContext {
     /// Returns true iff receive is enabled.
     fn is_receive_enabled(&self) -> bool;
 
-    /// This function should enable sending ibc fungible tokens from one account to another
+    /// Validates the sender and receiver accounts and the coin inputs
     fn send_coins_validate(
         &self,
         from_account: &Self::AccountId,
@@ -49,14 +49,14 @@ pub trait TokenTransferValidationContext: SendPacketValidationContext {
         coin: &PrefixedCoin,
     ) -> Result<(), TokenTransferError>;
 
-    /// This function to enable minting ibc tokens to a user account
+    /// Validates the receiver account and the coin input
     fn mint_coins_validate(
         &self,
         account: &Self::AccountId,
         coin: &PrefixedCoin,
     ) -> Result<(), TokenTransferError>;
 
-    /// This function should enable burning of minted tokens in a user account
+    /// Validates the sender account and the coin input
     fn burn_coins_validate(
         &self,
         account: &Self::AccountId,

--- a/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
@@ -7,7 +7,13 @@ use crate::core::ics04_channel::handler::ModuleExtras;
 use crate::core::ics04_channel::packet::Packet;
 use crate::prelude::*;
 
-pub fn process_recv_packet<Ctx: TokenTransferExecutionContext>(
+/// This function handles the transfer receiving logic.
+///
+/// Note that `send/mint_coins_validate` steps are performed on the host chain
+/// to validate accounts and token info. But the result is then used for
+/// execution on the IBC side, including storing acknowledgements and emitting
+/// events.
+pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
     ctx: &mut Ctx,
     packet: &Packet,
     data: PacketData,

--- a/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
+++ b/crates/ibc/src/applications/transfer/relay/on_recv_packet.rs
@@ -46,6 +46,16 @@ pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
             .get_channel_escrow_address(&packet.port_on_b, &packet.chan_on_b)
             .map_err(|token_err| (ModuleExtras::empty(), token_err))?;
 
+        // Note: it is correct to do the validation here because `recv_packet()`
+        // works slightly differently. We do not have a
+        // `on_recv_packet_validate()` callback because regardless of whether or
+        // not the app succeeds to receive the packet, we want to run the
+        // `execute()` phase. And this is because the app failing to receive
+        // does not constitute a failure of the message processing.
+        // Specifically, when the app fails to receive, we need to return
+        // a `TokenTransferAcknowledgement::Error` acknowledgement, which
+        // gets relayed back to the sender so that the escrowed tokens
+        // can be refunded.
         ctx.send_coins_validate(&escrow_address, &receiver_account, &coin)
             .map_err(|token_err| (ModuleExtras::empty(), token_err))?;
 
@@ -73,6 +83,16 @@ pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
             }
         };
 
+        // Note: it is correct to do the validation here because `recv_packet()`
+        // works slightly differently. We do not have a
+        // `on_recv_packet_validate()` callback because regardless of whether or
+        // not the app succeeds to receive the packet, we want to run the
+        // `execute()` phase. And this is because the app failing to receive
+        // does not constitute a failure of the message processing.
+        // Specifically, when the app fails to receive, we need to return
+        // a `TokenTransferAcknowledgement::Error` acknowledgement, which
+        // gets relayed back to the sender so that the escrowed tokens
+        // can be refunded.
         ctx.mint_coins_validate(&receiver_account, &coin)
             .map_err(|token_err| (extras.clone(), token_err))?;
 

--- a/crates/ibc/src/core/context/recv_packet.rs
+++ b/crates/ibc/src/core/context/recv_packet.rs
@@ -74,7 +74,7 @@ where
         .get_route_mut(&module_id)
         .ok_or(ChannelError::RouteNotFound)?;
 
-    let (extras, acknowledgement) = module.on_recv_packet_execute(&msg.packet, &msg.signer);
+    let (extras, acknowledgement) = module.on_recv_packet(&msg.packet, &msg.signer);
 
     // state changes
     {

--- a/crates/ibc/src/core/context/recv_packet.rs
+++ b/crates/ibc/src/core/context/recv_packet.rs
@@ -74,7 +74,7 @@ where
         .get_route_mut(&module_id)
         .ok_or(ChannelError::RouteNotFound)?;
 
-    let (extras, acknowledgement) = module.on_recv_packet(&msg.packet, &msg.signer);
+    let (extras, acknowledgement) = module.on_recv_packet_execute(&msg.packet, &msg.signer);
 
     // state changes
     {

--- a/crates/ibc/src/core/context/recv_packet.rs
+++ b/crates/ibc/src/core/context/recv_packet.rs
@@ -29,6 +29,7 @@ where
     recv_packet::validate(ctx_b, &msg)
 
     // nothing to validate with the module, since `onRecvPacket` cannot fail.
+    // If any error occurs, then an "error acknowledgement" must be returned.
 }
 
 pub(super) fn recv_packet_execute<ExecCtx>(

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -175,6 +175,11 @@ pub trait Module: Debug {
         Ok(ModuleExtras::empty())
     }
 
+    // Note: no `on_recv_packet_validate()`
+    // the `onRecvPacket` callback always succeeds
+    // if any error occurs, than an "error acknowledgement"
+    // must be returned
+
     fn on_recv_packet_execute(
         &mut self,
         packet: &Packet,

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -175,7 +175,7 @@ pub trait Module: Debug {
         Ok(ModuleExtras::empty())
     }
 
-    fn on_recv_packet(
+    fn on_recv_packet_execute(
         &mut self,
         packet: &Packet,
         relayer: &Signer,

--- a/crates/ibc/src/core/ics26_routing/context.rs
+++ b/crates/ibc/src/core/ics26_routing/context.rs
@@ -175,7 +175,7 @@ pub trait Module: Debug {
         Ok(ModuleExtras::empty())
     }
 
-    fn on_recv_packet_execute(
+    fn on_recv_packet(
         &mut self,
         packet: &Packet,
         relayer: &Signer,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -3,6 +3,8 @@
 use crate::applications::transfer::context::{
     cosmos_adr028_escrow_address, TokenTransferExecutionContext, TokenTransferValidationContext,
 };
+use crate::applications::transfer::error::TokenTransferError;
+use crate::applications::transfer::PrefixedCoin;
 use crate::clients::ics07_tendermint::TENDERMINT_CLIENT_TYPE;
 use crate::core::ics24_host::path::{
     AckPath, ChannelEndPath, ClientConnectionPath, ClientConsensusStatePath, ClientStatePath,
@@ -1403,7 +1405,7 @@ impl ExecutionContext for MockContext {
 impl TokenTransferValidationContext for MockContext {
     type AccountId = Signer;
 
-    fn get_port(&self) -> Result<PortId, crate::applications::transfer::error::TokenTransferError> {
+    fn get_port(&self) -> Result<PortId, TokenTransferError> {
         Ok(PortId::transfer())
     }
 
@@ -1411,7 +1413,7 @@ impl TokenTransferValidationContext for MockContext {
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
-    ) -> Result<Self::AccountId, crate::applications::transfer::error::TokenTransferError> {
+    ) -> Result<Self::AccountId, TokenTransferError> {
         let addr = cosmos_adr028_escrow_address(port_id, channel_id);
         Ok(bech32::encode("cosmos", addr).parse().unwrap())
     }
@@ -1423,31 +1425,56 @@ impl TokenTransferValidationContext for MockContext {
     fn is_receive_enabled(&self) -> bool {
         true
     }
+
+    fn send_coins_validate(
+        &self,
+        _from_account: &Self::AccountId,
+        _to_account: &Self::AccountId,
+        _coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError> {
+        Ok(())
+    }
+
+    fn mint_coins_validate(
+        &self,
+        _account: &Self::AccountId,
+        _coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError> {
+        Ok(())
+    }
+
+    fn burn_coins_validate(
+        &self,
+        _account: &Self::AccountId,
+        _coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError> {
+        Ok(())
+    }
 }
 
 impl TokenTransferExecutionContext for MockContext {
-    fn send_coins(
+    fn send_coins_execute(
         &mut self,
-        _from: &Self::AccountId,
-        _to: &Self::AccountId,
-        _amt: &crate::applications::transfer::PrefixedCoin,
-    ) -> Result<(), crate::applications::transfer::error::TokenTransferError> {
+        _from_account: &Self::AccountId,
+        _to_account: &Self::AccountId,
+        _coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError> {
         Ok(())
     }
 
-    fn mint_coins(
+    fn mint_coins_execute(
         &mut self,
         _account: &Self::AccountId,
-        _amt: &crate::applications::transfer::PrefixedCoin,
-    ) -> Result<(), crate::applications::transfer::error::TokenTransferError> {
+        _coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError> {
         Ok(())
     }
 
-    fn burn_coins(
+    fn burn_coins_execute(
         &mut self,
         _account: &Self::AccountId,
-        _amt: &crate::applications::transfer::PrefixedCoin,
-    ) -> Result<(), crate::applications::transfer::error::TokenTransferError> {
+        _coin: &PrefixedCoin,
+    ) -> Result<(), TokenTransferError> {
         Ok(())
     }
 }
@@ -1669,7 +1696,7 @@ mod tests {
                 Ok((ModuleExtras::empty(), counterparty_version.clone()))
             }
 
-            fn on_recv_packet_execute(
+            fn on_recv_packet(
                 &mut self,
                 _packet: &Packet,
                 _relayer: &Signer,
@@ -1769,7 +1796,7 @@ mod tests {
                 Ok((ModuleExtras::empty(), counterparty_version.clone()))
             }
 
-            fn on_recv_packet_execute(
+            fn on_recv_packet(
                 &mut self,
                 _packet: &Packet,
                 _relayer: &Signer,
@@ -1829,7 +1856,7 @@ mod tests {
         let mut on_recv_packet_result = |module_id: &'static str| {
             let module_id = ModuleId::from_str(module_id).unwrap();
             let m = ctx.get_route_mut(&module_id).unwrap();
-            let result = m.on_recv_packet_execute(
+            let result = m.on_recv_packet(
                 &Packet::default(),
                 &get_dummy_bech32_account().parse().unwrap(),
             );

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -1696,7 +1696,7 @@ mod tests {
                 Ok((ModuleExtras::empty(), counterparty_version.clone()))
             }
 
-            fn on_recv_packet(
+            fn on_recv_packet_execute(
                 &mut self,
                 _packet: &Packet,
                 _relayer: &Signer,
@@ -1796,7 +1796,7 @@ mod tests {
                 Ok((ModuleExtras::empty(), counterparty_version.clone()))
             }
 
-            fn on_recv_packet(
+            fn on_recv_packet_execute(
                 &mut self,
                 _packet: &Packet,
                 _relayer: &Signer,
@@ -1856,7 +1856,7 @@ mod tests {
         let mut on_recv_packet_result = |module_id: &'static str| {
             let module_id = ModuleId::from_str(module_id).unwrap();
             let m = ctx.get_route_mut(&module_id).unwrap();
-            let result = m.on_recv_packet(
+            let result = m.on_recv_packet_execute(
                 &Packet::default(),
                 &get_dummy_bech32_account().parse().unwrap(),
             );

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -112,7 +112,7 @@ impl Module for DummyTransferModule {
         Ok((ModuleExtras::empty(), counterparty_version.clone()))
     }
 
-    fn on_recv_packet_execute(
+    fn on_recv_packet(
         &mut self,
         _packet: &Packet,
         _relayer: &Signer,

--- a/crates/ibc/src/test_utils.rs
+++ b/crates/ibc/src/test_utils.rs
@@ -112,7 +112,7 @@ impl Module for DummyTransferModule {
         Ok((ModuleExtras::empty(), counterparty_version.clone()))
     }
 
-    fn on_recv_packet(
+    fn on_recv_packet_execute(
         &mut self,
         _packet: &Packet,
         _relayer: &Signer,

--- a/crates/ibc/src/timestamp.rs
+++ b/crates/ibc/src/timestamp.rs
@@ -95,7 +95,7 @@ impl scale_info::TypeInfo for Timestamp {
 
 // TODO: derive when tendermint::Time supports it:
 // https://github.com/informalsystems/tendermint-rs/pull/1054
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Timestamp {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let odt: Option<OffsetDateTime> = self.time.map(Into::into);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #502

### Remark

I attempted the separation of the `recv_packet` function into `recv_packet_validate` and `recv_packet_execute` , but encountered a limitation to do so, because:
Even if the validation fails, we still need to perform some _execution_ logic. Specifically, we need to store a failure `acknowledgement` containing the error log and emit the subsequent event. The problem is that we don't have mutable access to the context in the validation step, which makes it tricky to properly implement this logic.

There might be a way to solve this, but, IMO, highly likely requires us to touch some other parts and make changes beyond the scope of the current PR. Thus, I decided to put any ideas around this on hold, and that's the implementation I could come up with for now.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
