### PR TITLE
refactor: packet_commitments and packet_acknowledgements return PacketState

### DIFF
--- a/.changelog/unreleased/improvements/927-refactor-packet-commitments-and-packet-acknowledgements.md
+++ b/.changelog/unreleased/improvements/927-refactor-packet-commitments-and-packet-acknowledgements.md
@@ -1,0 +1,2 @@
+- Return PacketStates instead of paths from packet_commitments and
+  packet_acknowledgements ([\#927](https://github.com/cosmos/ibc-rs/issues/927))

--- a/crates/ibc-query/src/core/channel/query.rs
+++ b/crates/ibc-query/src/core/channel/query.rs
@@ -13,7 +13,7 @@ use ibc::core::ValidationContext;
 use ibc::Height;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::channel::v1::{
-    PacketState, QueryChannelClientStateRequest, QueryChannelClientStateResponse,
+    QueryChannelClientStateRequest, QueryChannelClientStateResponse,
     QueryChannelConsensusStateRequest, QueryChannelConsensusStateResponse, QueryChannelRequest,
     QueryChannelResponse, QueryChannelsRequest, QueryChannelsResponse,
     QueryConnectionChannelsRequest, QueryConnectionChannelsResponse,
@@ -274,17 +274,8 @@ where
     let commitments = ibc_ctx
         .packet_commitments(&channel_end_path)?
         .into_iter()
-        .map(|path| {
-            ibc_ctx
-                .get_packet_commitment(&path)
-                .map(|commitment| PacketState {
-                    port_id: path.port_id.as_str().into(),
-                    channel_id: path.channel_id.as_str().into(),
-                    sequence: path.sequence.into(),
-                    data: commitment.into_vec(),
-                })
-        })
-        .collect::<Result<_, _>>()?;
+        .map(Into::into)
+        .collect();
 
     Ok(QueryPacketCommitmentsResponse {
         commitments,
@@ -393,17 +384,8 @@ where
     let acknowledgements = ibc_ctx
         .packet_acknowledgements(&channel_end_path, commitment_sequences)?
         .into_iter()
-        .map(|path| {
-            ibc_ctx
-                .get_packet_acknowledgement(&path)
-                .map(|acknowledgement| PacketState {
-                    port_id: path.port_id.as_str().into(),
-                    channel_id: path.channel_id.as_str().into(),
-                    sequence: path.sequence.into(),
-                    data: acknowledgement.into_vec(),
-                })
-        })
-        .collect::<Result<_, _>>()?;
+        .map(Into::into)
+        .collect();
 
     Ok(QueryPacketAcknowledgementsResponse {
         acknowledgements,

--- a/crates/ibc-query/src/core/context.rs
+++ b/crates/ibc-query/src/core/context.rs
@@ -2,9 +2,9 @@
 
 use ibc::core::ics03_connection::connection::IdentifiedConnectionEnd;
 use ibc::core::ics04_channel::channel::IdentifiedChannelEnd;
-use ibc::core::ics04_channel::packet::Sequence;
+use ibc::core::ics04_channel::packet::{PacketState, Sequence};
 use ibc::core::ics24_host::identifier::{ClientId, ConnectionId};
-use ibc::core::ics24_host::path::{AckPath, ChannelEndPath, CommitmentPath, Path};
+use ibc::core::ics24_host::path::{ChannelEndPath, Path};
 use ibc::core::{ContextError, ValidationContext};
 use ibc::prelude::*;
 use ibc::Height;
@@ -56,7 +56,7 @@ pub trait QueryContext: ProvableContext + ValidationContext {
     fn packet_commitments(
         &self,
         channel_end_path: &ChannelEndPath,
-    ) -> Result<Vec<CommitmentPath>, ContextError>;
+    ) -> Result<Vec<PacketState>, ContextError>;
 
     /// Filters the list of packet sequences for the given channel end that are acknowledged.
     /// Returns all the packet acknowledgements if `sequences` is empty.
@@ -64,7 +64,7 @@ pub trait QueryContext: ProvableContext + ValidationContext {
         &self,
         channel_end_path: &ChannelEndPath,
         sequences: impl ExactSizeIterator<Item = Sequence>,
-    ) -> Result<Vec<AckPath>, ContextError>;
+    ) -> Result<Vec<PacketState>, ContextError>;
 
     /// Filters the packet sequences for the given channel end that are not received.
     fn unreceived_packets(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #927

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR refactors `QueryContext::packet_commitments` and `QueryContext::packet_acknowledgements` to return `PacketState`s directly.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
