### PR TITLE
feat: replace store_update_{time,height} by metadata update

### DIFF
--- a/.changelog/unreleased/breaking-changes/973-update-meta.md
+++ b/.changelog/unreleased/breaking-changes/973-update-meta.md
@@ -1,0 +1,6 @@
+- Merge client update time and height modification method pairs into
+  one, that is replace
+  a) client_update_{time,height} by client_update_meta,
+  b) store_update_{time,height} by store_update_meta and
+  c) delete_update_{time,height} by delete_update_meta.
+  ([#973](https://github.com/cosmos/ibc-rs/issues))

--- a/docs/architecture/adr-005-handlers-redesign.md
+++ b/docs/architecture/adr-005-handlers-redesign.md
@@ -426,15 +426,9 @@ trait ExecutionContext {
 
     /// Called upon successful client update.
     ///
-    /// Implementations are expected to use this to record the specified time
-    /// and height as the time at which this update (or header) was processed.
-    fn store_update_meta(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        host_timestamp: Timestamp,
-        host_height: Height,
-    ) -> Result<(), Error>;
+    /// Implementations are expected to use this to record the host time
+    /// and height as when this update (or header) was processed.
+    fn store_update_meta(&mut self, client_id: ClientId, height: Height) -> Result<(), Error>;
 
     /// Stores the given connection_end at path
     fn store_connection(
@@ -540,13 +534,7 @@ pub trait Host {
 
     /// Methods currently in `ClientKeeper`
     fn increase_client_counter(&mut self);
-    fn store_update_meta(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        host_timestamp: Timestamp,
-        host_height: Height,
-    ) -> Result<(), Error>;
+    fn store_update_meta(&mut self, client_id: ClientId, height: Height) -> Result<(), Error>;
 
     /// Methods currently in `ConnectionReader`
     fn host_oldest_height(&self) -> Height;

--- a/docs/architecture/adr-005-handlers-redesign.md
+++ b/docs/architecture/adr-005-handlers-redesign.md
@@ -373,11 +373,9 @@ trait ValidationContext {
     /// A hashing function for packet commitments
     fn hash(&self, value: Vec<u8>) -> Vec<u8>;
 
-    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error>;
-
-    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_height(&self, client_id: &ClientId, height: Height) -> Result<Height, Error>;
+    /// Returns the time and height when the client state for the
+    /// given [`ClientId`] was updated with a header for the given [`Height`]
+    fn client_update_meta(&self, client_id: &ClientId, height: Height) -> Result<(Timestamp, Height), Error>;
 
     /// Returns a counter on the number of channel ids that have been created thus far.
     /// The value of this counter should increase only via method
@@ -561,8 +559,7 @@ pub trait Host {
     /// Methods currently in `ChannelReader`
     fn connection_channels(&self, cid: &ConnectionId) -> Result<Vec<(PortId, ChannelId)>, Error>;
     fn hash(&self, value: Vec<u8>) -> Vec<u8>;
-    fn client_update_time(&self, client_id: &ClientId, height: Height) -> Result<Timestamp, Error>;
-    fn client_update_height(&self, client_id: &ClientId, height: Height) -> Result<Height, Error>;
+    fn client_update_meta(&self, client_id: &ClientId, height: Height) -> Result<(Timestamp, Height), Error>;
     fn channel_counter(&self) -> Result<u64, Error>;
     fn max_expected_time_per_block(&self) -> Duration;
     fn block_delay(&self, delay_period_time: Duration) -> u64;

--- a/docs/architecture/adr-005-handlers-redesign.md
+++ b/docs/architecture/adr-005-handlers-redesign.md
@@ -40,14 +40,14 @@ function updateClient(
 
     clientState.VerifyClientMessage(clientMessage)
     // Validation END
-    
+
     // Execution START
     foundMisbehaviour := clientState.CheckForMisbehaviour(clientMessage)
     if foundMisbehaviour {
         clientState.UpdateStateOnMisbehaviour(clientMessage)
     }
-    else {    
-        clientState.UpdateState(clientMessage) 
+    else {
+        clientState.UpdateState(clientMessage)
     }
     // Execution END
 }
@@ -99,13 +99,13 @@ pub trait Host {
     /// An error type that can represent all host errors.
     type Error;
 
-    /// The Host's key-value store that must provide access to IBC paths. 
+    /// The Host's key-value store that must provide access to IBC paths.
     type KvStore: IbcStore<Self::Error>;
 
     /// An event logging facility.
     type EventLogger: EventLogger<Event=Event<DefaultIbcTypes>>;
 
-    /// Methods to access the store (ro & rw). 
+    /// Methods to access the store (ro & rw).
     fn store(&self) -> &Self::KvStore;
     fn store_mut(&mut self) -> &mut Self::KvStore;
 
@@ -427,22 +427,14 @@ trait ExecutionContext {
     fn increase_client_counter(&mut self);
 
     /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified time as the time at which
-    /// this update (or header) was processed.
-    fn store_update_time(
+    ///
+    /// Implementations are expected to use this to record the specified time
+    /// and height as the time at which this update (or header) was processed.
+    fn store_update_meta(
         &mut self,
         client_id: ClientId,
         height: Height,
-        timestamp: Timestamp,
-    ) -> Result<(), Error>;
-
-    /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified height as the height at
-    /// at which this update (or header) was processed.
-    fn store_update_height(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
+        host_timestamp: Timestamp,
         host_height: Height,
     ) -> Result<(), Error>;
 
@@ -550,16 +542,11 @@ pub trait Host {
 
     /// Methods currently in `ClientKeeper`
     fn increase_client_counter(&mut self);
-    fn store_update_time(
+    fn store_update_meta(
         &mut self,
         client_id: ClientId,
         height: Height,
-        timestamp: Timestamp,
-    ) -> Result<(), Error>;
-    fn store_update_height(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
+        host_timestamp: Timestamp,
         host_height: Height,
     ) -> Result<(), Error>;
 
@@ -626,7 +613,7 @@ pub trait StoreSerde {
     /// Serialize to canonical binary representation
     fn serialize(self) -> Vec<u8>;
 
-    /// Deserialize from bytes 
+    /// Deserialize from bytes
     fn deserialize(value: &[u8]) -> Self;
 }
 

--- a/ibc-clients/ics07-tendermint/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state.rs
@@ -349,8 +349,7 @@ where
             ),
             tm_consensus_state.into(),
         )?;
-        ctx.store_update_time(client_id.clone(), self.latest_height(), host_timestamp)?;
-        ctx.store_update_height(client_id.clone(), self.latest_height(), host_height)?;
+        ctx.store_update_meta(client_id, self.latest_height(), host_timestamp, host_height)?;
 
         Ok(())
     }
@@ -400,8 +399,7 @@ where
                 ClientStatePath::new(client_id),
                 ClientState::from(new_client_state).into(),
             )?;
-            ctx.store_update_time(client_id.clone(), header_height, host_timestamp)?;
-            ctx.store_update_height(client_id.clone(), header_height, host_height)?;
+            ctx.store_update_meta(client_id, header_height, host_timestamp, host_height)?;
         }
 
         Ok(vec![header_height])
@@ -491,8 +489,7 @@ where
             ),
             TmConsensusState::from(new_consensus_state).into(),
         )?;
-        ctx.store_update_time(client_id.clone(), latest_height, host_timestamp)?;
-        ctx.store_update_height(client_id.clone(), latest_height, host_height)?;
+        ctx.store_update_meta(client_id, latest_height, host_timestamp, host_height)?;
 
         Ok(latest_height)
     }

--- a/ibc-clients/ics07-tendermint/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state.rs
@@ -335,21 +335,18 @@ where
         client_id: &ClientId,
         consensus_state: Any,
     ) -> Result<(), ClientError> {
-        let host_timestamp = CommonContext::host_timestamp(ctx)?;
-        let host_height = CommonContext::host_height(ctx)?;
-
+        let height = self.latest_height();
         let tm_consensus_state = TmConsensusState::try_from(consensus_state)?;
-
         ctx.store_client_state(ClientStatePath::new(client_id), self.clone().into())?;
         ctx.store_consensus_state(
             ClientConsensusStatePath::new(
                 client_id.clone(),
-                self.0.latest_height.revision_number(),
-                self.0.latest_height.revision_height(),
+                height.revision_number(),
+                height.revision_height(),
             ),
             tm_consensus_state.into(),
         )?;
-        ctx.store_update_meta(client_id, self.latest_height(), host_timestamp, host_height)?;
+        ctx.store_update_meta(client_id, height)?;
 
         Ok(())
     }
@@ -381,9 +378,6 @@ where
             //
             // Do nothing.
         } else {
-            let host_timestamp = CommonContext::host_timestamp(ctx)?;
-            let host_height = CommonContext::host_height(ctx)?;
-
             let new_consensus_state = ConsensusStateType::from(header.clone());
             let new_client_state = self.0.clone().with_header(header)?;
 
@@ -399,7 +393,7 @@ where
                 ClientStatePath::new(client_id),
                 ClientState::from(new_client_state).into(),
             )?;
-            ctx.store_update_meta(client_id, header_height, host_timestamp, host_height)?;
+            ctx.store_update_meta(client_id, header_height)?;
         }
 
         Ok(vec![header_height])
@@ -474,8 +468,6 @@ where
         );
 
         let latest_height = new_client_state.latest_height;
-        let host_timestamp = CommonContext::host_timestamp(ctx)?;
-        let host_height = CommonContext::host_height(ctx)?;
 
         ctx.store_client_state(
             ClientStatePath::new(client_id),
@@ -489,7 +481,7 @@ where
             ),
             TmConsensusState::from(new_consensus_state).into(),
         )?;
-        ctx.store_update_meta(client_id, latest_height, host_timestamp, host_height)?;
+        ctx.store_update_meta(client_id, latest_height)?;
 
         Ok(latest_height)
     }

--- a/ibc-clients/ics07-tendermint/src/client_state/update_client.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state/update_client.rs
@@ -218,13 +218,9 @@ impl ClientState {
 
             if tm_consensus_state_expiry > host_timestamp {
                 break;
-            } else {
-                let client_id = client_id.clone();
-
-                ctx.delete_consensus_state(client_consensus_state_path)?;
-                ctx.delete_update_time(client_id.clone(), height)?;
-                ctx.delete_update_height(client_id, height)?;
             }
+            ctx.delete_consensus_state(client_consensus_state_path)?;
+            ctx.delete_update_meta(client_id, height)?;
         }
 
         Ok(())

--- a/ibc-clients/ics07-tendermint/types/src/error.rs
+++ b/ibc-clients/ics07-tendermint/types/src/error.rs
@@ -76,10 +76,8 @@ pub enum Error {
     NotEnoughTrustedValsSigned { reason: VotingPowerTally },
     /// verification failed: `{detail}`
     VerificationError { detail: LightClientErrorDetail },
-    /// Processed time for the client `{client_id}` at height `{height}` not found
+    /// Processed time or height for the client `{client_id}` at height `{height}` not found
     ProcessedTimeNotFound { client_id: ClientId, height: Height },
-    /// Processed height for the client `{client_id}` at height `{height}` not found
-    ProcessedHeightNotFound { client_id: ClientId, height: Height },
     /// The given hash of the validators does not matches the given hash in the signed header. Expected: `{signed_header_validators_hash}`, got: `{validators_hash}`
     MismatchValidatorsHashes {
         validators_hash: Hash,

--- a/ibc-core/ics02-client/context/src/context.rs
+++ b/ibc-core/ics02-client/context/src/context.rs
@@ -56,14 +56,12 @@ pub trait ClientExecutionContext: Sized {
 
     /// Called upon successful client update.
     ///
-    /// Implementations are expected to use this to record the specified time
-    /// and height as the time at which this update (or header) was processed.
+    /// Implementations are expected to use this to record the host time and
+    /// height as when this update (or header) was processed.
     fn store_update_meta(
         &mut self,
         client_id: &ClientId,
         height: Height,
-        host_timestamp: Timestamp,
-        host_height: Height,
     ) -> Result<(), ContextError>;
 
     /// Delete the update time and height associated with the client at the

--- a/ibc-core/ics02-client/context/src/context.rs
+++ b/ibc-core/ics02-client/context/src/context.rs
@@ -12,19 +12,13 @@ use super::consensus_state::ConsensusState;
 /// [crate::client_state::ClientStateValidation] must
 /// inherit from this trait.
 pub trait ClientValidationContext {
-    /// Returns the time when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_time(
+    /// Returns the time and height when the client state for the given
+    /// [`ClientId`] was updated with a header for the given [`Height`]
+    fn client_update_meta(
         &self,
         client_id: &ClientId,
-        height: &Height,
-    ) -> Result<Timestamp, ContextError>;
-
-    /// Returns the height when the client state for the given [`ClientId`] was updated with a header for the given [`Height`]
-    fn client_update_height(
-        &self,
-        client_id: &ClientId,
-        height: &Height,
-    ) -> Result<Height, ContextError>;
+        height: Height,
+    ) -> Result<(Timestamp, Height), ContextError>;
 }
 
 /// Defines the methods that all client `ExecutionContext`s (precisely the

--- a/ibc-core/ics02-client/context/src/context.rs
+++ b/ibc-core/ics02-client/context/src/context.rs
@@ -61,40 +61,27 @@ pub trait ClientExecutionContext: Sized {
     ) -> Result<(), ContextError>;
 
     /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified time as the time at which
-    /// this update (or header) was processed.
-    fn store_update_time(
+    ///
+    /// Implementations are expected to use this to record the specified time
+    /// and height as the time at which this update (or header) was processed.
+    fn store_update_meta(
         &mut self,
-        client_id: ClientId,
+        client_id: &ClientId,
         height: Height,
         host_timestamp: Timestamp,
-    ) -> Result<(), ContextError>;
-
-    /// Called upon successful client update.
-    /// Implementations are expected to use this to record the specified height as the height at
-    /// at which this update (or header) was processed.
-    fn store_update_height(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
         host_height: Height,
     ) -> Result<(), ContextError>;
 
-    /// Delete the update time associated with the client at the specified height. This update
-    /// time should be associated with a consensus state through the specified height.
+    /// Delete the update time and height associated with the client at the
+    /// specified height.
+    ///
+    /// This update time should be associated with a consensus state through the
+    /// specified height.
     ///
     /// Note that this timestamp is determined by the host.
-    fn delete_update_time(
+    fn delete_update_meta(
         &mut self,
-        client_id: ClientId,
-        height: Height,
-    ) -> Result<(), ContextError>;
-
-    /// Delete the update height associated with the client at the specified height. This update
-    /// time should be associated with a consensus state through the specified height.
-    fn delete_update_height(
-        &mut self,
-        client_id: ClientId,
+        client_id: &ClientId,
         height: Height,
     ) -> Result<(), ContextError>;
 }

--- a/ibc-core/ics02-client/types/src/error.rs
+++ b/ibc-core/ics02-client/types/src/error.rs
@@ -32,10 +32,8 @@ pub enum ClientError {
     ClientStateAlreadyExists { client_id: ClientId },
     /// consensus state not found at: `{client_id}` at height `{height}`
     ConsensusStateNotFound { client_id: ClientId, height: Height },
-    /// Processed time for the client `{client_id}` at height `{height}` not found
+    /// Processed time or height for the client `{client_id}` at height `{height}` not found
     ProcessedTimeNotFound { client_id: ClientId, height: Height },
-    /// Processed height for the client `{client_id}` at height `{height}` not found
-    ProcessedHeightNotFound { client_id: ClientId, height: Height },
     /// header verification failed with reason: `{reason}`
     HeaderVerificationFailure { reason: String },
     /// failed to build trust threshold from fraction: `{numerator}`/`{denominator}`

--- a/ibc-core/ics03-connection/src/delay.rs
+++ b/ibc-core/ics03-connection/src/delay.rs
@@ -19,19 +19,16 @@ where
 
     // Fetch the latest time and height that the counterparty client was updated on the host chain.
     let client_id = connection_end.client_id();
-    let last_client_update_time = ctx
+    let last_client_update = ctx
         .get_client_validation_context()
-        .client_update_time(client_id, &packet_proof_height)?;
-    let last_client_update_height = ctx
-        .get_client_validation_context()
-        .client_update_height(client_id, &packet_proof_height)?;
+        .client_update_meta(client_id, packet_proof_height)?;
 
     // Fetch the connection delay time and height periods.
     let conn_delay_time_period = connection_end.delay_period();
     let conn_delay_height_period = ctx.block_delay(&conn_delay_time_period);
 
     // Verify that the current host chain time is later than the last client update time
-    let earliest_valid_time = (last_client_update_time + conn_delay_time_period)
+    let earliest_valid_time = (last_client_update.0 + conn_delay_time_period)
         .map_err(ConnectionError::TimestampOverflow)?;
     if current_host_time < earliest_valid_time {
         return Err(ContextError::ConnectionError(
@@ -43,7 +40,7 @@ where
     }
 
     // Verify that the current host chain height is later than the last client update height
-    let earliest_valid_height = last_client_update_height.add(conn_delay_height_period);
+    let earliest_valid_height = last_client_update.1.add(conn_delay_height_period);
     if current_host_height < earliest_valid_height {
         return Err(ContextError::ConnectionError(
             ConnectionError::NotEnoughBlocksElapsed {

--- a/ibc-testkit/src/testapp/ibc/clients/mock/client_state.rs
+++ b/ibc-testkit/src/testapp/ibc/clients/mock/client_state.rs
@@ -356,8 +356,12 @@ where
             new_consensus_state.into(),
         )?;
         ctx.store_client_state(ClientStatePath::new(client_id), new_client_state.into())?;
-        ctx.store_update_time(client_id.clone(), header_height, ctx.host_timestamp()?)?;
-        ctx.store_update_height(client_id.clone(), header_height, ctx.host_height()?)?;
+        ctx.store_update_meta(
+            client_id,
+            header_height,
+            ctx.host_timestamp()?,
+            ctx.host_height()?,
+        )?;
 
         Ok(vec![header_height])
     }
@@ -401,8 +405,7 @@ where
         let host_timestamp = ctx.host_timestamp()?;
         let host_height = ctx.host_height()?;
 
-        ctx.store_update_time(client_id.clone(), latest_height, host_timestamp)?;
-        ctx.store_update_height(client_id.clone(), latest_height, host_height)?;
+        ctx.store_update_meta(client_id, latest_height, host_timestamp, host_height)?;
 
         Ok(latest_height)
     }

--- a/ibc-testkit/src/testapp/ibc/clients/mock/client_state.rs
+++ b/ibc-testkit/src/testapp/ibc/clients/mock/client_state.rs
@@ -356,12 +356,7 @@ where
             new_consensus_state.into(),
         )?;
         ctx.store_client_state(ClientStatePath::new(client_id), new_client_state.into())?;
-        ctx.store_update_meta(
-            client_id,
-            header_height,
-            ctx.host_timestamp()?,
-            ctx.host_height()?,
-        )?;
+        ctx.store_update_meta(client_id, header_height)?;
 
         Ok(vec![header_height])
     }
@@ -401,11 +396,7 @@ where
             new_consensus_state.into(),
         )?;
         ctx.store_client_state(ClientStatePath::new(client_id), new_client_state.into())?;
-
-        let host_timestamp = ctx.host_timestamp()?;
-        let host_height = ctx.host_height()?;
-
-        ctx.store_update_meta(client_id, latest_height, host_timestamp, host_height)?;
+        ctx.store_update_meta(client_id, latest_height)?;
 
         Ok(latest_height)
     }

--- a/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
+++ b/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
@@ -273,61 +273,32 @@ impl ClientExecutionContext for MockContext {
         Ok(())
     }
 
-    fn delete_update_height(
+    fn delete_update_meta(
         &mut self,
-        client_id: ClientId,
+        client_id: &ClientId,
         height: Height,
     ) -> Result<(), ContextError> {
-        let _ = self
-            .ibc_store
-            .lock()
-            .client_processed_heights
-            .remove(&(client_id, height));
-
+        let key = (client_id.clone(), height);
+        let mut ibc_store = self.ibc_store.lock();
+        ibc_store.client_processed_times.remove(&key);
+        ibc_store.client_processed_heights.remove(&key);
         Ok(())
     }
 
-    fn delete_update_time(
+    fn store_update_meta(
         &mut self,
-        client_id: ClientId,
+        client_id: &ClientId,
         height: Height,
-    ) -> Result<(), ContextError> {
-        let _ = self
-            .ibc_store
-            .lock()
-            .client_processed_times
-            .remove(&(client_id, height));
-
-        Ok(())
-    }
-
-    fn store_update_time(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
-        timestamp: Timestamp,
-    ) -> Result<(), ContextError> {
-        let _ = self
-            .ibc_store
-            .lock()
-            .client_processed_times
-            .insert((client_id, height), timestamp);
-
-        Ok(())
-    }
-
-    fn store_update_height(
-        &mut self,
-        client_id: ClientId,
-        height: Height,
+        host_timestamp: Timestamp,
         host_height: Height,
     ) -> Result<(), ContextError> {
-        let _ = self
-            .ibc_store
-            .lock()
+        let mut ibc_store = self.ibc_store.lock();
+        ibc_store
+            .client_processed_times
+            .insert((client_id.clone(), height), host_timestamp);
+        ibc_store
             .client_processed_heights
-            .insert((client_id, height), host_height);
-
+            .insert((client_id.clone(), height), host_height);
         Ok(())
     }
 }

--- a/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
+++ b/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
@@ -168,7 +168,7 @@ impl ClientValidationContext for MockContext {
             let height = ibc_store.client_processed_heights.get(&key)?;
             Some((*time, *height))
         })()
-        .ok_or_else(|| ClientError::ProcessedTimeNotFound {
+        .ok_or(ClientError::ProcessedTimeNotFound {
             client_id: key.0,
             height,
         })

--- a/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
+++ b/ibc-testkit/src/testapp/ibc/core/client_ctx.rs
@@ -270,9 +270,9 @@ impl ClientExecutionContext for MockContext {
         &mut self,
         client_id: &ClientId,
         height: Height,
-        host_timestamp: Timestamp,
-        host_height: Height,
     ) -> Result<(), ContextError> {
+        let host_timestamp = ValidationContext::host_timestamp(self)?;
+        let host_height = ValidationContext::host_height(self)?;
         let mut ibc_store = self.ibc_store.lock();
         ibc_store
             .client_processed_times

--- a/ibc-testkit/tests/core/ics02_client/update_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/update_client.rs
@@ -141,10 +141,7 @@ fn test_consensus_state_pruning() {
         expired_height.revision_number(),
         expired_height.revision_height(),
     );
-    assert!(ctx
-        .client_update_height(&client_id, &expired_height)
-        .is_err());
-    assert!(ctx.client_update_time(&client_id, &expired_height).is_err());
+    assert!(ctx.client_update_meta(&client_id, expired_height).is_err());
     assert!(ctx.consensus_state(&client_cons_state_path).is_err());
 
     // Check that latest valid consensus state exists.
@@ -156,13 +153,8 @@ fn test_consensus_state_pruning() {
     );
 
     assert!(ctx
-        .client_update_height(&client_id, &earliest_valid_height)
+        .client_update_meta(&client_id, earliest_valid_height)
         .is_ok());
-
-    assert!(ctx
-        .client_update_time(&client_id, &earliest_valid_height)
-        .is_ok());
-
     assert!(ctx.consensus_state(&client_cons_state_path).is_ok());
 
     let end_host_timestamp = ctx.host_timestamp().unwrap();

--- a/ibc-testkit/tests/core/ics04_channel/acknowledgement.rs
+++ b/ibc-testkit/tests/core/ics04_channel/acknowledgement.rs
@@ -162,16 +162,10 @@ fn ack_success_happy_path(fixture: Fixture) {
             packet_commitment,
         );
     ctx.get_client_execution_context()
-        .store_update_time(
-            ClientId::default(),
+        .store_update_meta(
+            &ClientId::default(),
             client_height,
             Timestamp::from_nanoseconds(1000).unwrap(),
-        )
-        .unwrap();
-    ctx.get_client_execution_context()
-        .store_update_height(
-            ClientId::default(),
-            client_height,
             Height::new(0, 4).unwrap(),
         )
         .unwrap();

--- a/ibc-testkit/tests/core/ics04_channel/acknowledgement.rs
+++ b/ibc-testkit/tests/core/ics04_channel/acknowledgement.rs
@@ -162,12 +162,7 @@ fn ack_success_happy_path(fixture: Fixture) {
             packet_commitment,
         );
     ctx.get_client_execution_context()
-        .store_update_meta(
-            &ClientId::default(),
-            client_height,
-            Timestamp::from_nanoseconds(1000).unwrap(),
-            Height::new(0, 4).unwrap(),
-        )
+        .store_update_meta(&ClientId::default(), client_height)
         .unwrap();
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));

--- a/ibc-testkit/tests/core/ics04_channel/recv_packet.rs
+++ b/ibc-testkit/tests/core/ics04_channel/recv_packet.rs
@@ -136,12 +136,7 @@ fn recv_packet_validate_happy_path(fixture: Fixture) {
 
     context
         .get_client_execution_context()
-        .store_update_meta(
-            &ClientId::default(),
-            client_height,
-            Timestamp::from_nanoseconds(1000).unwrap(),
-            Height::new(0, 5).unwrap(),
-        )
+        .store_update_meta(&ClientId::default(), client_height)
         .unwrap();
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));

--- a/ibc-testkit/tests/core/ics04_channel/recv_packet.rs
+++ b/ibc-testkit/tests/core/ics04_channel/recv_packet.rs
@@ -136,17 +136,10 @@ fn recv_packet_validate_happy_path(fixture: Fixture) {
 
     context
         .get_client_execution_context()
-        .store_update_time(
-            ClientId::default(),
+        .store_update_meta(
+            &ClientId::default(),
             client_height,
             Timestamp::from_nanoseconds(1000).unwrap(),
-        )
-        .unwrap();
-    context
-        .get_client_execution_context()
-        .store_update_height(
-            ClientId::default(),
-            client_height,
             Height::new(0, 5).unwrap(),
         )
         .unwrap();

--- a/ibc-testkit/tests/core/ics04_channel/timeout.rs
+++ b/ibc-testkit/tests/core/ics04_channel/timeout.rs
@@ -191,15 +191,10 @@ fn timeout_fail_proof_timeout_not_reached(fixture: Fixture) {
             packet_commitment,
         );
 
-    ctx.store_update_time(
-        ClientId::default(),
+    ctx.store_update_meta(
+        &ClientId::default(),
         client_height,
         Timestamp::from_nanoseconds(5).unwrap(),
-    )
-    .unwrap();
-    ctx.store_update_height(
-        ClientId::default(),
-        client_height,
         Height::new(0, 4).unwrap(),
     )
     .unwrap();
@@ -274,16 +269,10 @@ fn timeout_unordered_channel_validate(fixture: Fixture) {
         );
 
     ctx.get_client_execution_context()
-        .store_update_time(
-            ClientId::default(),
+        .store_update_meta(
+            &ClientId::default(),
             client_height,
             Timestamp::from_nanoseconds(1000).unwrap(),
-        )
-        .unwrap();
-    ctx.get_client_execution_context()
-        .store_update_height(
-            ClientId::default(),
-            client_height,
             Height::new(0, 5).unwrap(),
         )
         .unwrap();
@@ -325,15 +314,10 @@ fn timeout_ordered_channel_validate(fixture: Fixture) {
             packet_commitment,
         );
 
-    ctx.store_update_time(
-        ClientId::default(),
+    ctx.store_update_meta(
+        &ClientId::default(),
         client_height,
         Timestamp::from_nanoseconds(1000).unwrap(),
-    )
-    .unwrap();
-    ctx.store_update_height(
-        ClientId::default(),
-        client_height,
         Height::new(0, 4).unwrap(),
     )
     .unwrap();

--- a/ibc-testkit/tests/core/ics04_channel/timeout.rs
+++ b/ibc-testkit/tests/core/ics04_channel/timeout.rs
@@ -191,13 +191,8 @@ fn timeout_fail_proof_timeout_not_reached(fixture: Fixture) {
             packet_commitment,
         );
 
-    ctx.store_update_meta(
-        &ClientId::default(),
-        client_height,
-        Timestamp::from_nanoseconds(5).unwrap(),
-        Height::new(0, 4).unwrap(),
-    )
-    .unwrap();
+    ctx.store_update_meta(&ClientId::default(), client_height)
+        .unwrap();
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));
 
@@ -269,12 +264,7 @@ fn timeout_unordered_channel_validate(fixture: Fixture) {
         );
 
     ctx.get_client_execution_context()
-        .store_update_meta(
-            &ClientId::default(),
-            client_height,
-            Timestamp::from_nanoseconds(1000).unwrap(),
-            Height::new(0, 5).unwrap(),
-        )
+        .store_update_meta(&ClientId::default(), client_height)
         .unwrap();
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));
@@ -314,13 +304,8 @@ fn timeout_ordered_channel_validate(fixture: Fixture) {
             packet_commitment,
         );
 
-    ctx.store_update_meta(
-        &ClientId::default(),
-        client_height,
-        Timestamp::from_nanoseconds(1000).unwrap(),
-        Height::new(0, 4).unwrap(),
-    )
-    .unwrap();
+    ctx.store_update_meta(&ClientId::default(), client_height)
+        .unwrap();
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));
 

--- a/ibc-testkit/tests/core/ics04_channel/timeout_on_close.rs
+++ b/ibc-testkit/tests/core/ics04_channel/timeout_on_close.rs
@@ -147,12 +147,7 @@ fn timeout_on_close_success_happy_path(fixture: Fixture) {
 
     context
         .get_client_execution_context()
-        .store_update_meta(
-            &ClientId::default(),
-            Height::new(0, 2).unwrap(),
-            Timestamp::from_nanoseconds(5000).unwrap(),
-            Height::new(0, 5).unwrap(),
-        )
+        .store_update_meta(&ClientId::default(), Height::new(0, 2).unwrap())
         .unwrap();
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));

--- a/ibc-testkit/tests/core/ics04_channel/timeout_on_close.rs
+++ b/ibc-testkit/tests/core/ics04_channel/timeout_on_close.rs
@@ -147,17 +147,10 @@ fn timeout_on_close_success_happy_path(fixture: Fixture) {
 
     context
         .get_client_execution_context()
-        .store_update_time(
-            ClientId::default(),
+        .store_update_meta(
+            &ClientId::default(),
             Height::new(0, 2).unwrap(),
             Timestamp::from_nanoseconds(5000).unwrap(),
-        )
-        .unwrap();
-    context
-        .get_client_execution_context()
-        .store_update_height(
-            ClientId::default(),
-            Height::new(0, 2).unwrap(),
             Height::new(0, 5).unwrap(),
         )
         .unwrap();


### PR DESCRIPTION
Observe that update time and height are *always* read and manipulated
together.  Replace pairs of methods for reading, updating and deleting
time and height with a single combined method for each operation.

Specifically, replace:
a) client_update_{time,height} by client_update_meta,
b) store_update_{time,height} by store_update_meta and
c) delete_update_{time,height} by delete_update_meta.

This allows better optimised implementations which, for example, keep
both pieces of information in a single map and perform a single lookup
to read or update them.

Furthermore, since the host timestamp and height come from the
implementation, remove those arguments from the store_update_meta
method with the implementation fetching the information by itself.

Closes: https://github.com/cosmos/ibc-rs/issues/973

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
