### PR TITLE
chore: enable `std` feature when `mocks` is enabled

### DIFF
--- a/.changelog/unreleased/improvements/850-fix-wasm-compilation-error-with-floats.md
+++ b/.changelog/unreleased/improvements/850-fix-wasm-compilation-error-with-floats.md
@@ -1,4 +1,4 @@
 - Fix compilation issue with Wasm envs because of floats
   - Use `serde-json-wasm` dependency instead of `serde-json` for no-floats support
   - Add CI test to include CosmWasm compilation check
-([/#850](https://github.com/cosmos/ibc-rs/issues/850))
+([\#850](https://github.com/cosmos/ibc-rs/issues/850))

--- a/.changelog/unreleased/improvements/926_mocks_implies_std.md
+++ b/.changelog/unreleased/improvements/926_mocks_implies_std.md
@@ -1,0 +1,9 @@
+- Change `mocks` feature to imply `std` since it requires
+  Timestamp::now to work.
+  ([\#926](https://github.com/cosmos/ibc-rs/pull/926))
+
+<!--
+    Add your entry's details here (in Markdown format).
+
+    If you don't change this message, or if this file is empty, the entry will
+    not be created. -->

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 std = [
     "ibc-proto/std",
     "ics23/std",
-    "serde/std",    
+    "serde/std",
     "tracing/std",
     "prost/std",
     "bytes/std",
@@ -46,7 +46,7 @@ schema = ["dep:schemars", "serde", "std"]
 
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
-mocks = ["tendermint-testgen", "tendermint/clock", "parking_lot", "typed-builder"]
+mocks = ["tendermint-testgen", "parking_lot", "typed-builder", "std"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.


### PR DESCRIPTION
`mocks` feature results in use of `Timestamp::now` which is only
defined when `std` feature is enabled.  Make `std` implied by `mocks`.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
