### PR TITLE
Generalize signature verifier of tendermint client.

### DIFF
--- a/crates/ibc/src/clients/ics07_tendermint/client_state/misbehaviour.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state/misbehaviour.rs
@@ -13,7 +13,8 @@ use crate::core::ics24_host::path::ClientConsensusStatePath;
 use crate::core::timestamp::Timestamp;
 use crate::prelude::*;
 
-impl ClientState {
+impl<V> ClientState<V>
+where V: Clone + tendermint::crypto::signature::Verifier {
     // verify_misbehaviour determines whether or not two conflicting headers at
     // the same height would have convinced the light client.
     pub fn verify_misbehaviour<ClientValidationContext>(

--- a/crates/ibc/src/clients/ics07_tendermint/client_state/update_client.rs
+++ b/crates/ibc/src/clients/ics07_tendermint/client_state/update_client.rs
@@ -13,7 +13,8 @@ use crate::core::ics24_host::identifier::ClientId;
 use crate::core::ics24_host::path::ClientConsensusStatePath;
 use crate::prelude::*;
 
-impl ClientState {
+impl<V> ClientState<V>
+where V: Clone + tendermint::crypto::signature::Verifier {
     pub fn verify_header<ClientValidationContext>(
         &self,
         ctx: &ClientValidationContext,

--- a/crates/ibc/src/core/ics02_client/handler/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/create_client.rs
@@ -157,7 +157,7 @@ mod tests {
 
         let tm_header = get_dummy_tendermint_header();
 
-        let tm_client_state = TmClientState::new_dummy_from_header(tm_header.clone()).into();
+        let tm_client_state = TmClientState::<tendermint::crypto::default::signature::Verifier>::new_dummy_from_header(tm_header.clone()).into();
 
         let client_type = tm_client_type();
 

--- a/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
+++ b/crates/ibc/src/core/ics02_client/handler/upgrade_client.rs
@@ -124,13 +124,16 @@ mod tests {
         let low_upgrade_height = Height::new(0, 26).unwrap();
         let msg_with_low_upgrade_height = MsgUpgradeClient::new_dummy(low_upgrade_height);
 
-        let msg_with_unknown_upgraded_cs = MsgUpgradeClient {
-            upgraded_client_state: TmClientState::new_dummy_from_header(
-                get_dummy_tendermint_header(),
-            )
-            .into(),
-            ..msg_default.clone()
-        };
+        let msg_with_unknown_upgraded_cs =
+            MsgUpgradeClient {
+                upgraded_client_state: TmClientState::<
+                    tendermint::crypto::default::signature::Verifier,
+                >::new_dummy_from_header(
+                    get_dummy_tendermint_header()
+                )
+                .into(),
+                ..msg_default.clone()
+            };
 
         let msg = match msg_variant {
             Msg::Default => msg_default,

--- a/crates/ibc/src/core/ics02_client/msgs/create_client.rs
+++ b/crates/ibc/src/core/ics02_client/msgs/create_client.rs
@@ -89,7 +89,7 @@ mod tests {
         let signer = get_dummy_account_id();
 
         let tm_header = get_dummy_tendermint_header();
-        let tm_client_state = TmClientState::new_dummy_from_header(tm_header.clone()).into();
+        let tm_client_state = TmClientState::<tendermint::crypto::default::signature::Verifier>::new_dummy_from_header(tm_header.clone()).into();
 
         let msg = MsgCreateClient::new(
             tm_client_state,

--- a/crates/ibc/src/hosts/tendermint/upgrade_proposal/handler.rs
+++ b/crates/ibc/src/hosts/tendermint/upgrade_proposal/handler.rs
@@ -20,7 +20,7 @@ pub fn upgrade_client_proposal_handler<Ctx>(
 ) -> Result<TmEvent, UpgradeClientError>
 where
     Ctx: UpgradeExecutionContext,
-    Ctx::AnyClientState: From<TmClientState>,
+    Ctx::AnyClientState: From<TmClientState<tendermint::crypto::default::signature::Verifier>>,
 {
     let plan = proposal.plan;
 

--- a/crates/ibc/src/hosts/tendermint/validate_self_client.rs
+++ b/crates/ibc/src/hosts/tendermint/validate_self_client.rs
@@ -21,7 +21,10 @@ pub trait ValidateSelfClientContext {
         &self,
         client_state_of_host_on_counterparty: Any,
     ) -> Result<(), ContextError> {
-        let tm_client_state = TmClientState::try_from(client_state_of_host_on_counterparty)
+        let tm_client_state =
+            TmClientState::<tendermint::crypto::default::signature::Verifier>::try_from(
+                client_state_of_host_on_counterparty,
+            )
             .map_err(|_| ConnectionError::InvalidClientState {
                 reason: "client must be a tendermint client".to_string(),
             })

--- a/crates/ibc/src/mock/context.rs
+++ b/crates/ibc/src/mock/context.rs
@@ -65,7 +65,7 @@ pub const DEFAULT_BLOCK_TIME_SECS: u64 = 3;
 ]
 #[mock]
 pub enum AnyClientState {
-    Tendermint(TmClientState),
+    Tendermint(TmClientState<tendermint::crypto::default::signature::Verifier>),
     Mock(MockClientState),
 }
 
@@ -723,7 +723,7 @@ impl MockContext {
                     })
                     .collect();
 
-                let client_state: TmClientState = TmClientStateConfig::builder()
+                let client_state: TmClientState<tendermint::crypto::default::signature::Verifier> = TmClientStateConfig::builder()
                     .chain_id(client.client_chain_id)
                     .latest_height(client.client_state_height)
                     .trusting_period(client.trusting_period)


### PR DESCRIPTION
## Description

While implementing [near-ibc](https://github.com/octopus-network/near-ibc), we found that the gas consumption of signature verification in tendermint client was high (about 9T gas for each) because it was using a pure rust implementation of the verifier (`tendermint::crypto::default::signature::Verifier`). In NEAR protocol, we can use a precompiled function to implement the ed25519 signature verification, which will only cost about 0.3T gas for each. So I made a change to the current tendermint client implementation, which enables a customized verifier of the tendermint `ClientState`. The verifier will be specified by the host implementation of `ibc-rs`, rather than a default implementation inside tendermint `ClientState`.

Of course I also made necessary changes to related code and tests.

This implementation had been included in the [latest near-ibc implementation](https://github.com/octopus-network/near-ibc/tree/upgrade-near-sdk) which reduced the gas consumption of signature verifications for about 96%. Obviously a big optimization for `near-ibc`.

I think this is also worth to be checked in `ibc-rs` to see whether this change is good enough to be included in the following releases.
