### PR TITLE
Bump ibc-proto to v0.30.0 and tendermint to v0.31

### DIFF
--- a/.changelog/unreleased/breaking-changes/689-bump-ibc-proto-to-0.30.md
+++ b/.changelog/unreleased/breaking-changes/689-bump-ibc-proto-to-0.30.md
@@ -1,0 +1,2 @@
+- Bump ibc-proto to v0.30.0 and tendermint to v0.31
+  ([#689](https://github.com/cosmos/ibc-rs/issues/689))

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -49,7 +49,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.29.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.9.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.22", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -77,20 +77,20 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint]
-version = "0.30"
+version = "0.31"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.30"
+version = "0.31"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.30"
+version = "0.31"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.30"
+version = "0.31"
 optional = true
 default-features = false
 
@@ -99,7 +99,7 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.30", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.30" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.31", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.31" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR bumps ibc-proto to v0.30.0 and tendermint to v0.31. This should be compatible with tower-abci v0.7.0 which also bumps tendermint to v0.31.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
