### PR TITLE
strip trace prefix in send transfer for coin

### DIFF
--- a/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
+++ b/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
@@ -1,7 +1,7 @@
 use ibc_app_transfer_types::error::TokenTransferError;
 use ibc_app_transfer_types::events::TransferEvent;
 use ibc_app_transfer_types::msgs::transfer::MsgTransfer;
-use ibc_app_transfer_types::{is_sender_chain_source, MODULE_ID_STR, TracePrefix};
+use ibc_app_transfer_types::{is_sender_chain_source, TracePrefix, MODULE_ID_STR};
 use ibc_core::channel::context::{SendPacketExecutionContext, SendPacketValidationContext};
 use ibc_core::channel::handler::{send_packet_execute, send_packet_validate};
 use ibc_core::channel::types::packet::Packet;

--- a/ibc-testkit/tests/core/ics02_client/create_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/create_client.rs
@@ -68,7 +68,7 @@ fn test_tm_create_client_ok() {
 
     let msg = MsgCreateClient::new(
         tm_client_state,
-        TmConsensusState::try_from(tm_header).unwrap().into(),
+        TmConsensusState::from(tm_header).into(),
         signer,
     );
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1022 

## Description

Stripping trace prefix in `send_transfer` similar to the one we have below.
https://github.com/cosmos/ibc-rs/blob/d96cc6632e53cbab1a4bb6f636a86427772806d8/ibc-apps/ics20-transfer/src/handler/on_recv_packet.rs#L40-L44


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
