### PR TITLE
tx_msg: Remove panic in `Msg::get_sign_bytes`

### DIFF
--- a/.changelog/unreleased/bug/593-remove-tx-msg-panic.md
+++ b/.changelog/unreleased/bug/593-remove-tx-msg-panic.md
@@ -1,0 +1,2 @@
+- tx_msg: Remove panic in `Msg::get_sign_bytes`
+  ([#593](https://github.com/cosmos/ibc-rs/issues/593))

--- a/crates/ibc/src/tx_msg.rs
+++ b/crates/ibc/src/tx_msg.rs
@@ -8,16 +8,8 @@ pub trait Msg: Clone {
     fn type_url(&self) -> String;
 
     fn get_sign_bytes(self) -> Vec<u8> {
-        let mut buf = Vec::new();
         let raw_msg: Self::Raw = self.into();
-        match prost::Message::encode(&raw_msg, &mut buf) {
-            Ok(()) => buf,
-            // Severe error that cannot be recovered.
-            Err(e) => panic!(
-                "Cannot encode the proto message {:?} into a buffer due to underlying error: {}",
-                raw_msg, e
-            ),
-        }
+        prost::Message::encode_to_vec(&raw_msg)
     }
 
     fn to_any(self) -> Any {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #593

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Remove the `panic` in `tx_msg::Msg::get_sign_bytes` by using `prost::Message::encode_to_vec`.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
