### PR TITLE
serde as string pub mod

### DIFF
--- a/.changelog/unreleased/improvements/791-serde-as-string-pub.md
+++ b/.changelog/unreleased/improvements/791-serde-as-string-pub.md
@@ -1,0 +1,2 @@
+- Made serde as string public
+  ([#777](https://github.com/cosmos/ibc-rs/issues/777))

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -63,7 +63,7 @@ mod signer;
 mod utils;
 
 #[cfg(feature = "serde")]
-mod serializers;
+pub mod serializers;
 
 #[cfg(test)]
 mod test;

--- a/crates/ibc/src/serializers.rs
+++ b/crates/ibc/src/serializers.rs
@@ -12,6 +12,8 @@ where
     hex.serialize(serializer)
 }
 
+
+/// use Display to serialize and FromStr to deserialize 
 pub mod serde_string {
     use core::fmt::Display;
     use core::str::FromStr;

--- a/crates/ibc/src/serializers.rs
+++ b/crates/ibc/src/serializers.rs
@@ -12,8 +12,7 @@ where
     hex.serialize(serializer)
 }
 
-
-/// use Display to serialize and FromStr to deserialize 
+/// use Display to serialize and FromStr to deserialize
 pub mod serde_string {
     use core::fmt::Display;
     use core::str::FromStr;


### PR DESCRIPTION
Closes: #791

## Description

Serde as string is useful, Osmosis has impl and CosmWasm has impl and I will copy paste too. 
Serde repo has not such tool impl btw. Mostly hex/bytes things.

So at least one place, which also consistently supports no_std and other serializers and modes would be awesome.  Osmosis and CW-STD do not support no_std.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests. No code changes, no tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR. @Farhad-Shabani as he is already on some serde decision things

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
