### PR TITLE
fix: remove traces of deprecated `mocks-no-std` feature

### DIFF
--- a/.changelog/unreleased/bug-fixes/819-remove-mocks-no-std-traces.md
+++ b/.changelog/unreleased/bug-fixes/819-remove-mocks-no-std-traces.md
@@ -1,2 +1,2 @@
-- Remove traces of deprecated `mock-no-std` feature
+- Remove traces of deprecated `mocks-no-std` feature
   ([#819](https://github.com/cosmos/ibc-rs/issues/821))

--- a/.changelog/unreleased/bug-fixes/819-remove-mocks-no-std-traces.md
+++ b/.changelog/unreleased/bug-fixes/819-remove-mocks-no-std-traces.md
@@ -1,0 +1,2 @@
+- Remove traces of deprecated `mock-no-std` feature
+  ([#819](https://github.com/cosmos/ibc-rs/issues/821))

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -53,7 +53,7 @@ pub mod clients;
 pub mod core;
 pub mod hosts;
 
-#[cfg(any(test, feature = "mocks", feature = "mocks-no-std"))]
+#[cfg(any(test, feature = "mocks"))]
 pub mod mock;
 #[cfg(any(test, feature = "mocks"))]
 pub mod test_utils; // Context mock, the underlying host chain, and client types: for testing all handlers.

--- a/crates/ibc/src/mock/mod.rs
+++ b/crates/ibc/src/mock/mod.rs
@@ -1,18 +1,18 @@
 //! Implementation of mocks for context, host chain, and client.
 
-#[cfg(any(test, feature = "mocks", feature = "mocks-no-std"))]
+#[cfg(any(test, feature = "mocks"))]
 pub mod client_state;
-#[cfg(any(test, feature = "mocks", feature = "mocks-no-std"))]
+#[cfg(any(test, feature = "mocks"))]
 pub mod consensus_state;
 #[cfg(any(test, feature = "mocks"))]
 pub mod context;
-#[cfg(any(test, feature = "mocks", feature = "mocks-no-std"))]
+#[cfg(any(test, feature = "mocks"))]
 pub mod header;
 #[cfg(any(test, feature = "mocks"))]
 pub mod host;
 #[cfg(any(test, feature = "mocks"))]
 pub mod ics18_relayer;
-#[cfg(any(test, feature = "mocks", feature = "mocks-no-std"))]
+#[cfg(any(test, feature = "mocks"))]
 pub mod misbehaviour;
 #[cfg(any(test, feature = "mocks"))]
 pub mod router;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #819

______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [X] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
