### PR TITLE
feat: derive AsRef for CommitmentProofBytes

### DIFF
--- a/.changelog/unreleased/features/1008-commitment-proof-bytes-as-ref.md
+++ b/.changelog/unreleased/features/1008-commitment-proof-bytes-as-ref.md
@@ -1,0 +1,4 @@
+- `[ibc-core-commitment-types`] implement `AsRef<Vec<u8>>` and
+  `AsRef<[u8]>` for `CommitmentProofBytes` so it’s possible to gain
+  access to the proof byte slice without having to own the object.
+  ([#1008](https://github.com/cosmos/ibc-rs/pull/1008))

--- a/ibc-clients/ics07-tendermint/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state.rs
@@ -199,7 +199,7 @@ impl ClientStateCommon for ClientState {
     ) -> Result<(), ClientError> {
         let merkle_path = apply_prefix(prefix, vec![path.to_string()]);
         let merkle_proof =
-            MerkleProof::try_from(proof.clone()).map_err(ClientError::InvalidCommitmentProof)?;
+            MerkleProof::try_from(proof).map_err(ClientError::InvalidCommitmentProof)?;
 
         merkle_proof
             .verify_membership(
@@ -221,7 +221,7 @@ impl ClientStateCommon for ClientState {
     ) -> Result<(), ClientError> {
         let merkle_path = apply_prefix(prefix, vec![path.to_string()]);
         let merkle_proof =
-            MerkleProof::try_from(proof.clone()).map_err(ClientError::InvalidCommitmentProof)?;
+            MerkleProof::try_from(proof).map_err(ClientError::InvalidCommitmentProof)?;
 
         merkle_proof
             .verify_non_membership(&self.0.proof_specs, root.clone().into(), merkle_path)

--- a/ibc-core/ics23-commitment/types/Cargo.toml
+++ b/ibc-core/ics23-commitment/types/Cargo.toml
@@ -10,7 +10,7 @@ keywords     = ["blockchain", "cosmos", "ibc", "commitment", "types"]
 readme       = "./../../README.md"
 description  = """
     Maintained by `ibc-rs`, encapsulates essential ICS-23 Vector Commitments data structures and domain types,
-    as specified in the Inter-Blockchain Communication (IBC) protocol. Designed for universal applicability 
+    as specified in the Inter-Blockchain Communication (IBC) protocol. Designed for universal applicability
     to facilitate development and integration across diverse IBC-enabled projects.
 """
 
@@ -20,7 +20,7 @@ all-features = true
 [dependencies]
 # external dependencies
 borsh           = { workspace = true, optional = true }
-derive_more     = { workspace = true }
+derive_more     = { workspace = true, features = ["as_ref"] }
 displaydoc      = { workspace = true }
 schemars        = { workspace = true, optional = true }
 serde           = { workspace = true, optional = true }
@@ -69,4 +69,3 @@ parity-scale-codec = [
     "ibc-primitives/parity-scale-codec",
     "ibc-proto/parity-scale-codec",
 ]
-

--- a/ibc-core/ics23-commitment/types/src/commitment.rs
+++ b/ibc-core/ics23-commitment/types/src/commitment.rs
@@ -130,7 +130,7 @@ impl<'a> TryFrom<&'a CommitmentProofBytes> for MerkleProof {
     type Error = CommitmentError;
 
     fn try_from(value: &'a CommitmentProofBytes) -> Result<Self, Self::Error> {
-        Protobuf::<RawMerkleProof>::decode(value.bytes.as_slice())
+        Protobuf::<RawMerkleProof>::decode(value.as_ref())
             .map_err(|e| CommitmentError::DecodingFailure(e.to_string()))
     }
 }

--- a/ibc-core/ics23-commitment/types/src/commitment.rs
+++ b/ibc-core/ics23-commitment/types/src/commitment.rs
@@ -118,14 +118,6 @@ impl TryFrom<MerkleProof> for CommitmentProofBytes {
     }
 }
 
-impl TryFrom<CommitmentProofBytes> for MerkleProof {
-    type Error = CommitmentError;
-
-    fn try_from(value: CommitmentProofBytes) -> Result<Self, Self::Error> {
-        Self::try_from(&value)
-    }
-}
-
 impl<'a> TryFrom<&'a CommitmentProofBytes> for MerkleProof {
     type Error = CommitmentError;
 


### PR DESCRIPTION
Derive AsRef for CommitmentProofBytes so it’s possible to access its
underlying bytes without having to own it.

The type can be converted into Vec but that requires ownership.  If
all one has is a reference to the proof bytes (as in verify_membership
method for example), there’s no way to access underlying bytes without
cloning it first.

With derive_more::AsRef added, one can now use as_ref method to borrow
the underlying bytes slice.

While at it.  Replace explicit From implementation by derive_more::Into
and get rid of unnecessary clone inside of conversion into MerkleProof.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
