### PR TITLE
feat: turn ClientConsensusStatePath::haight into Height

### DIFF
--- a/crates/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
+++ b/crates/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
@@ -235,11 +235,9 @@ impl ClientExecutionContext for MockContext {
                 client_state: Default::default(),
             });
 
-        let height = Height::new(consensus_state_path.epoch, consensus_state_path.height)
-            .expect("Never fails");
         client_record
             .consensus_states
-            .insert(height, consensus_state);
+            .insert(consensus_state_path.height, consensus_state);
 
         Ok(())
     }
@@ -258,10 +256,9 @@ impl ClientExecutionContext for MockContext {
                 client_state: Default::default(),
             });
 
-        let height = Height::new(consensus_state_path.epoch, consensus_state_path.height)
-            .expect("Never fails");
-
-        client_record.consensus_states.remove(&height);
+        client_record
+            .consensus_states
+            .remove(&consensus_state_path.height);
 
         Ok(())
     }

--- a/crates/ibc-testkit/src/testapp/ibc/core/core_ctx.rs
+++ b/crates/ibc-testkit/src/testapp/ibc/core/core_ctx.rs
@@ -70,7 +70,7 @@ impl ValidationContext for MockContext {
         client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<AnyConsensusState, ContextError> {
         let client_id = &client_cons_state_path.client_id;
-        let height = Height::new(client_cons_state_path.epoch, client_cons_state_path.height)?;
+        let height = client_cons_state_path.height;
         match self.ibc_store.lock().clients.get(client_id) {
             Some(client_record) => match client_record.consensus_states.get(&height) {
                 Some(consensus_state) => Ok(consensus_state.clone()),


### PR DESCRIPTION
Replace ClientConsensusStatePath’s epoch and height fields with
a single height field whose type is Height.  This stores the exact
same information but allows infallible way to get Height out of the
path.

Arguably it also makes more sense conceptually since the epoch and
height are really just a single Height field.  Even in formatted paths
those two are a single component so it makes sense to have them as
a single field.

Issue: https://github.com/cosmos/ibc-rs/issues/603

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
