### PR TITLE
prefix demon parity scale encoding enabled

### DIFF
--- a/.changelog/unreleased/feature/577-prefixed-denom-for-scale-codec.md
+++ b/.changelog/unreleased/feature/577-prefixed-denom-for-scale-codec.md
@@ -1,0 +1,2 @@
+- Prefixed denom parity scale codec enabled
+  ([#577](https://github.com/cosmos/ibc-rs/pull/577))

--- a/crates/ibc/src/applications/transfer/denom.rs
+++ b/crates/ibc/src/applications/transfer/denom.rs
@@ -14,6 +14,14 @@ use crate::serializers::serde_string;
 /// Base denomination type
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Display)]
 pub struct BaseDenom(String);
 
@@ -35,6 +43,14 @@ impl FromStr for BaseDenom {
     }
 }
 
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub struct TracePrefix {
     port_id: PortId,
@@ -60,6 +76,14 @@ impl Display for TracePrefix {
 // Internally, the `TracePath` is modelled as a `Vec<TracePrefix>` but with the order reversed, i.e.
 // "transfer/channel-0/transfer/channel-1/uatom" => `["transfer/channel-1", "transfer/channel-0"]`
 // This is done for ease of addition/removal of prefixes.
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord, From)]
 pub struct TracePath(Vec<TracePrefix>);
 
@@ -150,6 +174,14 @@ impl Display for TracePath {
 
 /// A type that contains the base denomination for ICS20 and the source tracing information path.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PrefixedDenom {
     /// A series of `{port-id}/{channel-id}`s for tracing the source of the token.


### PR DESCRIPTION
Closes: #N/A

## Description

Allow to store prefixed denom in Substrate storage and used in extrinsic (transaction instructions) to allow configuration for specified denoms and prefixes.

______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [X] No need to test, I just have built with relevant feature.
- [X] No GH issue, but issues and pulls share same incremental id, so used it. 
- [X] Actually some of stuff had already borsch and all had serde, so it was trivial, no need docs.
- [X] @hu55a1n1 

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
