### PR TITLE
fix: immut over mut ref on validate

### DIFF
--- a/.changelog/unreleased/bug-fixes/863-immut-ref-in-validate.md
+++ b/.changelog/unreleased/bug-fixes/863-immut-ref-in-validate.md
@@ -1,0 +1,2 @@
+- Replace mutable ref with immutable ref in validate handler
+  ([\#863](https://github.com/cosmos/ibc-rs/issues/863))

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -51,11 +51,7 @@ pub fn dispatch(
 /// That is, the state transition of message `i` must be applied before
 /// message `i+1` is validated. This is equivalent to calling
 /// `dispatch()` on each successively.
-pub fn validate<Ctx>(
-    ctx: &Ctx,
-    router: &impl Router,
-    msg: MsgEnvelope,
-) -> Result<(), RouterError>
+pub fn validate<Ctx>(ctx: &Ctx, router: &impl Router, msg: MsgEnvelope) -> Result<(), RouterError>
 where
     Ctx: ValidationContext,
 {

--- a/crates/ibc/src/core/handler.rs
+++ b/crates/ibc/src/core/handler.rs
@@ -53,7 +53,7 @@ pub fn dispatch(
 /// `dispatch()` on each successively.
 pub fn validate<Ctx>(
     ctx: &Ctx,
-    router: &mut impl Router,
+    router: &impl Router,
     msg: MsgEnvelope,
 ) -> Result<(), RouterError>
 where


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #864

## Description

The core validate handler uses mutable reference, even though, the mutable reference is not needed.

https://github.com/cosmos/ibc-rs/blob/133863db5f9ce56d57b2502913a21bde0fad7bda/crates/ibc/src/core/handler.rs#L54-L58

This PR updates it to immutable reference.

https://github.com/cosmos/ibc-rs/blob/99ca41047f8f7ddfd16c955fc340ebf969a641d4/crates/ibc/src/core/handler.rs#L54-L58


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
