### PR TITLE
Make dependencies to `parity-scale-codec` and `borsh` optional

### DIFF
--- a/ci/no-std-check/Cargo.lock
+++ b/ci/no-std-check/Cargo.lock
@@ -1119,12 +1119,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f844ebc1ddf70f2ad7cd5981a2feba261fff55e1ad6482c27551ee3c6cec7df4"
 dependencies = [
  "base64 0.21.0",
- "borsh",
  "bytes",
  "flex-error",
- "parity-scale-codec",
  "prost",
- "scale-info",
  "serde",
  "subtle-encoding",
  "tendermint-proto 0.31.1",

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -36,8 +36,8 @@ std = [
     "tendermint/clock",
     "tendermint/std",
 ]
-parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
-borsh = ["dep:borsh"]
+parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info", "ibc-proto/parity-scale-codec"]
+borsh = ["dep:borsh", "ibc-proto/borsh"]
 
 # This feature is required for token transfer (ICS-20)
 serde = ["dep:serde", "dep:serde_derive", "serde_json", "erased-serde"]
@@ -49,7 +49,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.30.0", default-features = false }
 ics23 = { version = "0.9.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.22", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }


### PR DESCRIPTION
## Description

Even though `parity-scale-codec` and `borsh` are provided as features in ibc-rs, ibc-proto-rs always enable them. 

It is desirable to be able to select whether or not to install them so that the developer can select the minimum necessary dependencies.
______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
