### PR TITLE
feat: add `coin` argument to `get_escrow_account` method

### DIFF
--- a/.changelog/unreleased/breaking-change/985-escrow-account.md
+++ b/.changelog/unreleased/breaking-change/985-escrow-account.md
@@ -1,0 +1,3 @@
+- Added `coin` argument to `get_escrow_account` method to support chains
+  where escrow account depends on the coin.
+  ([#985](https://github.com/cosmos/ibc-rs/issues/985))

--- a/ibc-apps/ics20-transfer/src/context.rs
+++ b/ibc-apps/ics20-transfer/src/context.rs
@@ -18,6 +18,7 @@ pub trait TokenTransferValidationContext {
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
+        coin: &PrefixedCoin,
     ) -> Result<Self::AccountId, TokenTransferError>;
 
     /// Returns Ok() if the host chain supports sending coins.

--- a/ibc-apps/ics20-transfer/src/handler/mod.rs
+++ b/ibc-apps/ics20-transfer/src/handler/mod.rs
@@ -29,7 +29,7 @@ pub fn refund_packet_token_execute(
     ) {
         // unescrow tokens back to sender
         let escrow_address =
-            ctx_a.get_escrow_account(&packet.port_id_on_a, &packet.chan_id_on_a)?;
+            ctx_a.get_escrow_account(&packet.port_id_on_a, &packet.chan_id_on_a, &data.token)?;
 
         ctx_a.send_coins_execute(&escrow_address, &sender, &data.token)
     }
@@ -56,7 +56,7 @@ pub fn refund_packet_token_validate(
         &data.token.denom,
     ) {
         let escrow_address =
-            ctx_a.get_escrow_account(&packet.port_id_on_a, &packet.chan_id_on_a)?;
+            ctx_a.get_escrow_account(&packet.port_id_on_a, &packet.chan_id_on_a, &data.token)?;
 
         ctx_a.send_coins_validate(&escrow_address, &sender, &data.token)
     } else {

--- a/ibc-apps/ics20-transfer/src/handler/on_recv_packet.rs
+++ b/ibc-apps/ics20-transfer/src/handler/on_recv_packet.rs
@@ -44,7 +44,7 @@ pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
         };
 
         let escrow_address = ctx_b
-            .get_escrow_account(&packet.port_id_on_b, &packet.chan_id_on_b)
+            .get_escrow_account(&packet.port_id_on_b, &packet.chan_id_on_b, &coin)
             .map_err(|token_err| (ModuleExtras::empty(), token_err))?;
 
         // Note: it is correct to do the validation here because `recv_packet()`

--- a/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
+++ b/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
@@ -69,7 +69,7 @@ where
         &token.denom,
     ) {
         let escrow_address =
-            token_ctx_a.get_escrow_account(&msg.port_id_on_a, &msg.chan_id_on_a)?;
+            token_ctx_a.get_escrow_account(&msg.port_id_on_a, &msg.chan_id_on_a, token)?;
         token_ctx_a.send_coins_validate(&sender, &escrow_address, token)?;
     } else {
         token_ctx_a.burn_coins_validate(&sender, token)?;
@@ -138,7 +138,7 @@ where
         &token.denom,
     ) {
         let escrow_address =
-            token_ctx_a.get_escrow_account(&msg.port_id_on_a, &msg.chan_id_on_a)?;
+            token_ctx_a.get_escrow_account(&msg.port_id_on_a, &msg.chan_id_on_a, token)?;
         token_ctx_a.send_coins_execute(&sender, &escrow_address, token)?;
     } else {
         token_ctx_a.burn_coins_execute(&sender, token)?;

--- a/ibc-testkit/src/testapp/ibc/applications/transfer/context.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/transfer/context.rs
@@ -19,6 +19,7 @@ impl TokenTransferValidationContext for DummyTransferModule {
         &self,
         port_id: &PortId,
         channel_id: &ChannelId,
+        _coin: &PrefixedCoin,
     ) -> Result<Self::AccountId, TokenTransferError> {
         let addr = cosmos_adr028_escrow_address(port_id, channel_id);
         Ok(bech32::encode("cosmos", addr).into())


### PR DESCRIPTION
To support blockchains and other systems where escrow account depends
on the coin being transferred (in addition to port and channel), add
`coin` argument to `get_escrow_account`.

Closes: https://github.com/cosmos/ibc-rs/issues/985

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
