### PR TITLE
Split `MsgUpdateClient` back into `MsgUpdateClient` and `MsgSubmitMisbehaviour`

### DIFF
--- a/.changelog/unreleased/breaking-changes/628-split-msgupdateclient.md
+++ b/.changelog/unreleased/breaking-changes/628-split-msgupdateclient.md
@@ -1,0 +1,2 @@
+- Split `MsgUpdateClient` back into `MsgUpdateClient` and `MsgSubmitMisbehaviour`
+  ([#628](https://github.com/cosmos/ibc-rs/issues/628))

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -1,7 +1,6 @@
 mod misbehaviour;
 mod update_client;
 
-use crate::core::ics02_client::msgs::update_client::UpdateKind;
 use crate::prelude::*;
 
 use core::cmp::max;
@@ -26,7 +25,7 @@ use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConse
 use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header as TmHeader;
 use crate::clients::ics07_tendermint::misbehaviour::Misbehaviour as TmMisbehaviour;
-use crate::core::ics02_client::client_state::{ClientState as Ics2ClientState, UpdatedState};
+use crate::core::ics02_client::client_state::{ClientState as Ics2ClientState, UpdatedState, UpdateKind};
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -306,13 +306,9 @@ impl Ics2ClientState for ClientState {
         &self,
         ctx: &mut dyn ExecutionContext,
         client_id: &ClientId,
-        client_message: Any,
-        _update_kind: &UpdateKind,
+        header: Any,
     ) -> Result<Vec<Height>, ClientError> {
-        // we only expect headers to make it here; if a TmMisbehaviour makes it to here,
-        // then it is not a valid misbehaviour (check_for_misbehaviour returned false),
-        // and so transaction should fail.
-        let header = TmHeader::try_from(client_message)?;
+        let header = TmHeader::try_from(header)?;
         let header_height = header.height();
 
         let maybe_existing_consensus_state = {

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -25,7 +25,9 @@ use crate::clients::ics07_tendermint::consensus_state::ConsensusState as TmConse
 use crate::clients::ics07_tendermint::error::Error;
 use crate::clients::ics07_tendermint::header::Header as TmHeader;
 use crate::clients::ics07_tendermint::misbehaviour::Misbehaviour as TmMisbehaviour;
-use crate::core::ics02_client::client_state::{ClientState as Ics2ClientState, UpdatedState, UpdateKind};
+use crate::core::ics02_client::client_state::{
+    ClientState as Ics2ClientState, UpdateKind, UpdatedState,
+};
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -22,6 +22,7 @@ use self::acknowledgement::{acknowledgement_packet_execute, acknowledgement_pack
 use self::recv_packet::{recv_packet_execute, recv_packet_validate};
 use self::timeout::{timeout_packet_execute, timeout_packet_validate, TimeoutMsgType};
 
+use super::ics02_client::msgs::MsgUpdateOrMisbehaviour;
 use super::{
     ics02_client::error::ClientError,
     ics03_connection::error::ConnectionError,
@@ -173,8 +174,12 @@ pub trait ValidationContext: Router {
         match msg {
             MsgEnvelope::Client(msg) => match msg {
                 ClientMsg::CreateClient(msg) => create_client::validate(self, msg),
-                ClientMsg::UpdateClient(msg) => update_client::validate(self, msg),
-                ClientMsg::Misbehaviour(_msg) => todo!(),
+                ClientMsg::UpdateClient(msg) => {
+                    update_client::validate(self, MsgUpdateOrMisbehaviour::UpdateClient(msg))
+                }
+                ClientMsg::Misbehaviour(msg) => {
+                    update_client::validate(self, MsgUpdateOrMisbehaviour::Misbehaviour(msg))
+                }
                 ClientMsg::UpgradeClient(msg) => upgrade_client::validate(self, msg),
             }
             .map_err(RouterError::ContextError),
@@ -382,8 +387,12 @@ pub trait ExecutionContext: ValidationContext {
         match msg {
             MsgEnvelope::Client(msg) => match msg {
                 ClientMsg::CreateClient(msg) => create_client::execute(self, msg),
-                ClientMsg::UpdateClient(msg) => update_client::execute(self, msg),
-                ClientMsg::Misbehaviour(_) => todo!(),
+                ClientMsg::UpdateClient(msg) => {
+                    update_client::execute(self, MsgUpdateOrMisbehaviour::UpdateClient(msg))
+                }
+                ClientMsg::Misbehaviour(msg) => {
+                    update_client::execute(self, MsgUpdateOrMisbehaviour::Misbehaviour(msg))
+                }
                 ClientMsg::UpgradeClient(msg) => upgrade_client::execute(self, msg),
             }
             .map_err(RouterError::ContextError),

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -174,6 +174,7 @@ pub trait ValidationContext: Router {
             MsgEnvelope::Client(msg) => match msg {
                 ClientMsg::CreateClient(msg) => create_client::validate(self, msg),
                 ClientMsg::UpdateClient(msg) => update_client::validate(self, msg),
+                ClientMsg::Misbehaviour(_msg) => todo!(),
                 ClientMsg::UpgradeClient(msg) => upgrade_client::validate(self, msg),
             }
             .map_err(RouterError::ContextError),
@@ -382,6 +383,7 @@ pub trait ExecutionContext: ValidationContext {
             MsgEnvelope::Client(msg) => match msg {
                 ClientMsg::CreateClient(msg) => create_client::execute(self, msg),
                 ClientMsg::UpdateClient(msg) => update_client::execute(self, msg),
+                ClientMsg::Misbehaviour(_) => todo!(),
                 ClientMsg::UpgradeClient(msg) => upgrade_client::execute(self, msg),
             }
             .map_err(RouterError::ContextError),

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -50,7 +50,6 @@ mod tests {
         msgs::transfer::test_util::get_dummy_msg_transfer, msgs::transfer::MsgTransfer,
         packet::PacketData, PrefixedCoin, MODULE_ID_STR,
     };
-    use crate::core::ics02_client::msgs::update_client::UpdateKind;
     use crate::core::ics02_client::msgs::{
         create_client::MsgCreateClient, update_client::MsgUpdateClient,
         upgrade_client::MsgUpgradeClient, ClientMsg,
@@ -273,7 +272,6 @@ mod tests {
                     header: MockHeader::new(update_client_height)
                         .with_timestamp(Timestamp::now())
                         .into(),
-                    update_kind: UpdateKind::UpdateClient,
                     signer: default_signer.clone(),
                 }))
                 .into(),
@@ -285,7 +283,6 @@ mod tests {
                 msg: MsgEnvelope::Client(ClientMsg::UpdateClient(MsgUpdateClient {
                     client_id: client_id.clone(),
                     header: MockHeader::new(update_client_height).into(),
-                    update_kind: UpdateKind::UpdateClient,
                     signer: default_signer.clone(),
                 }))
                 .into(),
@@ -363,7 +360,6 @@ mod tests {
                     header: MockHeader::new(update_client_height_after_send)
                         .with_timestamp(Timestamp::now())
                         .into(),
-                    update_kind: UpdateKind::UpdateClient,
                     signer: default_signer.clone(),
                 }))
                 .into(),
@@ -407,7 +403,6 @@ mod tests {
                 msg: MsgEnvelope::Client(ClientMsg::UpdateClient(MsgUpdateClient {
                     client_id: client_id.clone(),
                     header: MockHeader::new(update_client_height_after_second_send).into(),
-                    update_kind: UpdateKind::UpdateClient,
                     signer: default_signer.clone(),
                 }))
                 .into(),

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -270,7 +270,7 @@ mod tests {
                 name: "Client update successful".to_string(),
                 msg: MsgEnvelope::Client(ClientMsg::UpdateClient(MsgUpdateClient {
                     client_id: client_id.clone(),
-                    client_message: MockHeader::new(update_client_height)
+                    header: MockHeader::new(update_client_height)
                         .with_timestamp(Timestamp::now())
                         .into(),
                     update_kind: UpdateKind::UpdateClient,
@@ -284,7 +284,7 @@ mod tests {
                 name: "Client update fails due to stale header".to_string(),
                 msg: MsgEnvelope::Client(ClientMsg::UpdateClient(MsgUpdateClient {
                     client_id: client_id.clone(),
-                    client_message: MockHeader::new(update_client_height).into(),
+                    header: MockHeader::new(update_client_height).into(),
                     update_kind: UpdateKind::UpdateClient,
                     signer: default_signer.clone(),
                 }))
@@ -360,7 +360,7 @@ mod tests {
                 name: "Client update successful #2".to_string(),
                 msg: MsgEnvelope::Client(ClientMsg::UpdateClient(MsgUpdateClient {
                     client_id: client_id.clone(),
-                    client_message: MockHeader::new(update_client_height_after_send)
+                    header: MockHeader::new(update_client_height_after_send)
                         .with_timestamp(Timestamp::now())
                         .into(),
                     update_kind: UpdateKind::UpdateClient,
@@ -406,7 +406,7 @@ mod tests {
                 name: "Client update successful".to_string(),
                 msg: MsgEnvelope::Client(ClientMsg::UpdateClient(MsgUpdateClient {
                     client_id: client_id.clone(),
-                    client_message: MockHeader::new(update_client_height_after_second_send).into(),
+                    header: MockHeader::new(update_client_height_after_second_send).into(),
                     update_kind: UpdateKind::UpdateClient,
                     signer: default_signer.clone(),
                 }))

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -96,7 +96,7 @@ pub trait ClientState:
     /// client, such as the ClientState and corresponding ConsensusState. Upon
     /// successful update, a list of consensus heights is returned. It assumes
     /// the client_message has already been verified.
-    /// 
+    ///
     /// Note that `header` is the field associated with `UpdateKind::UpdateClient`.
     ///
     /// Post-condition: on success, the return value MUST contain at least one

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -96,6 +96,8 @@ pub trait ClientState:
     /// client, such as the ClientState and corresponding ConsensusState. Upon
     /// successful update, a list of consensus heights is returned. It assumes
     /// the client_message has already been verified.
+    /// 
+    /// Note that `header` is the field associated with `UpdateKind::UpdateClient`.
     ///
     /// Post-condition: on success, the return value MUST contain at least one
     /// height.
@@ -103,8 +105,7 @@ pub trait ClientState:
         &self,
         ctx: &mut dyn ExecutionContext,
         client_id: &ClientId,
-        client_message: Any,
-        update_kind: &UpdateKind,
+        header: Any,
     ) -> Result<Vec<Height>, ClientError>;
 
     /// update_state_on_misbehaviour should perform appropriate state changes on

--- a/crates/ibc/src/core/ics02_client/client_state.rs
+++ b/crates/ibc/src/core/ics02_client/client_state.rs
@@ -19,7 +19,6 @@ use crate::prelude::*;
 use crate::Height;
 
 use super::consensus_state::ConsensusState;
-use super::msgs::update_client::UpdateKind;
 
 use crate::core::{ExecutionContext, ValidationContext};
 
@@ -188,6 +187,19 @@ impl PartialEq<&Self> for Box<dyn ClientState> {
 
 pub fn downcast_client_state<CS: ClientState>(h: &dyn ClientState) -> Option<&CS> {
     h.as_any().downcast_ref::<CS>()
+}
+
+/// `UpdateKind` represents the 2 ways that a client can be updated
+/// in IBC: either through a `MsgUpdateClient`, or a `MsgSubmitMisbehaviour`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpdateKind {
+    /// this is the typical scenario where a new header is submitted to the client
+    /// to update the client. Note that light clients are free to define the type
+    /// of the object used to update them (e.g. could be a list of headers).
+    UpdateClient,
+    /// this is the scenario where misbehaviour is submitted to the client
+    /// (e.g 2 headers with the same height in Tendermint)
+    SubmitMisbehaviour,
 }
 
 pub struct UpdatedState {

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -1,11 +1,11 @@
 //! Protocol logic specific to processing ICS2 messages of type `MsgUpdateAnyClient`.
 
+use crate::core::ics02_client::client_state::UpdateKind;
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics02_client::msgs::MsgUpdateOrMisbehaviour;
 use crate::prelude::*;
 
 use crate::core::ics02_client::events::{ClientMisbehaviour, UpdateClient};
-use crate::core::ics02_client::msgs::update_client::UpdateKind;
 use crate::events::{IbcEvent, MessageEvent};
 
 use crate::core::context::ContextError;

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -14,11 +14,16 @@ pub mod misbehaviour;
 pub mod update_client;
 pub mod upgrade_client;
 
-#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub enum ClientMsg {
     CreateClient(MsgCreateClient),
     UpdateClient(MsgUpdateClient),
     Misbehaviour(MsgSubmitMisbehaviour),
     UpgradeClient(MsgUpgradeClient),
+}
+
+#[derive(Clone, Debug)]
+pub enum MsgUpdateOrMisbehaviour {
+    Update(MsgUpdateClient),
+    Misbehaviour(MsgSubmitMisbehaviour),
 }

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -4,10 +4,13 @@
 //! subsequently calls into the chain-specific (e.g., ICS 07) client handler. See:
 //! <https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics#create>.
 
+use ibc_proto::google::protobuf::Any;
+
 use crate::core::ics02_client::msgs::create_client::MsgCreateClient;
 use crate::core::ics02_client::msgs::misbehaviour::MsgSubmitMisbehaviour;
 use crate::core::ics02_client::msgs::update_client::MsgUpdateClient;
 use crate::core::ics02_client::msgs::upgrade_client::MsgUpgradeClient;
+use crate::core::ics24_host::identifier::ClientId;
 
 pub mod create_client;
 pub mod misbehaviour;
@@ -21,4 +24,25 @@ pub enum ClientMsg {
     UpdateClient(MsgUpdateClient),
     Misbehaviour(MsgSubmitMisbehaviour),
     UpgradeClient(MsgUpgradeClient),
+}
+
+pub(crate) enum MsgUpdateOrMisbehaviour {
+    UpdateClient(MsgUpdateClient),
+    Misbehaviour(MsgSubmitMisbehaviour),
+}
+
+impl MsgUpdateOrMisbehaviour {
+    pub(crate) fn client_id(&self) -> &ClientId {
+        match self {
+            MsgUpdateOrMisbehaviour::UpdateClient(msg) => &msg.client_id,
+            MsgUpdateOrMisbehaviour::Misbehaviour(msg) => &msg.client_id,
+        }
+    }
+
+    pub(crate) fn client_message(self) -> Any {
+        match self {
+            MsgUpdateOrMisbehaviour::UpdateClient(msg) => msg.header,
+            MsgUpdateOrMisbehaviour::Misbehaviour(msg) => msg.misbehaviour,
+        } 
+    }
 }

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -43,6 +43,6 @@ impl MsgUpdateOrMisbehaviour {
         match self {
             MsgUpdateOrMisbehaviour::UpdateClient(msg) => msg.header,
             MsgUpdateOrMisbehaviour::Misbehaviour(msg) => msg.misbehaviour,
-        } 
+        }
     }
 }

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -14,16 +14,11 @@ pub mod misbehaviour;
 pub mod update_client;
 pub mod upgrade_client;
 
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub enum ClientMsg {
     CreateClient(MsgCreateClient),
     UpdateClient(MsgUpdateClient),
     Misbehaviour(MsgSubmitMisbehaviour),
     UpgradeClient(MsgUpgradeClient),
-}
-
-#[derive(Clone, Debug)]
-pub enum MsgUpdateOrMisbehaviour {
-    Update(MsgUpdateClient),
-    Misbehaviour(MsgSubmitMisbehaviour),
 }

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -9,6 +9,7 @@ use crate::core::ics02_client::msgs::update_client::MsgUpdateClient;
 use crate::core::ics02_client::msgs::upgrade_client::MsgUpgradeClient;
 
 pub mod create_client;
+pub mod misbehaviour;
 pub mod update_client;
 pub mod upgrade_client;
 

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -5,6 +5,7 @@
 //! <https://github.com/cosmos/ibc/tree/master/spec/core/ics-002-client-semantics#create>.
 
 use crate::core::ics02_client::msgs::create_client::MsgCreateClient;
+use crate::core::ics02_client::msgs::misbehaviour::MsgSubmitMisbehaviour;
 use crate::core::ics02_client::msgs::update_client::MsgUpdateClient;
 use crate::core::ics02_client::msgs::upgrade_client::MsgUpgradeClient;
 
@@ -18,5 +19,6 @@ pub mod upgrade_client;
 pub enum ClientMsg {
     CreateClient(MsgCreateClient),
     UpdateClient(MsgUpdateClient),
+    Misbehaviour(MsgSubmitMisbehaviour),
     UpgradeClient(MsgUpgradeClient),
 }

--- a/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
@@ -1,0 +1,62 @@
+use crate::prelude::*;
+
+use ibc_proto::google::protobuf::Any as ProtoAny;
+use ibc_proto::ibc::core::client::v1::MsgSubmitMisbehaviour as RawMsgSubmitMisbehaviour;
+use ibc_proto::protobuf::Protobuf;
+
+use crate::core::ics02_client::error::ClientError;
+use crate::core::ics24_host::identifier::ClientId;
+use crate::signer::Signer;
+use crate::tx_msg::Msg;
+
+pub const TYPE_URL: &str = "/ibc.core.client.v1.MsgSubmitMisbehaviour";
+
+/// A type of message that submits client misbehaviour proof.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MsgSubmitMisbehaviour {
+    /// client unique identifier
+    pub client_id: ClientId,
+    /// misbehaviour used for freezing the light client
+    pub misbehaviour: ProtoAny,
+    /// signer address
+    pub signer: Signer,
+}
+
+impl Msg for MsgSubmitMisbehaviour {
+    type Raw = RawMsgSubmitMisbehaviour;
+
+    fn type_url(&self) -> String {
+        TYPE_URL.to_string()
+    }
+}
+
+impl Protobuf<RawMsgSubmitMisbehaviour> for MsgSubmitMisbehaviour {}
+
+impl TryFrom<RawMsgSubmitMisbehaviour> for MsgSubmitMisbehaviour {
+    type Error = ClientError;
+
+    fn try_from(raw: RawMsgSubmitMisbehaviour) -> Result<Self, Self::Error> {
+        let raw_misbehaviour = raw
+            .misbehaviour
+            .ok_or(ClientError::MissingRawMisbehaviour)?;
+
+        Ok(MsgSubmitMisbehaviour {
+            client_id: raw
+                .client_id
+                .parse()
+                .map_err(ClientError::InvalidRawMisbehaviour)?,
+            misbehaviour: raw_misbehaviour,
+            signer: raw.signer.parse().map_err(ClientError::Signer)?,
+        })
+    }
+}
+
+impl From<MsgSubmitMisbehaviour> for RawMsgSubmitMisbehaviour {
+    fn from(ics_msg: MsgSubmitMisbehaviour) -> Self {
+        RawMsgSubmitMisbehaviour {
+            client_id: ics_msg.client_id.to_string(),
+            misbehaviour: Some(ics_msg.misbehaviour),
+            signer: ics_msg.signer.to_string(),
+        }
+    }
+}

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -33,7 +33,7 @@ pub enum UpdateKind {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MsgUpdateClient {
     pub client_id: ClientId,
-    pub client_message: Any,
+    pub header: Any,
     pub update_kind: UpdateKind,
     pub signer: Signer,
 }
@@ -49,7 +49,7 @@ impl TryFrom<RawMsgUpdateClient> for MsgUpdateClient {
                 .client_id
                 .parse()
                 .map_err(ClientError::InvalidMsgUpdateClientId)?,
-            client_message: raw.header.ok_or(ClientError::MissingRawHeader)?,
+            header: raw.header.ok_or(ClientError::MissingRawHeader)?,
             update_kind: UpdateKind::UpdateClient,
             signer: raw.signer.parse().map_err(ClientError::Signer)?,
         })
@@ -60,7 +60,7 @@ impl From<MsgUpdateClient> for RawMsgUpdateClient {
     fn from(ics_msg: MsgUpdateClient) -> Self {
         RawMsgUpdateClient {
             client_id: ics_msg.client_id.to_string(),
-            header: Some(ics_msg.client_message),
+            header: Some(ics_msg.header),
             signer: ics_msg.signer.to_string(),
         }
     }
@@ -85,7 +85,7 @@ mod tests {
         pub fn new(client_id: ClientId, header: Any, signer: Signer) -> Self {
             MsgUpdateClient {
                 client_id,
-                client_message: header,
+                header,
                 update_kind: UpdateKind::UpdateClient,
                 signer,
             }

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -12,19 +12,6 @@ use crate::signer::Signer;
 
 pub const TYPE_URL: &str = "/ibc.core.client.v1.MsgUpdateClient";
 
-/// `UpdateKind` represents the 2 ways that a client can be updated
-/// in IBC: either through a `MsgUpdateClient`, or a `MsgSubmitMisbehaviour`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum UpdateKind {
-    /// this is the typical scenario where a new header is submitted to the client
-    /// to update the client. Note that light clients are free to define the type
-    /// of the object used to update them (e.g. could be a list of headers).
-    UpdateClient,
-    /// this is the scenario where misbehaviour is submitted to the client
-    /// (e.g 2 headers with the same height in Tendermint)
-    SubmitMisbehaviour,
-}
-
 /// Represents the message that triggers the update of an on-chain (IBC) client
 /// either with new headers, or evidence of misbehaviour.
 /// Note that some types of misbehaviour can be detected when a headers

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -10,8 +10,7 @@ use crate::core::ics02_client::error::ClientError;
 use crate::core::ics24_host::identifier::ClientId;
 use crate::signer::Signer;
 
-pub const UPDATE_CLIENT_TYPE_URL: &str = "/ibc.core.client.v1.MsgUpdateClient";
-pub const MISBEHAVIOUR_TYPE_URL: &str = "/ibc.core.client.v1.MsgSubmitMisbehaviour";
+pub const TYPE_URL: &str = "/ibc.core.client.v1.MsgUpdateClient";
 
 /// `UpdateKind` represents the 2 ways that a client can be updated
 /// in IBC: either through a `MsgUpdateClient`, or a `MsgSubmitMisbehaviour`.

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::ibc::core::client::v1::MsgSubmitMisbehaviour as RawMsgSubmitMisbehaviour;
 use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
 use ibc_proto::protobuf::Protobuf;
 
@@ -62,38 +61,6 @@ impl From<MsgUpdateClient> for RawMsgUpdateClient {
         RawMsgUpdateClient {
             client_id: ics_msg.client_id.to_string(),
             header: Some(ics_msg.client_message),
-            signer: ics_msg.signer.to_string(),
-        }
-    }
-}
-
-impl Protobuf<RawMsgSubmitMisbehaviour> for MsgUpdateClient {}
-
-impl TryFrom<RawMsgSubmitMisbehaviour> for MsgUpdateClient {
-    type Error = ClientError;
-
-    fn try_from(raw: RawMsgSubmitMisbehaviour) -> Result<Self, Self::Error> {
-        let raw_misbehaviour = raw
-            .misbehaviour
-            .ok_or(ClientError::MissingRawMisbehaviour)?;
-
-        Ok(MsgUpdateClient {
-            client_id: raw
-                .client_id
-                .parse()
-                .map_err(ClientError::InvalidRawMisbehaviour)?,
-            client_message: raw_misbehaviour,
-            update_kind: UpdateKind::SubmitMisbehaviour,
-            signer: raw.signer.parse().map_err(ClientError::Signer)?,
-        })
-    }
-}
-
-impl From<MsgUpdateClient> for RawMsgSubmitMisbehaviour {
-    fn from(ics_msg: MsgUpdateClient) -> Self {
-        RawMsgSubmitMisbehaviour {
-            client_id: ics_msg.client_id.to_string(),
-            misbehaviour: Some(ics_msg.client_message),
             signer: ics_msg.signer.to_string(),
         }
     }

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -34,7 +34,6 @@ pub enum UpdateKind {
 pub struct MsgUpdateClient {
     pub client_id: ClientId,
     pub header: Any,
-    pub update_kind: UpdateKind,
     pub signer: Signer,
 }
 
@@ -50,7 +49,6 @@ impl TryFrom<RawMsgUpdateClient> for MsgUpdateClient {
                 .parse()
                 .map_err(ClientError::InvalidMsgUpdateClientId)?,
             header: raw.header.ok_or(ClientError::MissingRawHeader)?,
-            update_kind: UpdateKind::UpdateClient,
             signer: raw.signer.parse().map_err(ClientError::Signer)?,
         })
     }
@@ -86,7 +84,6 @@ mod tests {
             MsgUpdateClient {
                 client_id,
                 header,
-                update_kind: UpdateKind::UpdateClient,
                 signer,
             }
         }

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -1,6 +1,7 @@
 //! Definition of domain type message `MsgUpdateAnyClient`.
 
 use crate::prelude::*;
+use crate::tx_msg::Msg;
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
@@ -21,6 +22,14 @@ pub struct MsgUpdateClient {
     pub client_id: ClientId,
     pub header: Any,
     pub signer: Signer,
+}
+
+impl Msg for MsgUpdateClient {
+    type Raw = RawMsgUpdateClient;
+
+    fn type_url(&self) -> String {
+        TYPE_URL.to_string()
+    }
 }
 
 impl Protobuf<RawMsgUpdateClient> for MsgUpdateClient {}

--- a/crates/ibc/src/core/ics26_routing/msgs.rs
+++ b/crates/ibc/src/core/ics26_routing/msgs.rs
@@ -4,7 +4,9 @@ use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::MsgSubmitMisbehaviour as RawMsgSubmitMisbehaviour;
 use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
 
-use crate::core::ics02_client::msgs::{create_client, update_client, upgrade_client, ClientMsg};
+use crate::core::ics02_client::msgs::{
+    create_client, misbehaviour, update_client, upgrade_client, ClientMsg,
+};
 use crate::core::ics03_connection::msgs::{
     conn_open_ack, conn_open_confirm, conn_open_init, conn_open_try, ConnectionMsg,
 };
@@ -50,11 +52,11 @@ impl TryFrom<Any> for MsgEnvelope {
                 Ok(MsgEnvelope::Client(ClientMsg::UpgradeClient(domain_msg)))
             }
             update_client::MISBEHAVIOUR_TYPE_URL => {
-                let domain_msg = <update_client::MsgUpdateClient as Protobuf<
+                let domain_msg = <misbehaviour::MsgSubmitMisbehaviour as Protobuf<
                     RawMsgSubmitMisbehaviour,
                 >>::decode_vec(&any_msg.value)
                 .map_err(RouterError::MalformedMessageBytes)?;
-                Ok(MsgEnvelope::Client(ClientMsg::UpdateClient(domain_msg)))
+                Ok(MsgEnvelope::Client(ClientMsg::Misbehaviour(domain_msg)))
             }
 
             // ICS03

--- a/crates/ibc/src/core/ics26_routing/msgs.rs
+++ b/crates/ibc/src/core/ics26_routing/msgs.rs
@@ -1,8 +1,6 @@
 use crate::prelude::*;
 
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::ibc::core::client::v1::MsgSubmitMisbehaviour as RawMsgSubmitMisbehaviour;
-use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
 
 use crate::core::ics02_client::msgs::{
     create_client, misbehaviour, update_client, upgrade_client, ClientMsg,
@@ -39,10 +37,7 @@ impl TryFrom<Any> for MsgEnvelope {
                 Ok(MsgEnvelope::Client(ClientMsg::CreateClient(domain_msg)))
             }
             update_client::TYPE_URL => {
-                let domain_msg =
-                    <update_client::MsgUpdateClient as Protobuf<RawMsgUpdateClient>>::decode_vec(
-                        &any_msg.value,
-                    )
+                let domain_msg = update_client::MsgUpdateClient::decode_vec(&any_msg.value)
                     .map_err(RouterError::MalformedMessageBytes)?;
                 Ok(MsgEnvelope::Client(ClientMsg::UpdateClient(domain_msg)))
             }
@@ -52,10 +47,8 @@ impl TryFrom<Any> for MsgEnvelope {
                 Ok(MsgEnvelope::Client(ClientMsg::UpgradeClient(domain_msg)))
             }
             misbehaviour::TYPE_URL => {
-                let domain_msg = <misbehaviour::MsgSubmitMisbehaviour as Protobuf<
-                    RawMsgSubmitMisbehaviour,
-                >>::decode_vec(&any_msg.value)
-                .map_err(RouterError::MalformedMessageBytes)?;
+                let domain_msg = misbehaviour::MsgSubmitMisbehaviour::decode_vec(&any_msg.value)
+                    .map_err(RouterError::MalformedMessageBytes)?;
                 Ok(MsgEnvelope::Client(ClientMsg::Misbehaviour(domain_msg)))
             }
 

--- a/crates/ibc/src/core/ics26_routing/msgs.rs
+++ b/crates/ibc/src/core/ics26_routing/msgs.rs
@@ -38,7 +38,7 @@ impl TryFrom<Any> for MsgEnvelope {
                     .map_err(RouterError::MalformedMessageBytes)?;
                 Ok(MsgEnvelope::Client(ClientMsg::CreateClient(domain_msg)))
             }
-            update_client::UPDATE_CLIENT_TYPE_URL => {
+            update_client::TYPE_URL => {
                 let domain_msg =
                     <update_client::MsgUpdateClient as Protobuf<RawMsgUpdateClient>>::decode_vec(
                         &any_msg.value,
@@ -51,7 +51,7 @@ impl TryFrom<Any> for MsgEnvelope {
                     .map_err(RouterError::MalformedMessageBytes)?;
                 Ok(MsgEnvelope::Client(ClientMsg::UpgradeClient(domain_msg)))
             }
-            update_client::MISBEHAVIOUR_TYPE_URL => {
+            misbehaviour::TYPE_URL => {
                 let domain_msg = <misbehaviour::MsgSubmitMisbehaviour as Protobuf<
                     RawMsgSubmitMisbehaviour,
                 >>::decode_vec(&any_msg.value)

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -9,7 +9,7 @@ use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::mock::ClientState as RawMockClientState;
 use ibc_proto::protobuf::Protobuf;
 
-use crate::core::ics02_client::client_state::{ClientState, UpdatedState, UpdateKind};
+use crate::core::ics02_client::client_state::{ClientState, UpdateKind, UpdatedState};
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -294,10 +294,9 @@ impl ClientState for MockClientState {
         &self,
         ctx: &mut dyn ExecutionContext,
         client_id: &ClientId,
-        client_message: Any,
-        _update_kind: &UpdateKind,
+        header: Any,
     ) -> Result<Vec<Height>, ClientError> {
-        let header = MockHeader::try_from(client_message)?;
+        let header = MockHeader::try_from(header)?;
         let header_height = header.height;
 
         let new_client_state = MockClientState::new(header).into_box();

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -1,4 +1,3 @@
-use crate::core::ics02_client::msgs::update_client::UpdateKind;
 use crate::core::ics24_host::path::{ClientConsensusStatePath, ClientStatePath};
 use crate::prelude::*;
 
@@ -10,7 +9,7 @@ use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::mock::ClientState as RawMockClientState;
 use ibc_proto::protobuf::Protobuf;
 
-use crate::core::ics02_client::client_state::{ClientState, UpdatedState};
+use crate::core::ics02_client::client_state::{ClientState, UpdatedState, UpdateKind};
 use crate::core::ics02_client::client_type::ClientType;
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;

--- a/crates/ibc/src/mock/ics18_relayer/context.rs
+++ b/crates/ibc/src/mock/ics18_relayer/context.rs
@@ -32,7 +32,7 @@ pub trait RelayerContext {
 mod tests {
     use crate::clients::ics07_tendermint::client_type as tm_client_type;
     use crate::core::ics02_client::header::{downcast_header, Header};
-    use crate::core::ics02_client::msgs::update_client::{MsgUpdateClient, UpdateKind};
+    use crate::core::ics02_client::msgs::update_client::MsgUpdateClient;
     use crate::core::ics02_client::msgs::ClientMsg;
     use crate::core::ics24_host::identifier::{ChainId, ClientId};
     use crate::core::ics26_routing::msgs::MsgEnvelope;
@@ -87,7 +87,6 @@ mod tests {
         Ok(ClientMsg::UpdateClient(MsgUpdateClient {
             client_id: client_id.clone(),
             header: src_header.clone_into(),
-            update_kind: UpdateKind::UpdateClient,
             signer: dest.signer(),
         }))
     }

--- a/crates/ibc/src/mock/ics18_relayer/context.rs
+++ b/crates/ibc/src/mock/ics18_relayer/context.rs
@@ -86,7 +86,7 @@ mod tests {
         // Client on destination chain can be updated.
         Ok(ClientMsg::UpdateClient(MsgUpdateClient {
             client_id: client_id.clone(),
-            client_message: src_header.clone_into(),
+            header: src_header.clone_into(),
             update_kind: UpdateKind::UpdateClient,
             signer: dest.signer(),
         }))


### PR DESCRIPTION

Closes: #628

cc @hdevalence

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
