### PR TITLE
perf: add PortId::from_bytes and rework identifier validation

### DIFF
--- a/.changelog/unreleased/section/936-port-id-from-bytes.md
+++ b/.changelog/unreleased/section/936-port-id-from-bytes.md
@@ -1,0 +1,3 @@
+- Add `PortId::from_bytes` method for constructing PortId from bytes
+  slice caller doesn’t know is valid UTF-8.  Useful when dealing with
+  binary protocols.  ([\#936](https://github.com/cosmos/ibc-rs/pull/936))

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -9,7 +9,7 @@
     rust_2018_idioms
 )]
 #![cfg_attr(not(test), deny(clippy::disallowed_methods, clippy::disallowed_types,))]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 // https://github.com/cosmos/ibc-rs/issues/342
 #![allow(clippy::result_large_err)]
 //! This library implements the InterBlockchain Communication (IBC) protocol in Rust. IBC is


### PR DESCRIPTION
The main motivating factor for this change is scenario in which one
has a slice of bytes and wants to parse it as PartId.  Since PortId
implements FromStr and has a new method which takes a String such
slice must first be converted into a string.  A parsing code might
look something like:

    fn port_id_from_bytes(bytes: &[u8]) -> Result<PortId, Error> {
        let id = core::str::from_utf8(bytes)?;
        let id = PortId::from_str(id)?;
        Ok(id)
    }

However, notice that in this situation the bytes are validated twice
(in fact three times, see below).  First `from_utf8` has to go through
it to check if the identifier is valid UTF-8; and then `from_str` has
to go through the bytes again.  This by itself is wasteful but what’s
even worse is that Unicode strings are not valid identifiers so the
logic of checking if bytes are valid UTF-8 is unnecessary.

With PortId::from_bytes, the code checks whether the bytes includes
any invalid characters.  If it doesn’t, than it knows the entire slice
is all ASCII bytes and thus can be converted to a string.

To handle error cases, introduce Error::InvalidUtf8 error which is
used in the bytes aren’t valid UTF-8.

----

With this change, validate_identifier_chars now works on slice of
bytes rather than on a str.  This by itself is probably an
optimisation since iterating over bytes is easier than over characters
of a string.  Since Unicode characters aren’t valid parts of
identifiers this doesn’t affect observable behaviour of the code.

----

Furthermore, this change also refactors the validation
code. Specifically, the old identifier validation code contained the
following:

    if id.contains(PATH_SEPARATOR) {
        return Err(Error::ContainSeparator { id: id.into() });
    }
    if !id.chars().all(|c| /* ... */) {
        return Err(Error::InvalidCharacter { id: id.into() });
    }

This means that all identifiers had to be scanned twice.  First to
look for a slash and then to check if all characters are valid.  After
all the refactoring the code is now equivalence of:

    if !id.bytes().all(|c| /* ... */) {
        if id.as_bytes().contains(PATH_SEPARATOR) {
            return Err(Error::ContainSeparator { id: id.into() });
        } else {
            return Err(Error::InvalidCharacter { id: id.into() });
        }
    }

With this, correct identifiers are scanned only once.


### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
