### PR TITLE
chore: fix dependency resolution because of `dep:` syntax in `serde` feature

### DIFF
--- a/.changelog/unreleased/bug-fixes/987-serde-json-feature.md
+++ b/.changelog/unreleased/bug-fixes/987-serde-json-feature.md
@@ -1,0 +1,2 @@
+- Fix dependency resolution whan building no_std
+  ([#987](https://github.com/cosmos/ibc-rs/issues/987))

--- a/.changelog/unreleased/bug-fixes/987-serde-json-feature.md
+++ b/.changelog/unreleased/bug-fixes/987-serde-json-feature.md
@@ -1,2 +1,3 @@
-- Fix dependency resolution whan building no_std
+- Fix dependency resolution by removing the `dep:` syntax in `serde` feature of
+  `ibc-app-transfer` crate.
   ([#987](https://github.com/cosmos/ibc-rs/issues/987))

--- a/ibc-apps/ics20-transfer/Cargo.toml
+++ b/ibc-apps/ics20-transfer/Cargo.toml
@@ -33,12 +33,12 @@ default = ["std"]
 std = [
     "ibc-app-transfer-types/std",
     "ibc-core/std",
-    "serde_json?/std",
+    "serde_json/std",
 ]
 serde = [
     "ibc-app-transfer-types/serde",
     "ibc-core/serde",
-    "dep:serde_json"
+    "serde_json"
 ]
 schema = [
     "ibc-app-transfer-types/schema",

--- a/ibc-apps/ics20-transfer/Cargo.toml
+++ b/ibc-apps/ics20-transfer/Cargo.toml
@@ -33,7 +33,7 @@ default = ["std"]
 std = [
     "ibc-app-transfer-types/std",
     "ibc-core/std",
-    "serde_json/std",
+    "serde_json?/std",
 ]
 serde = [
     "ibc-app-transfer-types/serde",


### PR DESCRIPTION
I’m not entirely sure if it’s no_std specifically that causes the
issue, but if ibc-apps-transfer is build without std feature but with
serde feature it enables serde_json/std feature while serde_json
dependency isn’t enabled.  This seems to confuse Cargo which thinks
serde_json is supposed to be a feature.  This all leads to a failure
in dependency resolution:

    error: failed to select a version for `ibc-app-transfer`.
        ... required by package `ibc-apps v0.48.0`
        ... which satisfies dependency `ibc-apps = "^0.48.0"` (locked to 0.48.0) of package `ibc v0.48.0`
        ... which satisfies dependency `ibc = "^0.48.0"` (locked to 0.48.0) of package `ibc-testkit v0.48.0`
        ... which satisfies dependency `ibc-testkit = "^0.48.0"` (locked to 0.48.0) of package …
    versions that meet the requirements `^0.48.0` (locked to 0.48.0) are: 0.48.0

    the package `ibc-apps` depends on `ibc-app-transfer`, with features: `serde_json` but `ibc-app-transfer` does not have these features.
     It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.

Closes: https://github.com/cosmos/ibc-rs/issues/987

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
