### PR TITLE
Fix ClassData and TokenData encoding in NonFungiblePacketData

### DIFF
--- a/ibc-apps/ics721-nft-transfer/types/Cargo.toml
+++ b/ibc-apps/ics721-nft-transfer/types/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 [dependencies]
 # external dependencies
 borsh           = { workspace = true, optional = true }
-base64          = "0.21.6"
+base64          = { version = "0.21.6", default-features = false }
 derive_more     = { workspace = true }
 displaydoc      = { workspace = true }
 http            = "1.0.0"
@@ -45,6 +45,7 @@ default = ["std"]
 std = [
     "serde/std",
     "serde_json/std",
+    "base64/std",
     "displaydoc/std",
     "http/std",
     "ibc-core/std",

--- a/ibc-apps/ics721-nft-transfer/types/Cargo.toml
+++ b/ibc-apps/ics721-nft-transfer/types/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 [dependencies]
 # external dependencies
 borsh           = { workspace = true, optional = true }
+base64          = "0.21.6"
 derive_more     = { workspace = true }
 displaydoc      = { workspace = true }
 http            = "1.0.0"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
[ICS-721 spec](https://github.com/cosmos/ibc/tree/main/spec/app/ics-721-nft-transfer#data-structures) says
> Both tokenData entries and classData MUST be Base64 encoded strings which SHOULD have the following JSON structure:

These data should be encoded/decoded when converting to/from proto `PacketData`.


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
