### PR TITLE
imp(ibc-testkit): deprecate `MockContext` multiple init methods

### DIFF
--- a/.changelog/unreleased/improvements/1042-deprecate-mockcontext-new-methods.md
+++ b/.changelog/unreleased/improvements/1042-deprecate-mockcontext-new-methods.md
@@ -1,0 +1,2 @@
+- [ibc-testkit] Deprecate `MockContext::new*` in favor of `MockContextConfig`.
+  ([\#1042](https://github.com/cosmos/ibc-rs/issues/1042))

--- a/ibc-testkit/src/fixtures/core/context.rs
+++ b/ibc-testkit/src/fixtures/core/context.rs
@@ -21,6 +21,7 @@ pub struct MockContextConfig {
     #[builder(default = HostType::Mock)]
     host_type: HostType,
 
+    #[builder(default = ChainId::new("mockgaia-0").expect("Never fails"))]
     host_id: ChainId,
 
     #[builder(default = Duration::from_secs(DEFAULT_BLOCK_TIME_SECS))]
@@ -33,6 +34,7 @@ pub struct MockContextConfig {
     #[builder(default, setter(strip_option))]
     validator_set_history: Option<Vec<Vec<TestgenValidator>>>,
 
+    #[builder(default = Height::new(0, 5).expect("Never fails"))]
     latest_height: Height,
 
     #[builder(default = Timestamp::now())]

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -52,12 +52,12 @@ mod tests {
     use tracing::debug;
 
     use super::RelayerContext;
+    use crate::fixtures::core::context::MockContextConfig;
     use crate::hosts::block::{HostBlock, HostType};
     use crate::relayer::context::ClientId;
     use crate::relayer::error::RelayerError;
     use crate::testapp::ibc::clients::mock::client_state::client_type as mock_client_type;
     use crate::testapp::ibc::core::router::MockRouter;
-    use crate::testapp::ibc::core::types::MockContext;
 
     /// Builds a `ClientMsg::UpdateClient` for a client with id `client_id` running on the `dest`
     /// context, assuming that the latest header on the source context is `src_header`.
@@ -121,31 +121,35 @@ mod tests {
         let chain_id_b = ChainId::new("mockgaiaB-1").unwrap();
 
         // Create two mock contexts, one for each chain.
-        let mut ctx_a =
-            MockContext::new(chain_id_a.clone(), HostType::Mock, 5, chain_a_start_height)
-                .with_client_parametrized_with_chain_id(
-                    chain_id_b.clone(),
-                    &client_on_a_for_b,
-                    client_on_a_for_b_height,
-                    Some(tm_client_type()), // The target host chain (B) is synthetic TM.
-                    Some(client_on_a_for_b_height),
-                );
+        let mut ctx_a = MockContextConfig::builder()
+            .host_id(chain_id_a.clone())
+            .host_type(HostType::Mock)
+            .max_history_size(5)
+            .latest_height(chain_a_start_height)
+            .build()
+            .with_client_parametrized_with_chain_id(
+                chain_id_b.clone(),
+                &client_on_a_for_b,
+                client_on_a_for_b_height,
+                Some(tm_client_type()), // The target host chain (B) is synthetic TM.
+                Some(client_on_a_for_b_height),
+            );
         // dummy; not actually used in client updates
         let mut router_a = MockRouter::new_with_transfer();
 
-        let mut ctx_b = MockContext::new(
-            chain_id_b,
-            HostType::SyntheticTendermint,
-            5,
-            chain_b_start_height,
-        )
-        .with_client_parametrized_with_chain_id(
-            chain_id_a,
-            &client_on_b_for_a,
-            client_on_b_for_a_height,
-            Some(mock_client_type()), // The target host chain is mock.
-            Some(client_on_b_for_a_height),
-        );
+        let mut ctx_b = MockContextConfig::builder()
+            .host_id(chain_id_b)
+            .host_type(HostType::SyntheticTendermint)
+            .max_history_size(5)
+            .latest_height(chain_b_start_height)
+            .build()
+            .with_client_parametrized_with_chain_id(
+                chain_id_a,
+                &client_on_b_for_a,
+                client_on_b_for_a_height,
+                Some(mock_client_type()), // The target host chain is mock.
+                Some(client_on_b_for_a_height),
+            );
         // dummy; not actually used in client updates
         let mut router_b = MockRouter::new_with_transfer();
 

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -123,8 +123,6 @@ mod tests {
         // Create two mock contexts, one for each chain.
         let mut ctx_a = MockContextConfig::builder()
             .host_id(chain_id_a.clone())
-            .host_type(HostType::Mock)
-            .max_history_size(5)
             .latest_height(chain_a_start_height)
             .build()
             .with_client_parametrized_with_chain_id(
@@ -140,7 +138,6 @@ mod tests {
         let mut ctx_b = MockContextConfig::builder()
             .host_id(chain_id_b)
             .host_type(HostType::SyntheticTendermint)
-            .max_history_size(5)
             .latest_height(chain_b_start_height)
             .build()
             .with_client_parametrized_with_chain_id(

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -148,12 +148,7 @@ pub struct MockClientConfig {
 /// creation of new domain objects.
 impl Default for MockContext {
     fn default() -> Self {
-        MockContextConfig::builder()
-            .host_id(ChainId::new("mockgaia-0").expect("Never fails"))
-            .host_type(HostType::Mock)
-            .max_history_size(5)
-            .latest_height(Height::new(0, 5).expect("Never fails"))
-            .build()
+        MockContextConfig::builder().build()
     }
 }
 
@@ -827,7 +822,6 @@ mod tests {
                 name: "Empty history, small pruning window".to_string(),
                 ctx: MockContextConfig::builder()
                     .host_id(mock_chain_id.clone())
-                    .host_type(HostType::Mock)
                     .max_history_size(2)
                     .latest_height(Height::new(cv, 1).expect("Never fails"))
                     .build(),
@@ -845,7 +839,6 @@ mod tests {
                 name: "Large pruning window".to_string(),
                 ctx: MockContextConfig::builder()
                     .host_id(mock_chain_id.clone())
-                    .host_type(HostType::Mock)
                     .max_history_size(30)
                     .latest_height(Height::new(cv, 2).expect("Never fails"))
                     .build(),
@@ -863,7 +856,6 @@ mod tests {
                 name: "Small pruning window".to_string(),
                 ctx: MockContextConfig::builder()
                     .host_id(mock_chain_id.clone())
-                    .host_type(HostType::Mock)
                     .max_history_size(3)
                     .latest_height(Height::new(cv, 30).expect("Never fails"))
                     .build(),
@@ -881,7 +873,6 @@ mod tests {
                 name: "Small pruning window, small starting height".to_string(),
                 ctx: MockContextConfig::builder()
                     .host_id(mock_chain_id.clone())
-                    .host_type(HostType::Mock)
                     .max_history_size(3)
                     .latest_height(Height::new(cv, 2).expect("Never fails"))
                     .build(),
@@ -899,7 +890,6 @@ mod tests {
                 name: "Large pruning window, large starting height".to_string(),
                 ctx: MockContextConfig::builder()
                     .host_id(mock_chain_id.clone())
-                    .host_type(HostType::Mock)
                     .max_history_size(50)
                     .latest_height(Height::new(cv, 2000).expect("Never fails"))
                     .build(),

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -33,6 +33,7 @@ use super::client_ctx::{MockClientRecord, PortChannelIdMap};
 use crate::fixtures::clients::tendermint::{
     dummy_tm_client_state_from_header, ClientStateConfig as TmClientStateConfig,
 };
+use crate::fixtures::core::context::MockContextConfig;
 use crate::hosts::block::{HostBlock, HostType};
 use crate::relayer::error::RelayerError;
 use crate::testapp::ibc::clients::mock::client_state::{
@@ -147,12 +148,12 @@ pub struct MockClientConfig {
 /// creation of new domain objects.
 impl Default for MockContext {
     fn default() -> Self {
-        Self::new(
-            ChainId::new("mockgaia-0").expect("Never fails"),
-            HostType::Mock,
-            5,
-            Height::new(0, 5).expect("Never fails"),
-        )
+        MockContextConfig::builder()
+            .host_id(ChainId::new("mockgaia-0").expect("Never fails"))
+            .host_type(HostType::Mock)
+            .max_history_size(5)
+            .latest_height(Height::new(0, 5).expect("Never fails"))
+            .build()
     }
 }
 
@@ -824,93 +825,93 @@ mod tests {
         let tests: Vec<Test> = vec![
             Test {
                 name: "Empty history, small pruning window".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::Mock,
-                    2,
-                    Height::new(cv, 1).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::Mock)
+                    .max_history_size(2)
+                    .latest_height(Height::new(cv, 1).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "[Synthetic TM host] Empty history, small pruning window".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::SyntheticTendermint,
-                    2,
-                    Height::new(cv, 1).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::SyntheticTendermint)
+                    .max_history_size(2)
+                    .latest_height(Height::new(cv, 1).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "Large pruning window".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::Mock,
-                    30,
-                    Height::new(cv, 2).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::Mock)
+                    .max_history_size(30)
+                    .latest_height(Height::new(cv, 2).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "[Synthetic TM host] Large pruning window".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::SyntheticTendermint,
-                    30,
-                    Height::new(cv, 2).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::SyntheticTendermint)
+                    .max_history_size(30)
+                    .latest_height(Height::new(cv, 2).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "Small pruning window".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::Mock,
-                    3,
-                    Height::new(cv, 30).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::Mock)
+                    .max_history_size(3)
+                    .latest_height(Height::new(cv, 30).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "[Synthetic TM host] Small pruning window".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::SyntheticTendermint,
-                    3,
-                    Height::new(cv, 30).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::SyntheticTendermint)
+                    .max_history_size(3)
+                    .latest_height(Height::new(cv, 30).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "Small pruning window, small starting height".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::Mock,
-                    3,
-                    Height::new(cv, 2).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::Mock)
+                    .max_history_size(3)
+                    .latest_height(Height::new(cv, 2).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "[Synthetic TM host] Small pruning window, small starting height".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::SyntheticTendermint,
-                    3,
-                    Height::new(cv, 2).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::SyntheticTendermint)
+                    .max_history_size(3)
+                    .latest_height(Height::new(cv, 2).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "Large pruning window, large starting height".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id.clone(),
-                    HostType::Mock,
-                    50,
-                    Height::new(cv, 2000).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id.clone())
+                    .host_type(HostType::Mock)
+                    .max_history_size(50)
+                    .latest_height(Height::new(cv, 2000).expect("Never fails"))
+                    .build(),
             },
             Test {
                 name: "[Synthetic TM host] Large pruning window, large starting height".to_string(),
-                ctx: MockContext::new(
-                    mock_chain_id,
-                    HostType::SyntheticTendermint,
-                    50,
-                    Height::new(cv, 2000).expect("Never fails"),
-                ),
+                ctx: MockContextConfig::builder()
+                    .host_id(mock_chain_id)
+                    .host_type(HostType::SyntheticTendermint)
+                    .max_history_size(50)
+                    .latest_height(Height::new(cv, 2000).expect("Never fails"))
+                    .build(),
             },
         ];
 

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -183,6 +183,10 @@ impl MockContext {
     /// the chain maintain in its history, which also determines the pruning window. Parameter
     /// `latest_height` determines the current height of the chain. This context
     /// has support to emulate two type of underlying chains: Mock or SyntheticTendermint.
+    #[deprecated(
+        since = "0.49.2",
+        note = "Please use `MockContextConfig::builder().build()` instead"
+    )]
     pub fn new(
         host_id: ChainId,
         host_type: HostType,
@@ -239,6 +243,10 @@ impl MockContext {
     /// Note: the validator history is used accordingly for current validator set and next validator set.
     /// `validator_history[i]` and `validator_history[i+1]` is i'th block's current and next validator set.
     /// The number of blocks will be `validator_history.len() - 1` due to the above.
+    #[deprecated(
+        since = "0.49.2",
+        note = "Please use `MockContextConfig::builder().build()` instead"
+    )]
     pub fn new_with_validator_history(
         host_id: ChainId,
         host_type: HostType,

--- a/ibc-testkit/tests/core/ics02_client/update_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/update_client.rs
@@ -203,23 +203,28 @@ fn test_update_synthetic_tendermint_client_adjacent_ok() {
     let update_height = Height::new(1, 21).unwrap();
     let chain_id_b = ChainId::new("mockgaiaB-1").unwrap();
 
-    let mut ctx = MockContext::new(
-        ChainId::new("mockgaiaA-1").unwrap(),
-        HostType::Mock,
-        5,
-        Height::new(1, 1).unwrap(),
-    )
-    .with_client_parametrized_with_chain_id(
-        chain_id_b.clone(),
-        &client_id,
-        client_height,
-        Some(tm_client_type()), // The target host chain (B) is synthetic TM.
-        Some(client_height),
-    );
+    let mut ctx = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaiaA-1").unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(5)
+        .latest_height(Height::new(1, 1).unwrap())
+        .build()
+        .with_client_parametrized_with_chain_id(
+            chain_id_b.clone(),
+            &client_id,
+            client_height,
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
+            Some(client_height),
+        );
 
     let mut router = MockRouter::new_with_transfer();
 
-    let ctx_b = MockContext::new(chain_id_b, HostType::SyntheticTendermint, 5, update_height);
+    let ctx_b = MockContextConfig::builder()
+        .host_id(chain_id_b)
+        .host_type(HostType::SyntheticTendermint)
+        .max_history_size(5)
+        .latest_height(update_height)
+        .build();
 
     let signer = dummy_account_id();
 
@@ -433,23 +438,28 @@ fn test_update_synthetic_tendermint_client_non_adjacent_ok() {
     let update_height = Height::new(1, 21).unwrap();
     let chain_id_b = ChainId::new("mockgaiaB-1").unwrap();
 
-    let mut ctx = MockContext::new(
-        ChainId::new("mockgaiaA-1").unwrap(),
-        HostType::Mock,
-        5,
-        Height::new(1, 1).unwrap(),
-    )
-    .with_client_parametrized_history_with_chain_id(
-        chain_id_b.clone(),
-        &client_id,
-        client_height,
-        Some(tm_client_type()), // The target host chain (B) is synthetic TM.
-        Some(client_height),
-    );
+    let mut ctx = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaiaA-1").unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(5)
+        .latest_height(Height::new(1, 1).unwrap())
+        .build()
+        .with_client_parametrized_history_with_chain_id(
+            chain_id_b.clone(),
+            &client_id,
+            client_height,
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
+            Some(client_height),
+        );
 
     let mut router = MockRouter::new_with_transfer();
 
-    let ctx_b = MockContext::new(chain_id_b, HostType::SyntheticTendermint, 5, update_height);
+    let ctx_b = MockContextConfig::builder()
+        .host_id(chain_id_b)
+        .host_type(HostType::SyntheticTendermint)
+        .max_history_size(5)
+        .latest_height(update_height)
+        .build();
 
     let signer = dummy_account_id();
 
@@ -491,7 +501,12 @@ fn test_update_synthetic_tendermint_client_duplicate_ok() {
     let ctx_b_chain_id = ChainId::new("mockgaiaB-1").unwrap();
     let start_height = Height::new(1, 11).unwrap();
 
-    let mut ctx_a = MockContext::new(ctx_a_chain_id, HostType::Mock, 5, start_height)
+    let mut ctx_a = MockContextConfig::builder()
+        .host_id(ctx_a_chain_id)
+        .host_type(HostType::Mock)
+        .max_history_size(5)
+        .latest_height(start_height)
+        .build()
         .with_client_parametrized_with_chain_id(
             ctx_b_chain_id.clone(),
             &client_id,
@@ -502,12 +517,12 @@ fn test_update_synthetic_tendermint_client_duplicate_ok() {
 
     let mut router_a = MockRouter::new_with_transfer();
 
-    let ctx_b = MockContext::new(
-        ctx_b_chain_id,
-        HostType::SyntheticTendermint,
-        5,
-        client_height,
-    );
+    let ctx_b = MockContextConfig::builder()
+        .host_id(ctx_b_chain_id)
+        .host_type(HostType::SyntheticTendermint)
+        .max_history_size(5)
+        .latest_height(client_height)
+        .build();
 
     let signer = dummy_account_id();
 
@@ -617,27 +632,27 @@ fn test_update_synthetic_tendermint_client_lower_height() {
 
     let chain_start_height = Height::new(1, 11).unwrap();
 
-    let ctx = MockContext::new(
-        ChainId::new("mockgaiaA-1").unwrap(),
-        HostType::Mock,
-        5,
-        chain_start_height,
-    )
-    .with_client_parametrized(
-        &client_id,
-        client_height,
-        Some(tm_client_type()), // The target host chain (B) is synthetic TM.
-        Some(client_height),
-    );
+    let ctx = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaiaA-1").unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(5)
+        .latest_height(chain_start_height)
+        .build()
+        .with_client_parametrized(
+            &client_id,
+            client_height,
+            Some(tm_client_type()), // The target host chain (B) is synthetic TM.
+            Some(client_height),
+        );
 
     let router = MockRouter::new_with_transfer();
 
-    let ctx_b = MockContext::new(
-        ChainId::new("mockgaiaB-1").unwrap(),
-        HostType::SyntheticTendermint,
-        5,
-        client_height,
-    );
+    let ctx_b = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaiaB-1").unwrap())
+        .host_type(HostType::SyntheticTendermint)
+        .max_history_size(5)
+        .latest_height(client_height)
+        .build();
 
     let signer = dummy_account_id();
 
@@ -774,29 +789,29 @@ fn test_misbehaviour_synthetic_tendermint_equivocation() {
     let chain_id_b = ChainId::new("mockgaiaB-1").unwrap();
 
     // Create a mock context for chain-A with a synthetic tendermint light client for chain-B
-    let mut ctx_a = MockContext::new(
-        ChainId::new("mockgaiaA-1").unwrap(),
-        HostType::Mock,
-        5,
-        Height::new(1, 1).unwrap(),
-    )
-    .with_client_parametrized_with_chain_id(
-        chain_id_b.clone(),
-        &client_id,
-        client_height,
-        Some(tm_client_type()),
-        Some(client_height),
-    );
+    let mut ctx_a = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaiaA-1").unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(5)
+        .latest_height(Height::new(1, 1).unwrap())
+        .build()
+        .with_client_parametrized_with_chain_id(
+            chain_id_b.clone(),
+            &client_id,
+            client_height,
+            Some(tm_client_type()),
+            Some(client_height),
+        );
 
     let mut router_a = MockRouter::new_with_transfer();
 
     // Create a mock context for chain-B
-    let ctx_b = MockContext::new(
-        chain_id_b.clone(),
-        HostType::SyntheticTendermint,
-        5,
-        misbehaviour_height,
-    );
+    let ctx_b = MockContextConfig::builder()
+        .host_id(chain_id_b.clone())
+        .host_type(HostType::SyntheticTendermint)
+        .max_history_size(5)
+        .latest_height(misbehaviour_height)
+        .build();
 
     // Get chain-B's header at `misbehaviour_height`
     let header1: TmHeader = {
@@ -838,19 +853,19 @@ fn test_misbehaviour_synthetic_tendermint_bft_time() {
     let chain_id_b = ChainId::new("mockgaiaB-1").unwrap();
 
     // Create a mock context for chain-A with a synthetic tendermint light client for chain-B
-    let mut ctx_a = MockContext::new(
-        ChainId::new("mockgaiaA-1").unwrap(),
-        HostType::Mock,
-        5,
-        Height::new(1, 1).unwrap(),
-    )
-    .with_client_parametrized_with_chain_id(
-        chain_id_b.clone(),
-        &client_id,
-        client_height,
-        Some(tm_client_type()),
-        Some(client_height),
-    );
+    let mut ctx_a = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaiaA-1").unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(5)
+        .latest_height(Height::new(1, 1).unwrap())
+        .build()
+        .with_client_parametrized_with_chain_id(
+            chain_id_b.clone(),
+            &client_id,
+            client_height,
+            Some(tm_client_type()),
+            Some(client_height),
+        );
 
     let mut router_a = MockRouter::new_with_transfer();
 

--- a/ibc-testkit/tests/core/ics02_client/update_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/update_client.rs
@@ -205,8 +205,6 @@ fn test_update_synthetic_tendermint_client_adjacent_ok() {
 
     let mut ctx = MockContextConfig::builder()
         .host_id(ChainId::new("mockgaiaA-1").unwrap())
-        .host_type(HostType::Mock)
-        .max_history_size(5)
         .latest_height(Height::new(1, 1).unwrap())
         .build()
         .with_client_parametrized_with_chain_id(
@@ -222,7 +220,6 @@ fn test_update_synthetic_tendermint_client_adjacent_ok() {
     let ctx_b = MockContextConfig::builder()
         .host_id(chain_id_b)
         .host_type(HostType::SyntheticTendermint)
-        .max_history_size(5)
         .latest_height(update_height)
         .build();
 
@@ -440,8 +437,6 @@ fn test_update_synthetic_tendermint_client_non_adjacent_ok() {
 
     let mut ctx = MockContextConfig::builder()
         .host_id(ChainId::new("mockgaiaA-1").unwrap())
-        .host_type(HostType::Mock)
-        .max_history_size(5)
         .latest_height(Height::new(1, 1).unwrap())
         .build()
         .with_client_parametrized_history_with_chain_id(
@@ -457,7 +452,6 @@ fn test_update_synthetic_tendermint_client_non_adjacent_ok() {
     let ctx_b = MockContextConfig::builder()
         .host_id(chain_id_b)
         .host_type(HostType::SyntheticTendermint)
-        .max_history_size(5)
         .latest_height(update_height)
         .build();
 
@@ -503,8 +497,6 @@ fn test_update_synthetic_tendermint_client_duplicate_ok() {
 
     let mut ctx_a = MockContextConfig::builder()
         .host_id(ctx_a_chain_id)
-        .host_type(HostType::Mock)
-        .max_history_size(5)
         .latest_height(start_height)
         .build()
         .with_client_parametrized_with_chain_id(
@@ -520,7 +512,6 @@ fn test_update_synthetic_tendermint_client_duplicate_ok() {
     let ctx_b = MockContextConfig::builder()
         .host_id(ctx_b_chain_id)
         .host_type(HostType::SyntheticTendermint)
-        .max_history_size(5)
         .latest_height(client_height)
         .build();
 
@@ -634,8 +625,6 @@ fn test_update_synthetic_tendermint_client_lower_height() {
 
     let ctx = MockContextConfig::builder()
         .host_id(ChainId::new("mockgaiaA-1").unwrap())
-        .host_type(HostType::Mock)
-        .max_history_size(5)
         .latest_height(chain_start_height)
         .build()
         .with_client_parametrized(
@@ -650,7 +639,6 @@ fn test_update_synthetic_tendermint_client_lower_height() {
     let ctx_b = MockContextConfig::builder()
         .host_id(ChainId::new("mockgaiaB-1").unwrap())
         .host_type(HostType::SyntheticTendermint)
-        .max_history_size(5)
         .latest_height(client_height)
         .build();
 
@@ -791,8 +779,6 @@ fn test_misbehaviour_synthetic_tendermint_equivocation() {
     // Create a mock context for chain-A with a synthetic tendermint light client for chain-B
     let mut ctx_a = MockContextConfig::builder()
         .host_id(ChainId::new("mockgaiaA-1").unwrap())
-        .host_type(HostType::Mock)
-        .max_history_size(5)
         .latest_height(Height::new(1, 1).unwrap())
         .build()
         .with_client_parametrized_with_chain_id(
@@ -809,7 +795,6 @@ fn test_misbehaviour_synthetic_tendermint_equivocation() {
     let ctx_b = MockContextConfig::builder()
         .host_id(chain_id_b.clone())
         .host_type(HostType::SyntheticTendermint)
-        .max_history_size(5)
         .latest_height(misbehaviour_height)
         .build();
 
@@ -855,8 +840,6 @@ fn test_misbehaviour_synthetic_tendermint_bft_time() {
     // Create a mock context for chain-A with a synthetic tendermint light client for chain-B
     let mut ctx_a = MockContextConfig::builder()
         .host_id(ChainId::new("mockgaiaA-1").unwrap())
-        .host_type(HostType::Mock)
-        .max_history_size(5)
         .latest_height(Height::new(1, 1).unwrap())
         .build()
         .with_client_parametrized_with_chain_id(

--- a/ibc-testkit/tests/core/ics03_connection/conn_open_ack.rs
+++ b/ibc-testkit/tests/core/ics03_connection/conn_open_ack.rs
@@ -14,6 +14,7 @@ use ibc::core::host::ValidationContext;
 use ibc::core::primitives::prelude::*;
 use ibc::core::primitives::ZERO_DURATION;
 use ibc_testkit::fixtures::core::connection::dummy_msg_conn_open_ack;
+use ibc_testkit::fixtures::core::context::MockContextConfig;
 use ibc_testkit::fixtures::{Expect, Fixture};
 use ibc_testkit::hosts::block::HostType;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
@@ -59,12 +60,12 @@ fn conn_open_ack_fixture(ctx: Ctx) -> Fixture<MsgConnectionOpenAck> {
     conn_end_open.set_state(State::Open); // incorrect field
 
     let ctx_default = MockContext::default();
-    let ctx_new = MockContext::new(
-        ChainId::new(&format!("mockgaia-{}", latest_height.revision_number())).unwrap(),
-        HostType::Mock,
-        max_history_size,
-        latest_height,
-    );
+    let ctx_new = MockContextConfig::builder()
+        .host_id(ChainId::new(&format!("mockgaia-{}", latest_height.revision_number())).unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(max_history_size)
+        .latest_height(latest_height)
+        .build();
     let ctx = match ctx {
         Ctx::New => ctx_new,
         Ctx::NewWithConnection => ctx_new

--- a/ibc-testkit/tests/core/ics03_connection/conn_open_ack.rs
+++ b/ibc-testkit/tests/core/ics03_connection/conn_open_ack.rs
@@ -16,7 +16,6 @@ use ibc::core::primitives::ZERO_DURATION;
 use ibc_testkit::fixtures::core::connection::dummy_msg_conn_open_ack;
 use ibc_testkit::fixtures::core::context::MockContextConfig;
 use ibc_testkit::fixtures::{Expect, Fixture};
-use ibc_testkit::hosts::block::HostType;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::MockContext;
 use test_log::test;
@@ -39,7 +38,6 @@ fn conn_open_ack_fixture(ctx: Ctx) -> Fixture<MsgConnectionOpenAck> {
     // Parametrize the host chain to have a height at least as recent as the
     // the height of the proofs in the Ack msg.
     let latest_height = proof_height.increment();
-    let max_history_size = 5;
 
     // A connection end that will exercise the successful path.
     let default_conn_end = ConnectionEnd::new(
@@ -62,8 +60,6 @@ fn conn_open_ack_fixture(ctx: Ctx) -> Fixture<MsgConnectionOpenAck> {
     let ctx_default = MockContext::default();
     let ctx_new = MockContextConfig::builder()
         .host_id(ChainId::new(&format!("mockgaia-{}", latest_height.revision_number())).unwrap())
-        .host_type(HostType::Mock)
-        .max_history_size(max_history_size)
         .latest_height(latest_height)
         .build();
     let ctx = match ctx {

--- a/ibc-testkit/tests/core/ics03_connection/conn_open_try.rs
+++ b/ibc-testkit/tests/core/ics03_connection/conn_open_try.rs
@@ -4,13 +4,11 @@ use ibc::core::connection::types::State;
 use ibc::core::entrypoint::{execute, validate};
 use ibc::core::handler::types::events::{IbcEvent, MessageEvent};
 use ibc::core::handler::types::msgs::MsgEnvelope;
-use ibc::core::host::types::identifiers::ChainId;
 use ibc::core::host::ValidationContext;
 use ibc::core::primitives::prelude::*;
 use ibc_testkit::fixtures::core::connection::dummy_msg_conn_open_try;
 use ibc_testkit::fixtures::core::context::MockContextConfig;
 use ibc_testkit::fixtures::{Expect, Fixture};
-use ibc_testkit::hosts::block::HostType;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::MockContext;
 use test_log::test;
@@ -53,8 +51,6 @@ fn conn_open_try_fixture(ctx_variant: Ctx, msg_variant: Msg) -> Fixture<MsgConne
     };
 
     let ctx_new = MockContextConfig::builder()
-        .host_id(ChainId::new("mockgaia-0").unwrap())
-        .host_type(HostType::Mock)
         .max_history_size(max_history_size)
         .latest_height(host_chain_height)
         .build();

--- a/ibc-testkit/tests/core/ics03_connection/conn_open_try.rs
+++ b/ibc-testkit/tests/core/ics03_connection/conn_open_try.rs
@@ -8,6 +8,7 @@ use ibc::core::host::types::identifiers::ChainId;
 use ibc::core::host::ValidationContext;
 use ibc::core::primitives::prelude::*;
 use ibc_testkit::fixtures::core::connection::dummy_msg_conn_open_try;
+use ibc_testkit::fixtures::core::context::MockContextConfig;
 use ibc_testkit::fixtures::{Expect, Fixture};
 use ibc_testkit::hosts::block::HostType;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
@@ -51,12 +52,12 @@ fn conn_open_try_fixture(ctx_variant: Ctx, msg_variant: Msg) -> Fixture<MsgConne
         ),
     };
 
-    let ctx_new = MockContext::new(
-        ChainId::new("mockgaia-0").unwrap(),
-        HostType::Mock,
-        max_history_size,
-        host_chain_height,
-    );
+    let ctx_new = MockContextConfig::builder()
+        .host_id(ChainId::new("mockgaia-0").unwrap())
+        .host_type(HostType::Mock)
+        .max_history_size(max_history_size)
+        .latest_height(host_chain_height)
+        .build();
     let ctx = match ctx_variant {
         Ctx::Default => MockContext::default(),
         Ctx::WithClient => ctx_new.with_client(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1042

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Removes multiple default initializers from `MockContext`and refactors the existing tests. 

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.
- [x] Rebase to `main`

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
