### PR TITLE
ADR 7: Light client contexts

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -32,3 +32,5 @@ To suggest an ADR, please make use of the [ADR template](./adr-template.md) prov
 | [003](./adr-003-ics20-implementation.md)           | ICS20 implementation                                  | Accepted |
 | [004](./adr-004-light-client-crates-extraction.md) | Light client crates extraction                        | Accepted |
 | [005](./adr-005-handlers-redesign.md)              | Handlers validation and execution separation          | Accepted |
+| [006](./adr-006-upgrade-client-implementation.md)  | Chain and client upgradability                        | Accepted |
+| [007](./adr-007-light-client-contexts.md)          | Light client contexts                                 | Accepted |

--- a/docs/architecture/adr-007-light-client-contexts.md
+++ b/docs/architecture/adr-007-light-client-contexts.md
@@ -11,9 +11,9 @@ This ADR is meant to address the main limitation of our current light client API
     + `next_consensus_state()` and `prev_consensus_state()` are not used in the core handlers; they're only there because of the Tendermint light client.
 3. It gives more power to light clients than they really need
     + By giving the light clients access to `ValidationContext` and `ExecutionContext`, we're effectively giving them the same capabilities as the core handlers.
-    + Although our current model is that all code is trusted (including light clients we didn't write), restraining the capabilities we give to light clients at the very least eliminates a class of bugs (e.g. calling the wrong method), and serves as documentation for exactly what the light client will need.
+    + Although our current model is that all code is trusted (including light clients we didn't write), restraining the capabilities we give to light clients at the very least eliminates a class of bugs (e.g. calling the wrong method), and serves as documentation for exactly which methods the light client needs.
 
-This ADR is all about fixing this issue; namely, to enable light clients to define a `Context` trait for the host to implement. One way to see this is that this new architecture allows light clients to define their own `ValidationContext` and `ExecutionContext`.
+This ADR is all about fixing this issue; namely, to enable light clients to define their own `ValidationContext` and `ExecutionContext` traits for the host to implement. 
 
 [ADR 4]: ../architecture/adr-004-light-client-crates-extraction.md
 [later improved]: https://github.com/cosmos/ibc-rs/pull/584
@@ -43,7 +43,7 @@ pub trait ClientState<ClientValidationContext, ClientExecutionContext>:
 }
 ```
 
-A blanket implementation implements `ClientState` when these 3 traits are implemented on a type. For details as to why `ClientState` was split into 3 traits, see the section "Why are there 3 `ClientState` traits?".
+A blanket implementation implements `ClientState` when these 3 traits are implemented on a given type. For details as to why `ClientState` was split into 3 traits, see the section "Why are there 3 `ClientState` traits?".
 
 The `ClientStateValidation` and `ClientStateExecution` traits are the most important ones, as they are the ones that enable light clients to define `Context` traits for the host to implement. Below, we discuss `ClientStateValidation`; `ClientStateExecution` works analogously.
 

--- a/docs/architecture/adr-007-light-client-contexts.md
+++ b/docs/architecture/adr-007-light-client-contexts.md
@@ -26,18 +26,16 @@ This ADR is all about fixing this issue; namely, to enable light clients to defi
 
 ### Changes to `ClientState`
 
-The `ClientState` functionality is split into 4 traits: 
+The `ClientState` functionality is split into 3 traits: 
 + `ClientStateBase`, 
-+ `ClientStateInitializer<AnyConsensusState>`, 
 + `ClientStateValidation<ClientValidationContext>`, and 
 + `ClientStateExecution<ClientExecutionContext>`
 
 Then, `ClientState` is defined as
 
 ```rust
-pub trait ClientState<AnyConsensusState, ClientValidationContext, ClientExecutionContext>:
+pub trait ClientState<ClientValidationContext, ClientExecutionContext>:
     ClientStateBase
-    + ClientStateInitializer<AnyConsensusState>
     + ClientStateValidation<ClientValidationContext>
     + ClientStateExecution<ClientExecutionContext>
     // + ...
@@ -45,7 +43,7 @@ pub trait ClientState<AnyConsensusState, ClientValidationContext, ClientExecutio
 }
 ```
 
-A blanket implementation implements `ClientState` when these 4 traits are implemented on a type. For details as to why `ClientState` was split into 4 traits, see the section "Why are there 4 `ClientState` traits?".
+A blanket implementation implements `ClientState` when these 3 traits are implemented on a type. For details as to why `ClientState` was split into 3 traits, see the section "Why are there 3 `ClientState` traits?".
 
 The `ClientStateValidation` and `ClientStateExecution` traits are the most important ones, as they are the ones that enable light clients to define `Context` traits for the host to implement. Below, we discuss `ClientStateValidation`; `ClientStateExecution` works analogously.
 
@@ -163,7 +161,6 @@ enum AnyConsensusState {
 
 #[derive(ClientState)]
 #[generics(
-    AnyConsensusState       = AnyConsensusState,
     ClientValidationContext = MyClientValidationContext,
     ClientExecutionContext  = MyClientExecutionContext
 )]
@@ -176,17 +173,17 @@ enum AnyClientState {
 
 ## FAQs
 
-### Why are there 4 `ClientState` traits?
+### Why are there 3 `ClientState` traits?
 
 The `ClientState` trait is defined as
 
 ```rust
-trait ClientState<AnyConsensusState, ClientValidationContext, ClientExecutionContext>
+trait ClientState<ClientValidationContext, ClientExecutionContext>
 ```
 
 The problem with defining all methods directly under `ClientState` is that it would force users to use fully qualified notation to call any method.
 
-This arises from the fact that no method uses all 3 generic parameters. [This playground] provides an explanatory example. Hence, our solution is to have all methods in a trait use every generic parameter of the trait to avoid this problem.
+This arises from the fact that no method uses both generic parameters. [This playground] provides an explanatory example. Hence, our solution is to have all methods in a trait use every generic parameter of the trait to avoid this problem.
 
 [This playground]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=da65c22f1532cecc9f92a2b7cb2d1360
 

--- a/docs/architecture/adr-007-light-client-contexts.md
+++ b/docs/architecture/adr-007-light-client-contexts.md
@@ -27,7 +27,7 @@ This ADR is all about fixing this issue; namely, to enable light clients to defi
 ### Changes to `ClientState`
 
 The `ClientState` functionality is split into 3 traits: 
-+ `ClientStateBase`, 
++ `ClientStateCommon`, 
 + `ClientStateValidation<ClientValidationContext>`, and 
 + `ClientStateExecution<ClientExecutionContext>`
 
@@ -35,7 +35,7 @@ Then, `ClientState` is defined as
 
 ```rust
 pub trait ClientState<ClientValidationContext, ClientExecutionContext>:
-    ClientStateBase
+    ClientStateCommon
     + ClientStateValidation<ClientValidationContext>
     + ClientStateExecution<ClientExecutionContext>
     // + ...
@@ -137,7 +137,7 @@ impl NearClientValidationContext for MyClientValidationContext {
 Notice that `ValidationContext::AnyClientState` needs to implement `ClientState`, and `ValidationContext::AnyConsensusState` needs to implement `ConsensusState`. Given that `AnyClientState` and `AnyConsensusState` are enums that wrap types that *must* implement `ClientState` or `ConsensusState` (respectively), implementing these traits is gruesome boilerplate:
 
 ```rust
-impl ClientStateBase for AnyClientState {
+impl ClientStateCommon for AnyClientState {
     fn client_type(&self) -> ClientType {
         match self {
             Tendermint(cs) => cs.client_type(),

--- a/docs/architecture/adr-007-light-client-contexts.md
+++ b/docs/architecture/adr-007-light-client-contexts.md
@@ -107,7 +107,7 @@ pub trait ClientExecutionContext: Sized {
 }
 ```
 
-Under our current architecture (inspired from ibc-go's [ADR 6]), clients have the responsibility to store the `ClientState` and `ConsensusState`. Hence, `ClientExecutionContext` defines a uniform interface that clients can use to store their `ClientState` and `ConsensusState`. It also means that the host only needs to implement these methods once, as opposed to once per client.
+Under our current architecture (inspired from ibc-go's [ADR 6]), clients have the responsibility to store the `ClientState` and `ConsensusState`. Hence, `ClientExecutionContext` defines a uniform interface that clients can use to store their `ClientState` and `ConsensusState`. It also means that the host only needs to implement these methods once, as opposed to once per client. Note that clients who don't store consensus states (e.g. solomachine) can simply leave the implementation of `store_consensus_state()` empty (or return an error, whichever is most appropriate).
 
 ### Changes to `ValidationContext` and `ExecutionContext`
 

--- a/docs/architecture/adr-007-light-client-dependencies.md
+++ b/docs/architecture/adr-007-light-client-dependencies.md
@@ -188,14 +188,15 @@ This arises from the fact that no method uses all 3 generic parameters. [This pl
 
 [This playground]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=da65c22f1532cecc9f92a2b7cb2d1360
 
-### Why have `ClientValidationContext` and `ClientExecutionContext` as opposed to just one `ClientContext`
-
 ### Alternatives to writing our own `ClientState` and `ConsensusState` derive macros
-+ `enum_derive` and `enum_delegate`
+We ended up having to write our own custom derive macros because existing crates that offer similar functionality had shortcomings that prevented us from using them:
 
++ `enum_dispatch`: the trait `ClientState` and the enum that implements `ClientState` need to be defined in the same crate
++ `enum_delegate v0.2`: was designed to remove the above restriction. However, generic traits are not supported.
+    + we investigated [turning the generic types into associated types] of `ClientState`; however we were hit by the other limitation of `enum_delegate`: `ClientState` cannot have any supertrait.
+
+[turning the generic types into associated types]: https://github.com/cosmos/ibc-rs/issues/296#issuecomment-1540630517
 ## Consequences
-
-> This section describes the consequences, after applying the decision. All consequences should be summarized here, not just the "positive" ones.
 
 ### Positive
 
@@ -208,6 +209,7 @@ This arises from the fact that no method uses all 3 generic parameters. [This pl
 
 
 ### Neutral
++ Our light client traits are no longer trait-object safe. Hence, for example, all uses of `Box<dyn ConsensusState>` are replaced by the analogous `ValidationContext::AnyConsensusState`.
 
 ## References
 

--- a/docs/architecture/adr-007-light-client-dependencies.md
+++ b/docs/architecture/adr-007-light-client-dependencies.md
@@ -1,0 +1,54 @@
+# ADR 007: LIGHT CLIENT DEPENDENCIES
+
+## Context
+
+This ADR is meant to address the main limitation of our current light client API, first introduced in [ADR 4] and [later improved] to adopt some of the ideas present in ibc-go's [ADR 6]. Implementing some `ClientState` methods require additional information from the host. For example, the Tendermint client's implementation of `ClientState::verify_client_message` needs [access to the host timestamp] to properly perform a message's verification. We solved this problem by [giving a reference] to a `ValidationContext` and `ExecutionContext`, since most methods are already made available by these traits. However, this solution has some limitations:
+
+1. Not all methods needed by every future light client is present in `ValidationContext` or `ExecutionContext`. For example, if a light client X finds that it would need access to some resource X, currently the only way to solve this is to submit a PR on the ibc-rs repository that adds a method `get_resource_Y()` to `ValidationContext`.
+    + This means that every host will need to implement `get_resource_Y()`, even if they don't use light client X.
+    + It clutters up `ValidationContext` and `ExecutionContext`.
+2. We found that some methods only needed by the Tendermint light client made their way into `ValidationContext`.
+    + `next_consensus_state()` and `prev_consensus_state()` are not used in the core handlers; they're only there because of the Tendermint light client.
+3. It gives more power to light clients than they really need
+    + By giving the light clients access to `ValidationContext` and `ExecutionContext`, we're effectively giving them the same capabilities as the core handlers.
+    + Although our current model is that all code is trusted (including light clients we didn't write), restraining the capabilities we give to light clients at the very least eliminates a class of bugs (e.g. calling the wrong method), and serves as documentation for exactly what the light client will need.
+
+This ADR is all about fixing this issue; namely, to enable light clients to impose a `Context` trait for the host to implement.
+
+[ADR 4]: ../architecture/adr-004-light-client-crates-extraction.md
+[later improved]: https://github.com/cosmos/ibc-rs/pull/584
+[ADR 6]: https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-006-02-client-refactor.md
+[access to the host timestamp]: https://github.com/cosmos/ibc-rs/blob/3e2566b3102af3fb6185cdc158cff818ec605535/crates/ibc/src/clients/ics07_tendermint/client_state/update_client.rs#L70
+[giving a reference]: https://github.com/cosmos/ibc-rs/blob/3e2566b3102af3fb6185cdc158cff818ec605535/crates/ibc/src/core/ics02_client/client_state.rs#L72
+
+## Decision
+
+The primary change is that we will no longer use dynamic dispatch. Namely, we will remove all occurances of `dyn ValidationContext`, `Box<dyn ConsensusState>`, etc. This is because our solution will be centered around generics, and our traits will no longer be trait object safe.
+
+The `ClientState` trait is split into 4 traits: `ClientStateBase`, `ClientStateInitializer<SupportedConsensusStates>`
+
++ What `SupportedConsensusStates` is
+
+### Light client implementation
+
+In this section, we will discuss the general pattern that light clients will use.
+
+
+## Consequences
+
+> This section describes the consequences, after applying the decision. All consequences should be summarized here, not just the "positive" ones.
+
+### Positive
+
+### Negative
++ If 2 light clients need the same (or very similar) methods, then the host will need to reimplement the same method multiple times
+    + Although mitigatable by implementing once in a function and delegating all trait methods to that implementation, it is at the very least additional boilerplate
+
+
+### Neutral
+
+## References
+
+> Are there any relevant PR comments, issues that led up to this, or articles referenced for why we made the given design choice? If so link them here!
+
+* [Main issue](https://github.com/cosmos/ibc-rs/issues/296)

--- a/docs/architecture/adr-007-light-client-dependencies.md
+++ b/docs/architecture/adr-007-light-client-dependencies.md
@@ -41,7 +41,9 @@ enum AnyClientState {
 }
 ```
 
-These will be given to `ibc-rs` through methods such as `ValidationContext::client_state()` and `ValidationContext::consensus_state()`.
+These will be passed to `ibc-rs` through methods such as `ValidationContext::client_state()` and `ValidationContext::consensus_state()`.
+
+### Changes to `ClientState`
 
 The `ClientState` trait is split into 4 traits: 
 + `ClientStateBase`, 
@@ -50,6 +52,28 @@ The `ClientState` trait is split into 4 traits:
 + `ClientStateExecution<ClientExecutionContext>`
 
 A blanket implementation implements `ClientState` when these 4 traits are implemented on a type. For details as to why `ClientState` was split into 4 traits, see the section "Why there are 4 `ClientState` traits".
+
+TODO: Pattern of how light clients work
++ Introduces the `ClientValidation/ExecutionContext`
+
+### Changes to `ValidationContext` and `ExecutionContext`
+
+`ValidationContext` is now defined as:
+
+```rust
+pub trait ValidationContext: Router {
+    type ClientValidationContext;
+    type ClientExecutionContext;
+    type AnyConsensusState: ConsensusState<EncodeError = ContextError>;
+    type AnyClientState: ClientState<
+        Self::AnyConsensusState,
+        Self::ClientValidationContext,
+        Self::ClientExecutionContext,
+    >;
+
+    ...
+}
+```
 
 ### Why there are 4 `ClientState` traits
 
@@ -67,9 +91,6 @@ This arises from the fact that no method uses all 3 generic parameters. [This pl
 
 ### Why have `ClientValidationContext` and `ClientExecutionContext` as opposed to just one `ClientContext`
 
-### Light client implementation
-
-In this section, we will discuss the general pattern that light clients will use.
 
 
 ## Consequences

--- a/docs/architecture/adr-007-light-client-dependencies.md
+++ b/docs/architecture/adr-007-light-client-dependencies.md
@@ -160,10 +160,11 @@ enum AnyConsensusState {
 }
 
 #[derive(ClientState)]
-#[generics(consensus_state = AnyConsensusState,
-           client_validation_context = MyClientValidationContext,
-           client_execution_context = MyClientExecutionContext)
-]
+#[generics(
+    AnyConsensusState       = AnyConsensusState,
+    ClientValidationContext = MyClientValidationContext,
+    ClientExecutionContext  = MyClientExecutionContext
+)]
 enum AnyClientState {
     Tendermint(TmClientState),
     Near(NearClientState),


### PR DESCRIPTION
[Rendered](https://github.com/cosmos/ibc-rs/blob/plafer/adr-7/docs/architecture/adr-007-light-client-contexts.md)
## Description

This ADR proposes to change to `ClientState` to allow light clients to define their own `Context` traits (details in the ADR).

Although most of it is already implemented in #683, I am open to making big changes to the design. The implementation served more as a means to validate that the design really made sense (and helped improve it as well).

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
