### PR TITLE
ics26_routing: Impl `Protobuf<Any>` for `MsgEnvelope`

### DIFF
--- a/.changelog/unreleased/feature/586-msg-envelope-to-protobuf.md
+++ b/.changelog/unreleased/feature/586-msg-envelope-to-protobuf.md
@@ -1,0 +1,1 @@
+- Impl `Protobuf<Any>` for `MsgEnvelope` ([#586](https://github.com/cosmos/ibc-rs/issues/586))

--- a/crates/ibc/src/core/ics26_routing/msgs.rs
+++ b/crates/ibc/src/core/ics26_routing/msgs.rs
@@ -13,6 +13,7 @@ use crate::core::ics04_channel::msgs::{
     chan_open_init, chan_open_try, recv_packet, timeout, timeout_on_close, ChannelMsg, PacketMsg,
 };
 use crate::core::ics26_routing::error::RouterError;
+use crate::tx_msg::Msg as _;
 use ibc_proto::protobuf::Protobuf;
 
 /// Enumeration of all messages that the local ICS26 module is capable of routing.
@@ -23,6 +24,8 @@ pub enum MsgEnvelope {
     Channel(ChannelMsg),
     Packet(PacketMsg),
 }
+
+impl Protobuf<Any> for MsgEnvelope {}
 
 impl TryFrom<Any> for MsgEnvelope {
     type Error = RouterError;
@@ -134,6 +137,37 @@ impl TryFrom<Any> for MsgEnvelope {
             _ => Err(RouterError::UnknownMessageTypeUrl {
                 url: any_msg.type_url,
             }),
+        }
+    }
+}
+
+impl From<MsgEnvelope> for Any {
+    fn from(ics_msg: MsgEnvelope) -> Self {
+        match ics_msg {
+            // ICS2 messages
+            MsgEnvelope::Client(ClientMsg::CreateClient(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Client(ClientMsg::UpdateClient(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Client(ClientMsg::UpgradeClient(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Client(ClientMsg::Misbehaviour(domain_msg)) => domain_msg.to_any(),
+
+            // ICS03
+            MsgEnvelope::Connection(ConnectionMsg::OpenInit(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Connection(ConnectionMsg::OpenTry(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Connection(ConnectionMsg::OpenAck(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Connection(ConnectionMsg::OpenConfirm(domain_msg)) => domain_msg.to_any(),
+
+            // ICS04 channel messages
+            MsgEnvelope::Channel(ChannelMsg::OpenInit(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Channel(ChannelMsg::OpenTry(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Channel(ChannelMsg::OpenAck(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Channel(ChannelMsg::OpenConfirm(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Channel(ChannelMsg::CloseInit(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Channel(ChannelMsg::CloseConfirm(domain_msg)) => domain_msg.to_any(),
+            // ICS04 packet messages
+            MsgEnvelope::Packet(PacketMsg::Recv(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Packet(PacketMsg::Ack(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Packet(PacketMsg::Timeout(domain_msg)) => domain_msg.to_any(),
+            MsgEnvelope::Packet(PacketMsg::TimeoutOnClose(domain_msg)) => domain_msg.to_any(),
         }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Implement `Protobuf<Any>` for `MsgEnvelope` so that serialization of `MsgEnvelope` types is possible. This matches the already-existing `TryFrom<Any>` implementation.

Using `msg.encode_vec().unwrap()` is safe because `.encode_vec()` will never return an error, as the buffer will always be constructed to be the correct size. I will submit a follow-up PR to ibc-proto to update the return type of `encode_vec()`.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
