### PR TITLE
deps: bump `ibc-proto-rs` to v0.38.0 + some other dependency upgrades

### DIFF
--- a/.changelog/unreleased/breaking-changes/949-bump-ibc-proto-rs-to-v0380.md
+++ b/.changelog/unreleased/breaking-changes/949-bump-ibc-proto-rs-to-v0380.md
@@ -1,2 +1,2 @@
 - Bump `ibc-proto-rs` to v0.38.0
- ([#949](https://github.com/cosmos/ibc-rs/issues/949))
+  ([\#949](https://github.com/cosmos/ibc-rs/issues/949))

--- a/.changelog/unreleased/breaking-changes/949-bump-ibc-proto-rs-to-v0380.md
+++ b/.changelog/unreleased/breaking-changes/949-bump-ibc-proto-rs-to-v0380.md
@@ -1,0 +1,2 @@
+- Bump `ibc-proto-rs` to v0.38.0
+ ([#949](https://github.com/cosmos/ibc-rs/issues/949))

--- a/ci/cw-check/Cargo.lock
+++ b/ci/cw-check/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63042806bb2f662ca1c68026231900cfe13361136ddfd0dd09bcb315056a22b8"
+checksum = "93cbf4cbe9e5113cc7c70f3208a7029b2205c629502cbb2ae7ea0a09a97d3005"
 dependencies = [
  "base64 0.21.2",
  "bytes",

--- a/ci/no-std-check/Cargo.lock
+++ b/ci/no-std-check/Cargo.lock
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63042806bb2f662ca1c68026231900cfe13361136ddfd0dd09bcb315056a22b8"
+checksum = "93cbf4cbe9e5113cc7c70f3208a7029b2205c629502cbb2ae7ea0a09a97d3005"
 dependencies = [
  "base64 0.21.4",
  "borsh",

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 
 [dependencies]
 ibc = { path = "../../crates/ibc", default-features = false, features = ["serde"] }
-ibc-proto = { version = "0.37.1", default-features = false, features = [
+ibc-proto = { version = "0.38.0", default-features = false, features = [
   "parity-scale-codec",
   "borsh",
   "serde",
@@ -15,10 +15,10 @@ tendermint = { version = "0.34", default-features = false }
 tendermint-proto = { version = "0.34", default-features = false }
 tendermint-light-client-verifier = { version = "0.34", default-features = false, features = ["rust-crypto"] }
 
-sp-core = { version = "24.0.0", default-features = false, optional = true }
-sp-io = { version = "26.0.0", default-features = false, optional = true }
-sp-runtime = { version = "27.0.0", default-features = false, optional = true }
-sp-std = { version = "11.0.0", default-features = false, optional = true }
+sp-core = { version = "25.0.0", default-features = false, optional = true }
+sp-io = { version = "27.0.0", default-features = false, optional = true }
+sp-runtime = { version = "28.0.0", default-features = false, optional = true }
+sp-std = { version = "12.0.0", default-features = false, optional = true }
 
 # The indirect dependency `syn` 2.0.4 has a bug that causes
 # compilation errors in `tendermint`. This is fixed in 2.0.5.

--- a/crates/ibc-derive/src/consensus_state.rs
+++ b/crates/ibc-derive/src/consensus_state.rs
@@ -36,7 +36,7 @@ pub fn consensus_state_derive_impl(ast: DeriveInput) -> TokenStream {
                 }
             }
 
-            fn encode_vec(&self) -> Vec<u8> {
+            fn encode_vec(self) -> Vec<u8> {
                 match self {
                     #(#encode_vec_impl),*
                 }

--- a/crates/ibc-query/Cargo.toml
+++ b/crates/ibc-query/Cargo.toml
@@ -19,6 +19,6 @@ std = ["ibc-proto/std", "ibc/std"]
 
 [dependencies]
 ibc = { version = "0.47.0", path = "../ibc", default-features = false }
-ibc-proto = { version = "0.37.1", default-features = false, features = ["server"] }
+ibc-proto = { version = "0.38.0", default-features = false, features = ["server"] }
 displaydoc = { version = "0.2", default-features = false }
 tonic = "0.10"

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -53,23 +53,23 @@ mocks = ["tendermint-testgen", "parking_lot", "typed-builder", "std"]
 ibc-proto = { version = "0.38.0", default-features = false }
 ics23 = { version = "0.11", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.31", default-features = false }
-serde_derive = { version = "1.0.104", default-features = false, optional = true }
+serde_derive = { version = "1.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_json =  { package = "serde-json-wasm", version = "1.0.0" , default-features = false, optional = true}
-tracing = { version = "0.1.36", default-features = false }
+tracing = { version = "0.1.40", default-features = false }
 prost = { version = "0.12", default-features = false }
-bytes = { version = "1.2.1", default-features = false }
+bytes = { version = "1.5.0", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
+num-traits = { version = "0.2.17", default-features = false }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display", "try_into"] }
 uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
+primitive-types = { version = "0.12.2", default-features = false, features = ["serde_no_std"] }
 
 ## for codec encode or decode
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "3.6.5", default-features = false, features = ["full"], optional = true }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
 ## for borsh encode or decode
 borsh = {version = "0.10", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
@@ -77,7 +77,7 @@ typed-builder = { version = "0.18.0", optional = true }
 
 ibc-derive = { version ="0.3.0", path = "../ibc-derive" }
 
-schemars = { version = "0.8.12", optional = true }
+schemars = { version = "0.8.15", optional = true }
 
 [dependencies.tendermint]
 version = "0.34"
@@ -99,8 +99,8 @@ default-features = false
 
 [dev-dependencies]
 env_logger = "0.10.0"
-rstest = "0.18.1"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-test-log = { version = "0.2.10", features = ["trace"] }
+rstest = "0.18.2"
+tracing-subscriber = { version = "0.3.17", features = ["fmt", "env-filter", "json"]}
+test-log = { version = "0.2.13", features = ["trace"] }
 tendermint-rpc = { version = "0.34", features = ["http-client", "websocket-client"] }
 ibc = { path = ".", features = ["mocks"] }

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -50,7 +50,7 @@ mocks = ["tendermint-testgen", "parking_lot", "typed-builder", "std"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.37.1", default-features = false }
+ibc-proto = { version = "0.38.0", default-features = false }
 ics23 = { version = "0.11", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.31", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -73,7 +73,7 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 ## for borsh encode or decode
 borsh = {version = "0.10", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-typed-builder = { version = "0.17.0", optional = true }
+typed-builder = { version = "0.18.0", optional = true }
 
 ibc-derive = { version ="0.3.0", path = "../ibc-derive" }
 

--- a/crates/ibc/src/applications/transfer/error.rs
+++ b/crates/ibc/src/applications/transfer/error.rs
@@ -4,7 +4,6 @@ use core::convert::Infallible;
 use core::str::Utf8Error;
 
 use displaydoc::Display;
-use ibc_proto::protobuf::Error as TendermintProtoError;
 use uint::FromDecStrErr;
 
 use crate::core::ics04_channel::acknowledgement::StatusValue;
@@ -64,8 +63,8 @@ pub enum TokenTransferError {
         port_id: PortId,
         exp_port_id: PortId,
     },
-    /// decoding raw msg error: `{0}`
-    DecodeRawMsg(TendermintProtoError),
+    /// decoding raw msg error: `{reason}`
+    DecodeRawMsg { reason: String },
     /// unknown msg type: `{msg_type}`
     UnknownMsgType { msg_type: String },
     /// invalid coin string: `{coin}`
@@ -89,7 +88,6 @@ impl std::error::Error for TokenTransferError {
                 ..
             } => Some(e),
             Self::InvalidAmount(e) => Some(e),
-            Self::DecodeRawMsg(e) => Some(e),
             Self::Utf8Decode(e) => Some(e),
             _ => None,
         }

--- a/crates/ibc/src/applications/transfer/msgs/transfer.rs
+++ b/crates/ibc/src/applications/transfer/msgs/transfer.rs
@@ -2,7 +2,7 @@
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::applications::transfer::v1::MsgTransfer as RawMsgTransfer;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::applications::transfer::error::TokenTransferError;
 use crate::applications::transfer::packet::PacketData;
@@ -115,7 +115,9 @@ impl TryFrom<Any> for MsgTransfer {
     fn try_from(raw: Any) -> Result<Self, Self::Error> {
         match raw.type_url.as_str() {
             TYPE_URL => {
-                MsgTransfer::decode_vec(&raw.value).map_err(TokenTransferError::DecodeRawMsg)
+                MsgTransfer::decode_vec(&raw.value).map_err(|e| TokenTransferError::DecodeRawMsg {
+                    reason: e.to_string(),
+                })
             }
             _ => Err(TokenTransferError::UnknownMsgType {
                 msg_type: raw.type_url,

--- a/crates/ibc/src/clients/ics07_tendermint/client_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state.rs
@@ -13,7 +13,7 @@ use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::Height as RawHeight;
 use ibc_proto::ibc::core::commitment::v1::MerkleProof as RawMerkleProof;
 use ibc_proto::ibc::lightclients::tendermint::v1::ClientState as RawTmClientState;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use prost::Message;
 use tendermint::chain::id::MAX_LENGTH as MaxChainIdLen;
 use tendermint::trust_threshold::TrustThresholdFraction as TendermintTrustThresholdFraction;
@@ -770,7 +770,7 @@ impl From<ClientState> for Any {
     fn from(client_state: ClientState) -> Self {
         Any {
             type_url: TENDERMINT_CLIENT_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawTmClientState>::encode_vec(&client_state),
+            value: Protobuf::<RawTmClientState>::encode_vec(client_state),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/consensus_state.rs
@@ -2,7 +2,7 @@
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState as RawConsensusState;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use tendermint::hash::Algorithm;
 use tendermint::time::Time;
 use tendermint::Hash;
@@ -126,7 +126,7 @@ impl From<ConsensusState> for Any {
     fn from(consensus_state: ConsensusState) -> Self {
         Any {
             type_url: TENDERMINT_CONSENSUS_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawConsensusState>::encode_vec(&consensus_state),
+            value: Protobuf::<RawConsensusState>::encode_vec(consensus_state),
         }
     }
 }
@@ -156,7 +156,7 @@ impl ConsensusStateTrait for ConsensusState {
         self.timestamp.into()
     }
 
-    fn encode_vec(&self) -> Vec<u8> {
+    fn encode_vec(self) -> Vec<u8> {
         <Self as Protobuf<Any>>::encode_vec(self)
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/header.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/header.rs
@@ -7,7 +7,7 @@ use core::str::FromStr;
 use bytes::Buf;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::lightclients::tendermint::v1::Header as RawHeader;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use pretty::{PrettySignedHeader, PrettyValidatorSet};
 use prost::Message;
 use tendermint::block::signed_header::SignedHeader;
@@ -186,7 +186,7 @@ impl From<Header> for Any {
     fn from(header: Header) -> Self {
         Any {
             type_url: TENDERMINT_HEADER_TYPE_URL.to_string(),
-            value: Protobuf::<RawHeader>::encode_vec(&header),
+            value: Protobuf::<RawHeader>::encode_vec(header),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/misbehaviour.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/misbehaviour.rs
@@ -3,7 +3,7 @@
 use bytes::Buf;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::lightclients::tendermint::v1::Misbehaviour as RawMisbehaviour;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use prost::Message;
 
 use crate::clients::ics07_tendermint::error::Error;
@@ -135,7 +135,7 @@ impl From<Misbehaviour> for Any {
     fn from(misbehaviour: Misbehaviour) -> Self {
         Any {
             type_url: TENDERMINT_MISBEHAVIOUR_TYPE_URL.to_string(),
-            value: Protobuf::<RawMisbehaviour>::encode_vec(&misbehaviour),
+            value: Protobuf::<RawMisbehaviour>::encode_vec(misbehaviour),
         }
     }
 }

--- a/crates/ibc/src/clients/ics07_tendermint/trust_threshold.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/trust_threshold.rs
@@ -6,7 +6,7 @@ use core::convert::TryFrom;
 use core::fmt::{Display, Error as FmtError, Formatter};
 
 use ibc_proto::ibc::lightclients::tendermint::v1::Fraction;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use tendermint::trust_threshold::TrustThresholdFraction;
 
 use crate::core::ics02_client::error::ClientError;

--- a/crates/ibc/src/core/context.rs
+++ b/crates/ibc/src/core/context.rs
@@ -65,8 +65,8 @@ pub enum RouterError {
     ContextError(ContextError),
     /// unknown type URL `{url}`
     UnknownMessageTypeUrl { url: String },
-    /// the message is malformed and cannot be decoded error: `{0}`
-    MalformedMessageBytes(ibc_proto::protobuf::Error),
+    /// the message is malformed and cannot be decoded error: `{reason}`
+    MalformedMessageBytes { reason: String },
     /// port `{port_id}` is unknown
     UnknownPort { port_id: PortId },
     /// module not found
@@ -84,7 +84,6 @@ impl std::error::Error for RouterError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
             Self::ContextError(e) => Some(e),
-            Self::MalformedMessageBytes(e) => Some(e),
             _ => None,
         }
     }

--- a/crates/ibc/src/core/ics02_client/consensus_state.rs
+++ b/crates/ibc/src/core/ics02_client/consensus_state.rs
@@ -24,5 +24,5 @@ pub trait ConsensusState: Send + Sync {
     /// Serializes the `ConsensusState`. This is expected to be implemented as
     /// first converting to the raw type (i.e. the protobuf definition), and then
     /// serializing that.
-    fn encode_vec(&self) -> Vec<u8>;
+    fn encode_vec(self) -> Vec<u8>;
 }

--- a/crates/ibc/src/core/ics02_client/error.rs
+++ b/crates/ibc/src/core/ics02_client/error.rs
@@ -1,7 +1,6 @@
 //! Defines the client error type
 
 use displaydoc::Display;
-use ibc_proto::protobuf::Error as TendermintProtoError;
 
 use super::client_state::Status;
 use crate::core::ics02_client::client_type::ClientType;
@@ -65,8 +64,8 @@ pub enum ClientError {
     Decode(prost::DecodeError),
     /// invalid client identifier error: `{0}`
     InvalidClientIdentifier(IdentifierError),
-    /// invalid raw header error: `{0}`
-    InvalidRawHeader(TendermintProtoError),
+    /// invalid raw header error: `{reason}`
+    InvalidRawHeader { reason: String },
     /// missing raw client message
     MissingClientMessage,
     /// invalid raw misbehaviour error: `{0}`
@@ -140,7 +139,6 @@ impl std::error::Error for ClientError {
             } => Some(e),
             Self::InvalidMsgUpdateClientId(e) => Some(e),
             Self::InvalidClientIdentifier(e) => Some(e),
-            Self::InvalidRawHeader(e) => Some(e),
             Self::InvalidRawMisbehaviour(e) => Some(e),
             Self::InvalidCommitmentProof(e) => Some(e),
             Self::InvalidPacketTimestamp(e) => Some(e),

--- a/crates/ibc/src/core/ics02_client/height.rs
+++ b/crates/ibc/src/core/ics02_client/height.rs
@@ -6,7 +6,7 @@ use core::str::FromStr;
 
 use displaydoc::Display;
 use ibc_proto::ibc::core::client::v1::Height as RawHeight;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
 use crate::prelude::*;

--- a/crates/ibc/src/core/ics02_client/msgs/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/create_client.rs
@@ -2,7 +2,7 @@
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::MsgCreateClient as RawMsgCreateClient;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
 use crate::core::Msg;

--- a/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/misbehaviour.rs
@@ -2,7 +2,7 @@
 
 use ibc_proto::google::protobuf::Any as ProtoAny;
 use ibc_proto::ibc::core::client::v1::MsgSubmitMisbehaviour as RawMsgSubmitMisbehaviour;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics24_host::identifier::ClientId;

--- a/crates/ibc/src/core/ics02_client/msgs/update_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/update_client.rs
@@ -2,7 +2,7 @@
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::MsgUpdateClient as RawMsgUpdateClient;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics24_host::identifier::ClientId;

--- a/crates/ibc/src/core/ics02_client/msgs/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/upgrade_client.rs
@@ -4,7 +4,7 @@ use core::str::FromStr;
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::MsgUpgradeClient as RawMsgUpgradeClient;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::{ClientError, UpgradeClientError};
 use crate::core::ics23_commitment::commitment::CommitmentProofBytes;

--- a/crates/ibc/src/core/ics03_connection/connection.rs
+++ b/crates/ibc/src/core/ics03_connection/connection.rs
@@ -8,7 +8,7 @@ use ibc_proto::ibc::core::connection::v1::{
     ConnectionEnd as RawConnectionEnd, Counterparty as RawCounterparty,
     IdentifiedConnection as RawIdentifiedConnection,
 };
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics03_connection::error::ConnectionError;

--- a/crates/ibc/src/core/ics03_connection/error.rs
+++ b/crates/ibc/src/core/ics03_connection/error.rs
@@ -3,7 +3,6 @@
 use alloc::string::String;
 
 use displaydoc::Display;
-use ibc_proto::protobuf::Error as ProtoError;
 
 use crate::core::ics02_client::error as client_error;
 use crate::core::ics03_connection::version::Version;
@@ -17,8 +16,6 @@ pub enum ConnectionError {
     Client(client_error::ClientError),
     /// invalid connection state: expected `{expected}`, actual `{actual}`
     InvalidState { expected: String, actual: String },
-    /// invalid connection end error: `{0}`
-    InvalidConnectionEnd(ProtoError),
     /// consensus height claimed by the client on the other party is too advanced: `{target_height}` (host chain current height: `{current_height}`)
     InvalidConsensusHeight {
         target_height: Height,

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_ack.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenAck`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use prost::Message;
 
 use crate::core::context::ContextError;

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_confirm.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenConfirm`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::context::ContextError;
 use crate::core::events::{IbcEvent, MessageEvent};

--- a/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/handler/conn_open_try.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to processing ICS3 messages of type `MsgConnectionOpenTry`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use prost::Message;
 
 use crate::core::context::ContextError;

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_ack.rs
@@ -1,6 +1,6 @@
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::connection::v1::MsgConnectionOpenAck as RawMsgConnectionOpenAck;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics03_connection::version::Version;

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_confirm.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_confirm.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::connection::v1::MsgConnectionOpenConfirm as RawMsgConnectionOpenConfirm;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics23_commitment::commitment::CommitmentProofBytes;

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_init.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_init.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 
 use ibc_proto::ibc::core::connection::v1::MsgConnectionOpenInit as RawMsgConnectionOpenInit;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics03_connection::connection::Counterparty;
 use crate::core::ics03_connection::error::ConnectionError;

--- a/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
+++ b/crates/ibc/src/core/ics03_connection/msgs/conn_open_try.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::connection::v1::MsgConnectionOpenTry as RawMsgConnectionOpenTry;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics03_connection::connection::Counterparty;
 use crate::core::ics03_connection::error::ConnectionError;

--- a/crates/ibc/src/core/ics03_connection/version.rs
+++ b/crates/ibc/src/core/ics03_connection/version.rs
@@ -3,7 +3,7 @@
 use core::fmt::Display;
 
 use ibc_proto::ibc::core::connection::v1::Version as RawVersion;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics03_connection::error::ConnectionError;
 use crate::core::ics04_channel::channel::Order;

--- a/crates/ibc/src/core/ics04_channel/channel.rs
+++ b/crates/ibc/src/core/ics04_channel/channel.rs
@@ -7,7 +7,7 @@ use ibc_proto::ibc::core::channel::v1::{
     Channel as RawChannel, Counterparty as RawCounterparty,
     IdentifiedChannel as RawIdentifiedChannel,
 };
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::Version;

--- a/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_close_confirm.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelCloseConfirm`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::events::{IbcEvent, MessageEvent};
 use crate::core::ics02_client::client_state::{ClientStateCommon, ClientStateValidation};

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_ack.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenAck`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::events::{IbcEvent, MessageEvent};
 use crate::core::ics02_client::client_state::{ClientStateCommon, ClientStateValidation};

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_confirm.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenConfirm`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::events::{IbcEvent, MessageEvent};
 use crate::core::ics02_client::client_state::{ClientStateCommon, ClientStateValidation};

--- a/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/chan_open_try.rs
@@ -1,6 +1,6 @@
 //! Protocol logic specific to ICS4 messages of type `MsgChannelOpenTry`.
 
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::events::{IbcEvent, MessageEvent};
 use crate::core::ics02_client::client_state::{ClientStateCommon, ClientStateValidation};

--- a/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/handler/timeout_on_close.rs
@@ -1,4 +1,4 @@
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use prost::Message;
 
 use crate::core::ics02_client::client_state::{ClientStateCommon, ClientStateValidation};

--- a/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/acknowledgement.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgAcknowledgement as RawMsgAcknowledgement;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::acknowledgement::Acknowledgement;
 use crate::core::ics04_channel::error::PacketError;

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_close_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_close_confirm.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgChannelCloseConfirm as RawMsgChannelCloseConfirm;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics23_commitment::commitment::CommitmentProofBytes;

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_close_init.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_close_init.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgChannelCloseInit as RawMsgChannelCloseInit;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics24_host::identifier::{ChannelId, PortId};

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_ack.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_ack.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgChannelOpenAck as RawMsgChannelOpenAck;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics04_channel::Version;

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_confirm.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_confirm.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgChannelOpenConfirm as RawMsgChannelOpenConfirm;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::ChannelError;
 use crate::core::ics23_commitment::commitment::CommitmentProofBytes;

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_init.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_init.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgChannelOpenInit as RawMsgChannelOpenInit;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::channel::{
     verify_connection_hops_length, ChannelEnd, Counterparty, Order, State,

--- a/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/chan_open_try.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgChannelOpenTry as RawMsgChannelOpenTry;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::channel::{
     verify_connection_hops_length, ChannelEnd, Counterparty, Order, State,

--- a/crates/ibc/src/core/ics04_channel/msgs/recv_packet.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/recv_packet.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgRecvPacket as RawMsgRecvPacket;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::PacketError;
 use crate::core::ics04_channel::packet::Packet;

--- a/crates/ibc/src/core/ics04_channel/msgs/timeout.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/timeout.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgTimeout as RawMsgTimeout;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::PacketError;
 use crate::core::ics04_channel::packet::{Packet, Sequence};

--- a/crates/ibc/src/core/ics04_channel/msgs/timeout_on_close.rs
+++ b/crates/ibc/src/core/ics04_channel/msgs/timeout_on_close.rs
@@ -1,5 +1,5 @@
 use ibc_proto::ibc::core::channel::v1::MsgTimeoutOnClose as RawMsgTimeoutOnClose;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics04_channel::error::PacketError;
 use crate::core::ics04_channel::packet::{Packet, Sequence};

--- a/crates/ibc/src/core/msgs.rs
+++ b/crates/ibc/src/core/msgs.rs
@@ -1,5 +1,5 @@
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::context::RouterError;
 use crate::core::ics02_client::msgs::{
@@ -57,45 +57,61 @@ impl TryFrom<Any> for MsgEnvelope {
             create_client::TYPE_URL => {
                 // Pop out the message and then wrap it in the corresponding type.
                 let domain_msg = create_client::MsgCreateClient::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Client(ClientMsg::CreateClient(domain_msg)))
             }
             update_client::TYPE_URL => {
                 let domain_msg = update_client::MsgUpdateClient::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Client(ClientMsg::UpdateClient(domain_msg)))
             }
             upgrade_client::TYPE_URL => {
                 let domain_msg = upgrade_client::MsgUpgradeClient::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Client(ClientMsg::UpgradeClient(domain_msg)))
             }
             misbehaviour::TYPE_URL => {
                 let domain_msg = misbehaviour::MsgSubmitMisbehaviour::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Client(ClientMsg::Misbehaviour(domain_msg)))
             }
 
             // ICS03
             conn_open_init::TYPE_URL => {
                 let domain_msg = conn_open_init::MsgConnectionOpenInit::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Connection(ConnectionMsg::OpenInit(domain_msg)))
             }
             conn_open_try::TYPE_URL => {
                 let domain_msg = conn_open_try::MsgConnectionOpenTry::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Connection(ConnectionMsg::OpenTry(domain_msg)))
             }
             conn_open_ack::TYPE_URL => {
                 let domain_msg = conn_open_ack::MsgConnectionOpenAck::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Connection(ConnectionMsg::OpenAck(domain_msg)))
             }
             conn_open_confirm::TYPE_URL => {
                 let domain_msg =
                     conn_open_confirm::MsgConnectionOpenConfirm::decode_vec(&any_msg.value)
-                        .map_err(RouterError::MalformedMessageBytes)?;
+                        .map_err(|e| RouterError::MalformedMessageBytes {
+                            reason: e.to_string(),
+                        })?;
                 Ok(MsgEnvelope::Connection(ConnectionMsg::OpenConfirm(
                     domain_msg,
                 )))
@@ -104,55 +120,79 @@ impl TryFrom<Any> for MsgEnvelope {
             // ICS04 channel messages
             chan_open_init::TYPE_URL => {
                 let domain_msg = chan_open_init::MsgChannelOpenInit::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Channel(ChannelMsg::OpenInit(domain_msg)))
             }
             chan_open_try::TYPE_URL => {
                 let domain_msg = chan_open_try::MsgChannelOpenTry::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Channel(ChannelMsg::OpenTry(domain_msg)))
             }
             chan_open_ack::TYPE_URL => {
                 let domain_msg = chan_open_ack::MsgChannelOpenAck::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Channel(ChannelMsg::OpenAck(domain_msg)))
             }
             chan_open_confirm::TYPE_URL => {
-                let domain_msg =
-                    chan_open_confirm::MsgChannelOpenConfirm::decode_vec(&any_msg.value)
-                        .map_err(RouterError::MalformedMessageBytes)?;
+                let domain_msg = chan_open_confirm::MsgChannelOpenConfirm::decode_vec(
+                    &any_msg.value,
+                )
+                .map_err(|e| RouterError::MalformedMessageBytes {
+                    reason: e.to_string(),
+                })?;
                 Ok(MsgEnvelope::Channel(ChannelMsg::OpenConfirm(domain_msg)))
             }
             chan_close_init::TYPE_URL => {
                 let domain_msg = chan_close_init::MsgChannelCloseInit::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                    reason: e.to_string(),
+                })?;
                 Ok(MsgEnvelope::Channel(ChannelMsg::CloseInit(domain_msg)))
             }
             chan_close_confirm::TYPE_URL => {
                 let domain_msg =
                     chan_close_confirm::MsgChannelCloseConfirm::decode_vec(&any_msg.value)
-                        .map_err(RouterError::MalformedMessageBytes)?;
+                        .map_err(|e| RouterError::MalformedMessageBytes {
+                            reason: e.to_string(),
+                        })?;
                 Ok(MsgEnvelope::Channel(ChannelMsg::CloseConfirm(domain_msg)))
             }
             // ICS04 packet messages
             recv_packet::TYPE_URL => {
-                let domain_msg = recv_packet::MsgRecvPacket::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                let domain_msg =
+                    recv_packet::MsgRecvPacket::decode_vec(&any_msg.value).map_err(|e| {
+                        RouterError::MalformedMessageBytes {
+                            reason: e.to_string(),
+                        }
+                    })?;
                 Ok(MsgEnvelope::Packet(PacketMsg::Recv(domain_msg)))
             }
             acknowledgement::TYPE_URL => {
                 let domain_msg = acknowledgement::MsgAcknowledgement::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Packet(PacketMsg::Ack(domain_msg)))
             }
             timeout::TYPE_URL => {
-                let domain_msg = timeout::MsgTimeout::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                let domain_msg = timeout::MsgTimeout::decode_vec(&any_msg.value).map_err(|e| {
+                    RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    }
+                })?;
                 Ok(MsgEnvelope::Packet(PacketMsg::Timeout(domain_msg)))
             }
             timeout_on_close::TYPE_URL => {
                 let domain_msg = timeout_on_close::MsgTimeoutOnClose::decode_vec(&any_msg.value)
-                    .map_err(RouterError::MalformedMessageBytes)?;
+                    .map_err(|e| RouterError::MalformedMessageBytes {
+                        reason: e.to_string(),
+                    })?;
                 Ok(MsgEnvelope::Packet(PacketMsg::TimeoutOnClose(domain_msg)))
             }
             _ => Err(RouterError::UnknownMessageTypeUrl {

--- a/crates/ibc/src/hosts/tendermint/upgrade_proposal/plan.rs
+++ b/crates/ibc/src/hosts/tendermint/upgrade_proposal/plan.rs
@@ -5,7 +5,7 @@ use alloc::string::{String, ToString};
 
 use ibc_proto::cosmos::upgrade::v1beta1::Plan as RawPlan;
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::UpgradeClientError;
 
@@ -108,7 +108,7 @@ impl From<Plan> for Any {
     fn from(value: Plan) -> Self {
         Any {
             type_url: TYPE_URL.to_string(),
-            value: Protobuf::<RawPlan>::encode_vec(&value),
+            value: Protobuf::<RawPlan>::encode_vec(value),
         }
     }
 }

--- a/crates/ibc/src/hosts/tendermint/upgrade_proposal/proposal.rs
+++ b/crates/ibc/src/hosts/tendermint/upgrade_proposal/proposal.rs
@@ -4,7 +4,7 @@ use alloc::string::{String, ToString};
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::client::v1::UpgradeProposal as RawUpgradeProposal;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use super::Plan;
 use crate::core::ics02_client::error::UpgradeClientError;

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -73,5 +73,5 @@ pub mod proto {
     pub use ibc_proto::ibc::apps::transfer;
     pub use ibc_proto::ibc::core;
     pub use ibc_proto::ibc::lightclients::tendermint;
-    pub use ibc_proto::protobuf;
+    pub use ibc_proto::Protobuf;
 }

--- a/crates/ibc/src/mock/client_state.rs
+++ b/crates/ibc/src/mock/client_state.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::mock::ClientState as RawMockClientState;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::client_state::{
     ClientStateCommon, ClientStateExecution, ClientStateValidation, Status, UpdateKind,
@@ -127,7 +127,7 @@ impl From<MockClientState> for Any {
     fn from(client_state: MockClientState) -> Self {
         Any {
             type_url: MOCK_CLIENT_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawMockClientState>::encode_vec(&client_state),
+            value: Protobuf::<RawMockClientState>::encode_vec(client_state),
         }
     }
 }

--- a/crates/ibc/src/mock/consensus_state.rs
+++ b/crates/ibc/src/mock/consensus_state.rs
@@ -1,6 +1,6 @@
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::mock::ConsensusState as RawMockConsensusState;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::consensus_state::ConsensusState;
 use crate::core::ics02_client::error::ClientError;
@@ -89,7 +89,7 @@ impl From<MockConsensusState> for Any {
     fn from(consensus_state: MockConsensusState) -> Self {
         Any {
             type_url: MOCK_CONSENSUS_STATE_TYPE_URL.to_string(),
-            value: Protobuf::<RawMockConsensusState>::encode_vec(&consensus_state),
+            value: Protobuf::<RawMockConsensusState>::encode_vec(consensus_state),
         }
     }
 }
@@ -103,7 +103,7 @@ impl ConsensusState for MockConsensusState {
         self.header.timestamp
     }
 
-    fn encode_vec(&self) -> Vec<u8> {
+    fn encode_vec(self) -> Vec<u8> {
         <Self as Protobuf<Any>>::encode_vec(self)
     }
 }

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -11,7 +11,7 @@ use core::time::Duration;
 
 use derive_more::{From, TryInto};
 use ibc_proto::google::protobuf::Any;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 use parking_lot::Mutex;
 use tendermint_testgen::Validator as TestgenValidator;
 use tracing::debug;

--- a/crates/ibc/src/mock/host.rs
+++ b/crates/ibc/src/mock/host.rs
@@ -4,7 +4,7 @@ use core::str::FromStr;
 
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::lightclients::tendermint::v1::Header as RawHeader;
-use ibc_proto::protobuf::Protobuf as ErasedProtobuf;
+use ibc_proto::Protobuf as ErasedProtobuf;
 use tendermint::block::Header as TmHeader;
 use tendermint::validator::Set as ValidatorSet;
 use tendermint_testgen::light_block::TmLightBlock;

--- a/crates/ibc/src/mock/misbehaviour.rs
+++ b/crates/ibc/src/mock/misbehaviour.rs
@@ -1,7 +1,7 @@
 use bytes::Buf;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::mock::Misbehaviour as RawMisbehaviour;
-use ibc_proto::protobuf::Protobuf;
+use ibc_proto::Protobuf;
 
 use crate::core::ics02_client::error::ClientError;
 use crate::core::ics24_host::identifier::ClientId;
@@ -79,7 +79,7 @@ impl From<Misbehaviour> for Any {
     fn from(misbehaviour: Misbehaviour) -> Self {
         Any {
             type_url: MOCK_MISBEHAVIOUR_TYPE_URL.to_string(),
-            value: Protobuf::<RawMisbehaviour>::encode_vec(&misbehaviour),
+            value: Protobuf::<RawMisbehaviour>::encode_vec(misbehaviour),
         }
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Upgrades ibc-proto-rs to v0.38.0
- Upgrades sp-* dependencies
- Upgrades `type-builder` to v0.18.0
- The `encode_vec` method of the `ConsensusState` trait takes `self` by value to avoid unnecessary cloning 


- Integration tests: https://github.com/informalsystems/basecoin-rs/pull/143
______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
