### PR TITLE
fix: packet sequence in Timeout handlers should be encoded in big-endian

### DIFF
--- a/.changelog/unreleased/bug-fixes/1004-fix-packet-sequence-encoding.md
+++ b/.changelog/unreleased/bug-fixes/1004-fix-packet-sequence-encoding.md
@@ -1,0 +1,2 @@
+- Encode packet sequence into a big endian bytes.
+  ([\#1004](https://github.com/cosmos/ibc-rs/pull/1004))

--- a/ibc-core/ics04-channel/src/handler/timeout.rs
+++ b/ibc-core/ics04-channel/src/handler/timeout.rs
@@ -229,14 +229,13 @@ where
             }
             let seq_recv_path_on_b =
                 SeqRecvPath::new(&msg.packet.port_id_on_b, &msg.packet.chan_id_on_b);
-            let value = u64::from(msg.packet.seq_on_a).to_be_bytes().to_vec();
 
             client_state_of_b_on_a.verify_membership(
                 conn_end_on_a.counterparty().prefix(),
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
                 Path::SeqRecv(seq_recv_path_on_b),
-                value,
+                msg.packet.seq_on_a.to_vec(),
             )
         } else {
             let receipt_path_on_b = ReceiptPath::new(

--- a/ibc-core/ics04-channel/src/handler/timeout.rs
+++ b/ibc-core/ics04-channel/src/handler/timeout.rs
@@ -229,13 +229,14 @@ where
             }
             let seq_recv_path_on_b =
                 SeqRecvPath::new(&msg.packet.port_id_on_b, &msg.packet.chan_id_on_b);
+            let value = u64::from(msg.packet.seq_on_a).to_be_bytes().to_vec();
 
             client_state_of_b_on_a.verify_membership(
                 conn_end_on_a.counterparty().prefix(),
                 &msg.proof_unreceived_on_b,
                 consensus_state_of_b_on_a.root(),
                 Path::SeqRecv(seq_recv_path_on_b),
-                msg.packet.seq_on_a.to_vec(),
+                value,
             )
         } else {
             let receipt_path_on_b = ReceiptPath::new(

--- a/ibc-core/ics24-host/types/src/identifiers/sequence.rs
+++ b/ibc-core/ics24-host/types/src/identifiers/sequence.rs
@@ -1,5 +1,4 @@
 use ibc_primitives::prelude::*;
-use ibc_primitives::ToVec;
 
 use crate::error::IdentifierError;
 
@@ -50,10 +49,9 @@ impl Sequence {
         Sequence(self.0 + 1)
     }
 
-    /// Encodes the sequence number into a `Vec<u8>` using
-    /// `prost::Message::encode_to_vec`.
+    /// Encodes the sequence number into a byte array in big endian.
     pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
+        self.0.to_be_bytes().to_vec()
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

refer to: 
[// Note: We expect the return to be a u64 encoded in big-endian. Refer to ibc-go:
        // https://github.com/cosmos/ibc-go/blob/25767f6bdb5bab2c2a116b41d92d753c93e18121/modules/core/04-channel/client/utils/utils.go#L191](https://github.com/informalsystems/hermes/blob/c945791f0fca43acf58648a78635ae21e774e483/crates/relayer/src/chain/cosmos.rs#L1989-L1990)

The `seq_on_a` of MsgTimeout packet should be encoded as a big-endian bytes.
Here's a code snippet to show this problem.
https://gist.github.com/en/e4f6befdef94b1e906ed0054709ccd4b

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
