### PR TITLE
fix: revamp `Height::from_str` to reject invalid heights

### DIFF
--- a/crates/ibc/src/core/ics02_client/height.rs
+++ b/crates/ibc/src/core/ics02_client/height.rs
@@ -150,7 +150,7 @@ impl core::fmt::Display for Height {
 }
 
 /// Encodes all errors related to chain heights
-#[derive(Debug, Display)]
+#[derive(Debug, Display, PartialEq)]
 pub enum HeightError {
     /// cannot convert into a `Height` type from string `{height}`
     HeightConversion {
@@ -159,6 +159,8 @@ pub enum HeightError {
     },
     /// attempted to parse an invalid zero height
     ZeroHeight,
+    /// invalid height format string
+    InvalidFormat,
 }
 
 #[cfg(feature = "std")]
@@ -166,7 +168,7 @@ impl std::error::Error for HeightError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
             HeightError::HeightConversion { error: e, .. } => Some(e),
-            HeightError::ZeroHeight => None,
+            _ => None,
         }
     }
 }
@@ -175,17 +177,20 @@ impl TryFrom<&str> for Height {
     type Error = HeightError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let split: Vec<&str> = value.split('-').collect();
+        let (rev_number_str, rev_height_str) = match value.split_once('-') {
+            Some((rev_number_str, rev_height_str)) => (rev_number_str, rev_height_str),
+            None => return Err(HeightError::InvalidFormat),
+        };
 
         let revision_number =
-            split[0]
+            rev_number_str
                 .parse::<u64>()
                 .map_err(|e| HeightError::HeightConversion {
                     height: value.to_owned(),
                     error: e,
                 })?;
         let revision_height =
-            split[1]
+            rev_height_str
                 .parse::<u64>()
                 .map_err(|e| HeightError::HeightConversion {
                     height: value.to_owned(),
@@ -207,5 +212,33 @@ impl FromStr for Height {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Height::try_from(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_height_from_str() {
+        let height = Height::new(0, 1).unwrap();
+        assert_eq!(height, "0-1".parse().unwrap());
+    }
+
+    #[test]
+    fn invalid_heights_from_str() {
+        assert_eq!(
+            HeightError::ZeroHeight,
+            "0-0".parse::<Height>().unwrap_err()
+        );
+        assert_eq!(
+            HeightError::InvalidFormat,
+            "0".parse::<Height>().unwrap_err()
+        );
+        assert!("0-".parse::<Height>().is_err());
+        assert!("-0".parse::<Height>().is_err());
+        assert!("-".parse::<Height>().is_err());
+        assert!("".parse::<Height>().is_err());
+        assert!("0-1-2".parse::<Height>().is_err());
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #752

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
