### PR TITLE
Improve ChainId implementation; this is API breaking change

### DIFF
--- a/crates/ibc/src/clients/ics07_tendermint/error.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/error.rs
@@ -17,7 +17,7 @@ use tendermint_light_client_verifier::Verdict;
 /// The main error type
 #[derive(Debug, Display)]
 pub enum Error {
-    /// chain-id is (`{chain_id}`) is too long, got: `{len}`, max allowed: `{max_len}`
+    /// chain-id (`{chain_id}`) is too long, got: `{len}`, max allowed: `{max_len}`
     ChainIdTooLong {
         chain_id: ChainId,
         len: usize,
@@ -101,6 +101,8 @@ pub enum Error {
     MisbehaviourHeadersNotAtSameHeight,
     /// invalid raw client id: `{client_id}`
     InvalidRawClientId { client_id: String },
+    /// chain-id (`{chain_id}`) has no epoch version
+    InvalidRawChainId { chain_id: String },
 }
 
 #[cfg(feature = "std")]

--- a/crates/ibc/src/core/ics02_client/handler/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/update_client.rs
@@ -181,10 +181,10 @@ mod tests {
         let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let update_height = Height::new(1, 21).unwrap();
-        let chain_id_b = ChainId::new("mockgaiaB".to_string(), 1);
+        let chain_id_b = ChainId::new("mockgaiaB", 1);
 
         let mut ctx = MockContext::new(
-            ChainId::new("mockgaiaA".to_string(), 1),
+            ChainId::new("mockgaiaA", 1),
             HostType::Mock,
             5,
             Height::new(1, 1).unwrap(),
@@ -227,10 +227,10 @@ mod tests {
         let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let update_height = Height::new(1, 21).unwrap();
-        let chain_id_b = ChainId::new("mockgaiaB".to_string(), 1);
+        let chain_id_b = ChainId::new("mockgaiaB", 1);
 
         let mut ctx = MockContext::new(
-            ChainId::new("mockgaiaA".to_string(), 1),
+            ChainId::new("mockgaiaA", 1),
             HostType::Mock,
             5,
             Height::new(1, 1).unwrap(),
@@ -274,8 +274,8 @@ mod tests {
         let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
 
-        let ctx_a_chain_id = ChainId::new("mockgaiaA".to_string(), 1);
-        let ctx_b_chain_id = ChainId::new("mockgaiaB".to_string(), 1);
+        let ctx_a_chain_id = ChainId::new("mockgaiaA", 1);
+        let ctx_b_chain_id = ChainId::new("mockgaiaB", 1);
         let start_height = Height::new(1, 11).unwrap();
 
         let mut ctx_a = MockContext::new(ctx_a_chain_id, HostType::Mock, 5, start_height)
@@ -329,7 +329,7 @@ mod tests {
             let client_state = {
                 #[allow(deprecated)]
                 let raw_client_state = RawTmClientState {
-                    chain_id: ChainId::from(tm_block.header().chain_id.clone()).to_string(),
+                    chain_id: tm_block.header().chain_id.to_string(),
                     trust_level: Some(Fraction {
                         numerator: 1,
                         denominator: 3,
@@ -399,7 +399,7 @@ mod tests {
         let chain_start_height = Height::new(1, 11).unwrap();
 
         let ctx = MockContext::new(
-            ChainId::new("mockgaiaA".to_string(), 1),
+            ChainId::new("mockgaiaA", 1),
             HostType::Mock,
             5,
             chain_start_height,
@@ -412,7 +412,7 @@ mod tests {
         );
 
         let ctx_b = MockContext::new(
-            ChainId::new("mockgaiaB".to_string(), 1),
+            ChainId::new("mockgaiaB", 1),
             HostType::SyntheticTendermint,
             5,
             client_height,
@@ -538,11 +538,11 @@ mod tests {
         let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let misbehaviour_height = Height::new(1, 21).unwrap();
-        let chain_id_b = ChainId::new("mockgaiaB".to_string(), 1);
+        let chain_id_b = ChainId::new("mockgaiaB", 1);
 
         // Create a mock context for chain-A with a synthetic tendermint light client for chain-B
         let mut ctx_a = MockContext::new(
-            ChainId::new("mockgaiaA".to_string(), 1),
+            ChainId::new("mockgaiaA", 1),
             HostType::Mock,
             5,
             Height::new(1, 1).unwrap(),
@@ -599,11 +599,11 @@ mod tests {
         let client_id = ClientId::new(tm_client_type(), 0).unwrap();
         let client_height = Height::new(1, 20).unwrap();
         let misbehaviour_height = Height::new(1, 21).unwrap();
-        let chain_id_b = ChainId::new("mockgaiaB".to_string(), 1);
+        let chain_id_b = ChainId::new("mockgaiaB", 1);
 
         // Create a mock context for chain-A with a synthetic tendermint light client for chain-B
         let mut ctx_a = MockContext::new(
-            ChainId::new("mockgaiaA".to_string(), 1),
+            ChainId::new("mockgaiaA", 1),
             HostType::Mock,
             5,
             Height::new(1, 1).unwrap(),

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -254,7 +254,7 @@ mod tests {
 
         let ctx_default = MockContext::default();
         let ctx_new = MockContext::new(
-            ChainId::new("mockgaia".to_string(), latest_height.revision_number()),
+            ChainId::new("mockgaia", latest_height.revision_number()),
             HostType::Mock,
             max_history_size,
             latest_height,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -253,7 +253,7 @@ mod tests {
         };
 
         let ctx_new = MockContext::new(
-            ChainId::new("mockgaia".to_string(), 0),
+            ChainId::new("mockgaia", 0),
             HostType::Mock,
             max_history_size,
             host_chain_height,

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -96,7 +96,7 @@ pub struct MockContext {
 impl Default for MockContext {
     fn default() -> Self {
         Self::new(
-            ChainId::new("mockgaia".to_string(), 0),
+            ChainId::new("mockgaia", 0),
             HostType::Mock,
             5,
             Height::new(0, 5).unwrap(),
@@ -1487,7 +1487,7 @@ mod tests {
             Test {
                 name: "Empty history, small pruning window".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::Mock,
                     2,
                     Height::new(cv, 1).unwrap(),
@@ -1496,7 +1496,7 @@ mod tests {
             Test {
                 name: "[Synthetic TM host] Empty history, small pruning window".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mocksgaia".to_string(), cv),
+                    ChainId::new("mocksgaia", cv),
                     HostType::SyntheticTendermint,
                     2,
                     Height::new(cv, 1).unwrap(),
@@ -1505,7 +1505,7 @@ mod tests {
             Test {
                 name: "Large pruning window".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::Mock,
                     30,
                     Height::new(cv, 2).unwrap(),
@@ -1514,7 +1514,7 @@ mod tests {
             Test {
                 name: "[Synthetic TM host] Large pruning window".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mocksgaia".to_string(), cv),
+                    ChainId::new("mocksgaia", cv),
                     HostType::SyntheticTendermint,
                     30,
                     Height::new(cv, 2).unwrap(),
@@ -1523,7 +1523,7 @@ mod tests {
             Test {
                 name: "Small pruning window".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::Mock,
                     3,
                     Height::new(cv, 30).unwrap(),
@@ -1532,7 +1532,7 @@ mod tests {
             Test {
                 name: "[Synthetic TM host] Small pruning window".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::SyntheticTendermint,
                     3,
                     Height::new(cv, 30).unwrap(),
@@ -1541,7 +1541,7 @@ mod tests {
             Test {
                 name: "Small pruning window, small starting height".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::Mock,
                     3,
                     Height::new(cv, 2).unwrap(),
@@ -1550,7 +1550,7 @@ mod tests {
             Test {
                 name: "[Synthetic TM host] Small pruning window, small starting height".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::SyntheticTendermint,
                     3,
                     Height::new(cv, 2).unwrap(),
@@ -1559,7 +1559,7 @@ mod tests {
             Test {
                 name: "Large pruning window, large starting height".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::Mock,
                     50,
                     Height::new(cv, 2000).unwrap(),
@@ -1568,7 +1568,7 @@ mod tests {
             Test {
                 name: "[Synthetic TM host] Large pruning window, large starting height".to_string(),
                 ctx: MockContext::new(
-                    ChainId::new("mockgaia".to_string(), cv),
+                    ChainId::new("mockgaia", cv),
                     HostType::SyntheticTendermint,
                     50,
                     Height::new(cv, 2000).unwrap(),
@@ -1817,7 +1817,7 @@ mod tests {
         }
 
         let mut ctx = MockContext::new(
-            ChainId::new("mockgaia".to_string(), 1),
+            ChainId::new("mockgaia", 1),
             HostType::Mock,
             1,
             Height::new(1, 1).unwrap(),

--- a/crates/ibc/src/mock/ics18_relayer/context.rs
+++ b/crates/ibc/src/mock/ics18_relayer/context.rs
@@ -109,8 +109,8 @@ mod tests {
         let client_on_a_for_b = ClientId::new(tm_client_type(), 0).unwrap();
         let client_on_b_for_a = ClientId::new(mock_client_type(), 0).unwrap();
 
-        let chain_id_a = ChainId::new("mockgaiaA".to_string(), 1);
-        let chain_id_b = ChainId::new("mockgaiaB".to_string(), 1);
+        let chain_id_a = ChainId::new("mockgaiaA", 1);
+        let chain_id_b = ChainId::new("mockgaiaB", 1);
 
         // Create two mock contexts, one for each chain.
         let mut ctx_a =

--- a/crates/ibc/tests/support/signed_header.json
+++ b/crates/ibc/tests/support/signed_header.json
@@ -4,7 +4,7 @@
       "block": "0",
       "app": "0"
     },
-    "chain_id": "test-chain-01",
+    "chain_id": "test-chain-1",
     "height": "20",
     "time": "2019-11-02T15:04:10Z",
     "last_block_id": {


### PR DESCRIPTION
ChainId::new allocates a new String so there’s no point in passing
ownership of name argument.  The constructor can accept it as a str
slice without loss of functionality.  This reduces allocations when
creating ids since caller no longer has to have an owned string.

Replace From implementations with TryFrom implementations.  Conversion
now fails if string is not in an epoch format.  There’s still a way to
construct an identifier without epoch format if it comes from
tendermint::chain::Id (or by using ChainId::new with zero version;
behaviour of that might change).  And since there’s From
implementation available, also get rid of ChainId::from_string.

Optimise epoch format parsing.  from_string used to check if argument
was in epoch format and then call chain_version which did it again.
To avoid duplicating work, introduce split_chain_id method which does
the parsing and returns result which includes all the information
callers might want.

Similarly, calling split and collecting values into a vector is
wasteful if all we need is the last token.  Furthermore, regexes are
quite a heavy machinery for the task of checking if string ends with
a number.  To address that, use split_last and parse the number to
check if it’s valid.


### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [n/a] Added tests.
- [n/a] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
