### PR TITLE
ibc: prevent invalid Height from being deserialised

### DIFF
--- a/.changelog/unreleased/improvements/932-height-deserialize.md
+++ b/.changelog/unreleased/improvements/932-height-deserialize.md
@@ -1,0 +1,7 @@
+- Prevent borsh and serde from deserialising Height with zero revision
+  height. ([\#932](https://github.com/cosmos/ibc-rs/pull/932))
+<!--
+    Add your entry's details here (in Markdown format).
+
+    If you don't change this message, or if this file is empty, the entry will
+    not be created. -->


### PR DESCRIPTION
Change revision_height from u64 to NonZeroU64 to make invalid heights
(ones where revision_height is zero) impossible to represent.  This
makes borsh and serde deserialisation fail when given invalid height
(while in the past they would construct an invalid object).

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
