### PR TITLE
Bump ibc-proto to v0.29.0 and add `memo` field to `PacketData`

### DIFF
--- a/.changelog/unreleased/breaking-changes/559-bump-ibc-proto.md
+++ b/.changelog/unreleased/breaking-changes/559-bump-ibc-proto.md
@@ -1,0 +1,2 @@
+- Bump ibc-proto to v0.29.0, bump tendermint to v0.30.0, and add `memo` field to
+  `PacketData` ([#559](https://github.com/cosmos/ibc-rs/issues/559))

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -52,7 +52,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.26.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.29.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.9.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.21", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -80,20 +80,20 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint]
-version = "0.29"
+version = "0.30"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.29"
+version = "0.30"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.29"
+version = "0.30"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.29"
+version = "0.30"
 optional = true
 default-features = false
 
@@ -102,7 +102,7 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.29", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.29" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.30", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.30" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc/src/applications/transfer/context.rs
+++ b/crates/ibc/src/applications/transfer/context.rs
@@ -287,6 +287,7 @@ pub fn on_recv_packet_execute(
         receiver: data.receiver,
         denom: data.token.denom,
         amount: data.token.amount,
+        memo: data.memo,
         success: ack.is_successful(),
     };
     extras.events.push(recv_event.into());
@@ -355,6 +356,7 @@ pub fn on_acknowledgement_packet_execute(
         receiver: data.receiver,
         denom: data.token.denom,
         amount: data.token.amount,
+        memo: data.memo,
         acknowledgement: acknowledgement.clone(),
     };
 
@@ -405,6 +407,7 @@ pub fn on_timeout_packet_execute(
         refund_receiver: data.sender,
         refund_denom: data.token.denom,
         refund_amount: data.token.amount,
+        memo: data.memo,
     };
 
     let extras = ModuleExtras {

--- a/crates/ibc/src/applications/transfer/events.rs
+++ b/crates/ibc/src/applications/transfer/events.rs
@@ -1,5 +1,5 @@
 use crate::applications::transfer::acknowledgement::TokenTransferAcknowledgement;
-use crate::applications::transfer::{Amount, PrefixedDenom, MODULE_ID_STR};
+use crate::applications::transfer::{Amount, Memo, PrefixedDenom, MODULE_ID_STR};
 use crate::events::ModuleEvent;
 use crate::prelude::*;
 use crate::signer::Signer;
@@ -23,6 +23,7 @@ pub struct RecvEvent {
     pub receiver: Signer,
     pub denom: PrefixedDenom,
     pub amount: Amount,
+    pub memo: Memo,
     pub success: bool,
 }
 
@@ -33,6 +34,7 @@ impl From<RecvEvent> for ModuleEvent {
             receiver,
             denom,
             amount,
+            memo,
             success,
         } = ev;
         Self {
@@ -43,6 +45,7 @@ impl From<RecvEvent> for ModuleEvent {
                 ("receiver", receiver).into(),
                 ("denom", denom).into(),
                 ("amount", amount).into(),
+                ("memo", memo).into(),
                 ("success", success).into(),
             ],
         }
@@ -54,6 +57,7 @@ pub struct AckEvent {
     pub receiver: Signer,
     pub denom: PrefixedDenom,
     pub amount: Amount,
+    pub memo: Memo,
     pub acknowledgement: TokenTransferAcknowledgement,
 }
 
@@ -64,6 +68,7 @@ impl From<AckEvent> for ModuleEvent {
             receiver,
             denom,
             amount,
+            memo,
             acknowledgement,
         } = ev;
         Self {
@@ -74,6 +79,7 @@ impl From<AckEvent> for ModuleEvent {
                 ("receiver", receiver).into(),
                 ("denom", denom).into(),
                 ("amount", amount).into(),
+                ("memo", memo).into(),
                 ("acknowledgement", acknowledgement).into(),
             ],
         }
@@ -103,6 +109,7 @@ pub struct TimeoutEvent {
     pub refund_receiver: Signer,
     pub refund_denom: PrefixedDenom,
     pub refund_amount: Amount,
+    pub memo: Memo,
 }
 
 impl From<TimeoutEvent> for ModuleEvent {
@@ -111,6 +118,7 @@ impl From<TimeoutEvent> for ModuleEvent {
             refund_receiver,
             refund_denom,
             refund_amount,
+            memo,
         } = ev;
         Self {
             kind: EVENT_TYPE_TIMEOUT.to_string(),
@@ -119,6 +127,7 @@ impl From<TimeoutEvent> for ModuleEvent {
                 ("refund_receiver", refund_receiver).into(),
                 ("refund_denom", refund_denom).into(),
                 ("refund_amount", refund_amount).into(),
+                ("memo", memo).into(),
             ],
         }
     }
@@ -148,6 +157,7 @@ pub struct TransferEvent {
     pub receiver: Signer,
     pub amount: Amount,
     pub denom: PrefixedDenom,
+    pub memo: Memo,
 }
 
 impl From<TransferEvent> for ModuleEvent {
@@ -157,6 +167,7 @@ impl From<TransferEvent> for ModuleEvent {
             receiver,
             amount,
             denom,
+            memo,
         } = ev;
 
         Self {
@@ -166,6 +177,7 @@ impl From<TransferEvent> for ModuleEvent {
                 ("receiver", receiver).into(),
                 ("amount", amount).into(),
                 ("denom", denom).into(),
+                ("memo", memo).into(),
             ],
         }
     }

--- a/crates/ibc/src/applications/transfer/memo.rs
+++ b/crates/ibc/src/applications/transfer/memo.rs
@@ -1,0 +1,47 @@
+use core::convert::Infallible;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+
+use crate::prelude::*;
+
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Memo(String);
+
+impl AsRef<str> for Memo {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Memo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for Memo {
+    fn from(memo: String) -> Self {
+        Self(memo)
+    }
+}
+
+impl FromStr for Memo {
+    type Err = Infallible;
+
+    fn from_str(memo: &str) -> Result<Self, Infallible> {
+        Ok(Self(memo.to_owned()))
+    }
+}

--- a/crates/ibc/src/applications/transfer/mod.rs
+++ b/crates/ibc/src/applications/transfer/mod.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod denom;
 pub mod error;
 pub mod events;
+pub mod memo;
 pub mod msgs;
 pub mod packet;
 pub mod relay;
@@ -15,6 +16,7 @@ pub mod relay;
 pub use amount::*;
 pub use coin::*;
 pub use denom::*;
+pub use memo::*;
 
 /// Module identifier for the ICS20 application.
 pub const MODULE_ID_STR: &str = "transfer";

--- a/crates/ibc/src/applications/transfer/msgs/transfer.rs
+++ b/crates/ibc/src/applications/transfer/msgs/transfer.rs
@@ -83,6 +83,7 @@ impl TryFrom<RawMsgTransfer> for MsgTransfer {
                     .map_err(|_| TokenTransferError::InvalidToken)?,
                 sender: raw_msg.sender.into(),
                 receiver: raw_msg.receiver.into(),
+                memo: raw_msg.memo.into(),
             },
             timeout_height_on_b,
             timeout_timestamp_on_b,
@@ -100,6 +101,7 @@ impl From<MsgTransfer> for RawMsgTransfer {
             receiver: domain_msg.packet_data.receiver.to_string(),
             timeout_height: domain_msg.timeout_height_on_b.into(),
             timeout_timestamp: domain_msg.timeout_timestamp_on_b.nanoseconds(),
+            memo: domain_msg.packet_data.memo.to_string(),
         }
     }
 }
@@ -123,6 +125,7 @@ impl TryFrom<Any> for MsgTransfer {
 
 #[cfg(test)]
 pub mod test_util {
+    use alloc::borrow::ToOwned;
     use core::ops::Add;
     use core::time::Duration;
     use primitive_types::U256;
@@ -158,6 +161,7 @@ pub mod test_util {
                 .into(),
                 sender: address.clone(),
                 receiver: address,
+                memo: "".to_owned().into(),
             },
             timeout_timestamp_on_b: timeout_timestamp
                 .unwrap_or_else(|| Timestamp::now().add(Duration::from_secs(10)).unwrap()),
@@ -176,6 +180,7 @@ pub mod test_util {
                 token: coin,
                 sender: msg.packet_data.sender.clone(),
                 receiver: msg.packet_data.receiver.clone(),
+                memo: msg.packet_data.memo.clone(),
             };
             serde_json::to_vec(&data).expect("PacketData's infallible Serialize impl failed")
         };

--- a/crates/ibc/src/applications/transfer/packet.rs
+++ b/crates/ibc/src/applications/transfer/packet.rs
@@ -5,7 +5,7 @@ use core::str::FromStr;
 use ibc_proto::ibc::applications::transfer::v2::FungibleTokenPacketData as RawPacketData;
 
 use super::error::TokenTransferError;
-use super::{Amount, PrefixedCoin, PrefixedDenom};
+use super::{Amount, Memo, PrefixedCoin, PrefixedDenom};
 use crate::signer::Signer;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -18,6 +18,7 @@ pub struct PacketData {
     pub token: PrefixedCoin,
     pub sender: Signer,
     pub receiver: Signer,
+    pub memo: Memo,
 }
 
 impl TryFrom<RawPacketData> for PacketData {
@@ -31,6 +32,7 @@ impl TryFrom<RawPacketData> for PacketData {
             token: PrefixedCoin { denom, amount },
             sender: raw_pkt_data.sender.into(),
             receiver: raw_pkt_data.receiver.into(),
+            memo: raw_pkt_data.memo.into(),
         })
     }
 }
@@ -42,6 +44,7 @@ impl From<PacketData> for RawPacketData {
             amount: pkt_data.token.amount.to_string(),
             sender: pkt_data.sender.to_string(),
             receiver: pkt_data.receiver.to_string(),
+            memo: pkt_data.memo.to_string(),
         }
     }
 }

--- a/crates/ibc/src/applications/transfer/relay/send_transfer.rs
+++ b/crates/ibc/src/applications/transfer/relay/send_transfer.rs
@@ -168,6 +168,7 @@ where
             receiver: msg.packet_data.receiver,
             amount: msg.packet_data.token.amount,
             denom: msg.packet_data.token.denom,
+            memo: msg.packet_data.memo,
         };
         ctx_a.emit_ibc_event(ModuleEvent::from(transfer_event).into());
 

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -422,8 +422,7 @@ impl Ics2ClientState for ClientState {
 
         upgraded_tm_client_state.zero_custom_fields();
         let client_state_value =
-            Protobuf::<RawTmClientState>::encode_vec(&upgraded_tm_client_state)
-                .map_err(ClientError::Encode)?;
+            Protobuf::<RawTmClientState>::encode_vec(&upgraded_tm_client_state);
 
         // Verify the proof of the upgraded client state
         merkle_proof_upgrade_client
@@ -444,8 +443,7 @@ impl Ics2ClientState for ClientState {
             key_path: cons_upgrade_path,
         };
 
-        let cons_state_value = Protobuf::<RawTmConsensusState>::encode_vec(&upgraded_tm_cons_state)
-            .map_err(ClientError::Encode)?;
+        let cons_state_value = Protobuf::<RawTmConsensusState>::encode_vec(&upgraded_tm_cons_state);
 
         // Verify the proof of the upgraded consensus state
         merkle_proof_upgrade_cons_state
@@ -725,8 +723,7 @@ impl From<ClientState> for Any {
     fn from(client_state: ClientState) -> Self {
         Any {
             type_url: TENDERMINT_CLIENT_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawTmClientState>::encode_vec(&client_state)
-                .expect("encoding to `Any` from `TmClientState`"),
+            value: Protobuf::<RawTmClientState>::encode_vec(&client_state),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
@@ -127,8 +127,7 @@ impl From<ConsensusState> for Any {
     fn from(consensus_state: ConsensusState) -> Self {
         Any {
             type_url: TENDERMINT_CONSENSUS_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawConsensusState>::encode_vec(&consensus_state)
-                .expect("encoding to `Any` from `TmConsensusState`"),
+            value: Protobuf::<RawConsensusState>::encode_vec(&consensus_state),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/header.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/header.rs
@@ -154,8 +154,7 @@ impl From<Header> for Any {
     fn from(header: Header) -> Self {
         Any {
             type_url: TENDERMINT_HEADER_TYPE_URL.to_string(),
-            value: Protobuf::<RawHeader>::encode_vec(&header)
-                .expect("encoding to `Any` from `TmHeader`"),
+            value: Protobuf::<RawHeader>::encode_vec(&header),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/misbehaviour.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/misbehaviour.rs
@@ -120,8 +120,7 @@ impl From<Misbehaviour> for Any {
     fn from(misbehaviour: Misbehaviour) -> Self {
         Any {
             type_url: TENDERMINT_MISBEHAVIOUR_TYPE_URL.to_string(),
-            value: Protobuf::<RawMisbehaviour>::encode_vec(&misbehaviour)
-                .expect("encoding to `Any` from `TmMisbehaviour`"),
+            value: Protobuf::<RawMisbehaviour>::encode_vec(&misbehaviour),
         }
     }
 }

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -223,6 +223,7 @@ mod tests {
                 },
                 sender: msg_transfer_two.packet_data.sender.clone(),
                 receiver: msg_transfer_two.packet_data.receiver.clone(),
+                memo: "".to_owned().into(),
             };
             serde_json::to_vec(&data).expect("PacketData's infallible Serialize impl failed")
         };

--- a/crates/ibc/src/core/ics02_client/error.rs
+++ b/crates/ibc/src/core/ics02_client/error.rs
@@ -51,8 +51,6 @@ pub enum ClientError {
     MissingRawConsensusState,
     /// invalid client id in the update client message: `{0}`
     InvalidMsgUpdateClientId(ValidationError),
-    /// Encode error: `{0}`
-    Encode(TendermintProtoError),
     /// decode error: `{0}`
     Decode(prost::DecodeError),
     /// invalid client identifier error: `{0}`

--- a/crates/ibc/src/core/ics03_connection/connection.rs
+++ b/crates/ibc/src/core/ics03_connection/connection.rs
@@ -357,13 +357,6 @@ impl ConnectionEnd {
     pub fn validate_basic(&self) -> Result<(), ValidationError> {
         self.counterparty.validate_basic()
     }
-
-    pub(crate) fn proto_encode_vec(&self) -> Result<Vec<u8>, ConnectionError> {
-        let value = self
-            .encode_vec()
-            .map_err(ConnectionError::InvalidConnectionEnd)?;
-        Ok(value)
-    }
 }
 
 #[cfg_attr(

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -1,9 +1,9 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenAck`.
 
+use ibc_proto::protobuf::Protobuf;
 use prost::Message;
 
 use crate::core::context::ContextError;
-use crate::core::ics02_client::error::ClientError;
 use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::events::OpenAck;
@@ -99,7 +99,7 @@ where
                     &msg.proof_conn_end_on_b,
                     consensus_state_of_b_on_a.root(),
                     Path::Connection(ConnectionPath::new(&msg.conn_id_on_b)),
-                    expected_conn_end_on_b.proto_encode_vec()?,
+                    expected_conn_end_on_b.encode_vec(),
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
         }
@@ -132,9 +132,7 @@ where
                 &msg.proof_consensus_state_of_a_on_b,
                 consensus_state_of_b_on_a.root(),
                 Path::ClientConsensusState(client_cons_state_path_on_b),
-                expected_consensus_state_of_a_on_b
-                    .encode_vec()
-                    .map_err(ClientError::Encode)?,
+                expected_consensus_state_of_a_on_b.encode_vec(),
             )
             .map_err(|e| ConnectionError::ConsensusStateVerificationFailure {
                 height: msg.proofs_height_on_b,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -1,5 +1,7 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenConfirm`.
 
+use ibc_proto::protobuf::Protobuf;
+
 use crate::core::context::ContextError;
 use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::error::ConnectionError;
@@ -84,7 +86,7 @@ where
                 &msg.proof_conn_end_on_a,
                 consensus_state_of_a_on_b.root(),
                 Path::Connection(ConnectionPath::new(conn_id_on_a)),
-                expected_conn_end_on_a.proto_encode_vec()?,
+                expected_conn_end_on_a.encode_vec(),
             )
             .map_err(ConnectionError::VerifyConnectionState)?;
     }

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -1,9 +1,9 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenTry`.
 
+use ibc_proto::protobuf::Protobuf;
 use prost::Message;
 
 use crate::core::context::ContextError;
-use crate::core::ics02_client::error::ClientError;
 use crate::core::ics03_connection::connection::{ConnectionEnd, Counterparty, State};
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::events::OpenTry;
@@ -91,7 +91,7 @@ where
                     &msg.proof_conn_end_on_a,
                     consensus_state_of_a_on_b.root(),
                     Path::Connection(ConnectionPath::new(&vars.conn_id_on_a)),
-                    expected_conn_end_on_a.proto_encode_vec()?,
+                    expected_conn_end_on_a.encode_vec(),
                 )
                 .map_err(ConnectionError::VerifyConnectionState)?;
         }
@@ -124,9 +124,7 @@ where
                 &msg.proof_consensus_state_of_b_on_a,
                 consensus_state_of_a_on_b.root(),
                 Path::ClientConsensusState(client_cons_state_path_on_a),
-                expected_consensus_state_of_b_on_a
-                    .encode_vec()
-                    .map_err(ClientError::Encode)?,
+                expected_consensus_state_of_b_on_a.encode_vec(),
             )
             .map_err(|e| ConnectionError::ConsensusStateVerificationFailure {
                 height: msg.proofs_height_on_a,

--- a/crates/ibc/src/core/ics04_channel/channel.rs
+++ b/crates/ibc/src/core/ics04_channel/channel.rs
@@ -272,15 +272,6 @@ impl ChannelEnd {
     pub fn version_matches(&self, other: &Version) -> bool {
         self.version().eq(other)
     }
-
-    pub(crate) fn proto_encode_vec(&self) -> Result<Vec<u8>, ChannelError> {
-        let value = self
-            .encode_vec()
-            .map_err(|_| ChannelError::InvalidChannelEnd {
-                channel_end: self.to_string(),
-            })?;
-        Ok(value)
-    }
 }
 
 #[cfg_attr(

--- a/crates/ibc/src/core/ics04_channel/error.rs
+++ b/crates/ibc/src/core/ics04_channel/error.rs
@@ -21,8 +21,6 @@ pub enum ChannelError {
     UnknownState { state: i32 },
     /// channel order type unknown: `{type_id}`
     UnknownOrderType { type_id: String },
-    /// invalid channel end: `{channel_end}`
-    InvalidChannelEnd { channel_end: String },
     /// invalid connection hops length: expected `{expected}`; actual `{actual}`
     InvalidConnectionHopsLength { expected: usize, actual: usize },
     /// invalid signer error: `{reason}`

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -1,5 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseConfirm`.
 
+use ibc_proto::protobuf::Protobuf;
+
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
 use crate::core::ics04_channel::error::ChannelError;
@@ -85,7 +87,7 @@ where
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
                 Path::ChannelEnd(chan_end_path_on_a),
-                expected_chan_end_on_a.proto_encode_vec()?,
+                expected_chan_end_on_a.encode_vec(),
             )
             .map_err(ChannelError::VerifyChannelFailed)?;
     }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -1,4 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenAck`.
+
+use ibc_proto::protobuf::Protobuf;
+
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
 use crate::core::ics04_channel::error::ChannelError;
@@ -83,7 +86,7 @@ where
                 &msg.proof_chan_end_on_b,
                 consensus_state_of_b_on_a.root(),
                 Path::ChannelEnd(chan_end_path_on_b),
-                expected_chan_end_on_b.proto_encode_vec()?,
+                expected_chan_end_on_b.encode_vec(),
             )
             .map_err(ChannelError::VerifyChannelFailed)?;
     }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -1,5 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenConfirm`.
 
+use ibc_proto::protobuf::Protobuf;
+
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
 use crate::core::ics04_channel::error::ChannelError;
@@ -86,7 +88,7 @@ where
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
                 Path::ChannelEnd(chan_end_path_on_a),
-                expected_chan_end_on_a.proto_encode_vec()?,
+                expected_chan_end_on_a.encode_vec(),
             )
             .map_err(ChannelError::VerifyChannelFailed)?;
     }

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -1,5 +1,7 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenTry`.
 
+use ibc_proto::protobuf::Protobuf;
+
 use crate::core::ics03_connection::connection::State as ConnectionState;
 use crate::core::ics04_channel::channel::{ChannelEnd, Counterparty, State};
 use crate::core::ics04_channel::error::ChannelError;
@@ -73,7 +75,7 @@ where
                 &msg.proof_chan_end_on_a,
                 consensus_state_of_a_on_b.root(),
                 Path::ChannelEnd(chan_end_path_on_a),
-                expected_chan_end_on_a.proto_encode_vec()?,
+                expected_chan_end_on_a.encode_vec(),
             )
             .map_err(ChannelError::VerifyChannelFailed)?;
     }

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -1,3 +1,4 @@
+use ibc_proto::protobuf::Protobuf;
 use prost::Message;
 
 use crate::core::ics03_connection::delay::verify_conn_delay_passed;
@@ -116,7 +117,7 @@ where
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
                 Path::ChannelEnd(chan_end_path_on_b),
-                expected_chan_end_on_b.proto_encode_vec()?,
+                expected_chan_end_on_b.encode_vec(),
             )
             .map_err(ChannelError::VerifyChannelFailed)
             .map_err(PacketError::Channel)?;

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -132,8 +132,7 @@ impl From<MockClientState> for Any {
     fn from(client_state: MockClientState) -> Self {
         Any {
             type_url: MOCK_CLIENT_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawMockClientState>::encode_vec(&client_state)
-                .expect("encoding to `Any` from `MockClientState`"),
+            value: Protobuf::<RawMockClientState>::encode_vec(&client_state),
         }
     }
 }

--- a/crates/ibc/src/mock/consensus_state.rs
+++ b/crates/ibc/src/mock/consensus_state.rs
@@ -89,8 +89,7 @@ impl From<MockConsensusState> for Any {
     fn from(consensus_state: MockConsensusState) -> Self {
         Any {
             type_url: MOCK_CONSENSUS_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawMockConsensusState>::encode_vec(&consensus_state)
-                .expect("encoding to `Any` from `MockConsensusState`"),
+            value: Protobuf::<RawMockConsensusState>::encode_vec(&consensus_state),
         }
     }
 }

--- a/crates/ibc/src/mock/header.rs
+++ b/crates/ibc/src/mock/header.rs
@@ -121,8 +121,7 @@ impl From<MockHeader> for Any {
     fn from(header: MockHeader) -> Self {
         Any {
             type_url: MOCK_HEADER_TYPE_URL.to_string(),
-            value: Protobuf::<RawMockHeader>::encode_vec(&header)
-                .expect("encoding to `Any` from `TmHeader`"),
+            value: Protobuf::<RawMockHeader>::encode_vec(&header),
         }
     }
 }
@@ -135,7 +134,7 @@ mod tests {
     #[test]
     fn encode_any() {
         let header = MockHeader::new(Height::new(1, 10).unwrap()).with_timestamp(Timestamp::none());
-        let bytes = <MockHeader as Protobuf<Any>>::encode_vec(&header).unwrap();
+        let bytes = <MockHeader as Protobuf<Any>>::encode_vec(&header);
 
         assert_eq!(
             &bytes,

--- a/crates/ibc/src/mock/misbehaviour.rs
+++ b/crates/ibc/src/mock/misbehaviour.rs
@@ -80,8 +80,7 @@ impl From<Misbehaviour> for Any {
     fn from(misbehaviour: Misbehaviour) -> Self {
         Any {
             type_url: MOCK_MISBEHAVIOUR_TYPE_URL.to_string(),
-            value: Protobuf::<RawMisbehaviour>::encode_vec(&misbehaviour)
-                .expect("encoding to `Any` from `TmMisbehaviour`"),
+            value: Protobuf::<RawMisbehaviour>::encode_vec(&misbehaviour),
         }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #559

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
This PR bumps ibc-proto to v0.29.0, which also introduces the `memo` field that is added to `PacketData` for ICS-20, and tendermint to v0.30.0.

Most of the other changes are due to `Protobuf::encode_vec` no longer returning a `Result`.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
