### PR TITLE
fix TypeInfo implement for Timestamp

### DIFF
--- a/crates/ibc/src/core/timestamp.rs
+++ b/crates/ibc/src/core/timestamp.rs
@@ -77,7 +77,7 @@ impl scale_info::TypeInfo for Timestamp {
             .path(scale_info::Path::new("Timestamp", module_path!()))
             .composite(
                 scale_info::build::Fields::named()
-                    .field(|f| f.ty::<u6>().name("time").type_name("u64")),
+                    .field(|f| f.ty::<u64>().name("time").type_name("u64")),
             )
     }
 }

--- a/crates/ibc/src/core/timestamp.rs
+++ b/crates/ibc/src/core/timestamp.rs
@@ -75,12 +75,10 @@ impl scale_info::TypeInfo for Timestamp {
     fn type_info() -> scale_info::Type {
         scale_info::Type::builder()
             .path(scale_info::Path::new("Timestamp", module_path!()))
-            // i128 is chosen before we represent the timestamp is nanoseconds, which is represented as a i128 by Time
-            .composite(scale_info::build::Fields::named().field(|f| {
-                f.ty::<Option<i128>>()
-                    .name("time")
-                    .type_name("Option<i128>")
-            }))
+            .composite(
+                scale_info::build::Fields::named()
+                    .field(|f| f.ty::<u6>().name("time").type_name("u64")),
+            )
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #687 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

When implementing the `parity scale codec` of `Timestamp`, the internal `Time` has been converted to `u64` storage, so here the type `i128` should also be changed to `u64` when implementing `TypeInfo`.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
