### PR TITLE
feat: add From derive for ICS26 messages

### DIFF
--- a/.changelog/unreleased/improvements/938-add-from.md
+++ b/.changelog/unreleased/improvements/938-add-from.md
@@ -1,0 +1,2 @@
+- Add From implementation for ICS26 enum types to make it simpler
+  to construct the types.  ([\#938](https://github.com/cosmos/ibc-rs/pull/938))

--- a/crates/ibc/src/core/ics02_client/msgs.rs
+++ b/crates/ibc/src/core/ics02_client/msgs.rs
@@ -21,7 +21,7 @@ pub mod upgrade_client;
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub enum ClientMsg {
     CreateClient(MsgCreateClient),
     UpdateClient(MsgUpdateClient),

--- a/crates/ibc/src/core/ics03_connection/msgs.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs.rs
@@ -29,7 +29,7 @@ pub mod conn_open_try;
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub enum ConnectionMsg {
     OpenInit(MsgConnectionOpenInit),
     OpenTry(MsgConnectionOpenTry),

--- a/crates/ibc/src/core/ics04_channel/msgs.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs.rs
@@ -36,7 +36,7 @@ use crate::core::ics24_host::identifier::PortId;
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub enum ChannelMsg {
     OpenInit(MsgChannelOpenInit),
     OpenTry(MsgChannelOpenTry),
@@ -52,7 +52,7 @@ pub enum ChannelMsg {
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub enum PacketMsg {
     Recv(MsgRecvPacket),
     Ack(MsgAcknowledgement),

--- a/crates/ibc/src/core/msgs.rs
+++ b/crates/ibc/src/core/msgs.rs
@@ -40,7 +40,7 @@ pub trait Msg: Clone {
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub enum MsgEnvelope {
     Client(ClientMsg),
     Connection(ConnectionMsg),


### PR DESCRIPTION
Add derive_more::From to MsgEnvelope and encapsulated enums so that
it’s easier to construct those objects without having to spell out
their names or variants.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [-] Added tests.
- [-] Linked to GitHub issue.
- [-] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
