### PR TITLE
imp: use global paths in generated code by `ibc-derive`

### DIFF
--- a/.changelog/unreleased/improvements/1017-use-global-paths-in-generated-code.md
+++ b/.changelog/unreleased/improvements/1017-use-global-paths-in-generated-code.md
@@ -1,0 +1,3 @@
+- `[ibc-derive]` Use global paths in generated code by macros to prevent
+  namespace conflicts with local modules
+  ([#1017](https://github.com/cosmos/ibc-rs/pull/1017))

--- a/ibc-derive/src/utils.rs
+++ b/ibc-derive/src/utils.rs
@@ -10,67 +10,67 @@ pub struct Imports;
 
 impl Imports {
     pub fn CommitmentRoot() -> TokenStream {
-        quote! {ibc::core::commitment_types::commitment::CommitmentRoot}
+        quote! {::ibc::core::commitment_types::commitment::CommitmentRoot}
     }
 
     pub fn CommitmentPrefix() -> TokenStream {
-        quote! {ibc::core::commitment_types::commitment::CommitmentPrefix}
+        quote! {::ibc::core::commitment_types::commitment::CommitmentPrefix}
     }
 
     pub fn CommitmentProofBytes() -> TokenStream {
-        quote! {ibc::core::commitment_types::commitment::CommitmentProofBytes}
+        quote! {::ibc::core::commitment_types::commitment::CommitmentProofBytes}
     }
 
     pub fn Path() -> TokenStream {
-        quote! {ibc::core::host::types::path::Path}
+        quote! {::ibc::core::host::types::path::Path}
     }
 
     pub fn ConsensusState() -> TokenStream {
-        quote! {ibc::core::client::context::consensus_state::ConsensusState}
+        quote! {::ibc::core::client::context::consensus_state::ConsensusState}
     }
 
     pub fn ClientStateCommon() -> TokenStream {
-        quote! {ibc::core::client::context::client_state::ClientStateCommon}
+        quote! {::ibc::core::client::context::client_state::ClientStateCommon}
     }
 
     pub fn ClientStateValidation() -> TokenStream {
-        quote! {ibc::core::client::context::client_state::ClientStateValidation}
+        quote! {::ibc::core::client::context::client_state::ClientStateValidation}
     }
 
     pub fn ClientStateExecution() -> TokenStream {
-        quote! {ibc::core::client::context::client_state::ClientStateExecution}
+        quote! {::ibc::core::client::context::client_state::ClientStateExecution}
     }
 
     pub fn ClientId() -> TokenStream {
-        quote! {ibc::core::host::types::identifiers::ClientId}
+        quote! {::ibc::core::host::types::identifiers::ClientId}
     }
 
     pub fn ClientType() -> TokenStream {
-        quote! {ibc::core::host::types::identifiers::ClientType}
+        quote! {::ibc::core::host::types::identifiers::ClientType}
     }
 
     pub fn ClientError() -> TokenStream {
-        quote! {ibc::core::client::types::error::ClientError}
+        quote! {::ibc::core::client::types::error::ClientError}
     }
 
     pub fn Height() -> TokenStream {
-        quote! {ibc::core::client::types::Height}
+        quote! {::ibc::core::client::types::Height}
     }
 
     pub fn Any() -> TokenStream {
-        quote! {ibc::primitives::proto::Any}
+        quote! {::ibc::primitives::proto::Any}
     }
 
     pub fn Timestamp() -> TokenStream {
-        quote! {ibc::core::primitives::Timestamp}
+        quote! {::ibc::core::primitives::Timestamp}
     }
 
     pub fn UpdateKind() -> TokenStream {
-        quote! {ibc::core::client::types::UpdateKind}
+        quote! {::ibc::core::client::types::UpdateKind}
     }
 
     pub fn Status() -> TokenStream {
-        quote! {ibc::core::client::types::Status}
+        quote! {::ibc::core::client::types::Status}
     }
 }
 


### PR DESCRIPTION
Because the generated code uses paths which start with `ibc::`, they
are first resolved from the local module’s namespace.  That is, if an
`ibc` module is defined, the derives create code which does not
compile.  This is demonstrated by the following fragment:

    use ::ibc::core::client::context::consensus_state::ConsensusState;
    use ::ibc::core::commitment_types::commitment::CommitmentRoot;

    mod ibc {}

    #[derive(ConsensusState)]
    enum AnyConsensusState { Foo(Foo) }

    struct Foo;

    impl ConsensusState for Foo {
        fn root(&self) -> &CommitmentRoot { todo!() }
        fn timestamp(&self) -> ::ibc::primitives::Timestamp { todo!() }
        fn encode_vec(self) -> Vec<u8> { todo!() }
    }

The compilation fails with ‘failed to resolve: could not find `core`
in `ibc`’ errors.

To solve this, use global paths (i.e. ones starting with
`::ibc::`). Starting from 2018 Rust edition such paths resolve from
the extern prelude and thus `::ibc` points at the `ibc` crate.

Note however that in 2015 edition global paths are anchored at the
crate root so `::ibc` will attempt to look for `crate::ibc`
module. This means that this change is breaking for code using ancient
Rust editions.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
