### PR TITLE
imp: re-export `Timestamp` & `Duration` from `ibc_proto::google::protobuf`

### DIFF
--- a/.changelog/unreleased/improvements/1054-re-export-all-google-proto-types.md
+++ b/.changelog/unreleased/improvements/1054-re-export-all-google-proto-types.md
@@ -1,0 +1,3 @@
+- [ibc-primitives] Re-exports additional google proto types, like `Timestamp`
+  and `Duration` for added convenience when developing IBC light clients or
+  applications. ([\#1054](https://github.com/cosmos/ibc-rs/pull/1054))

--- a/ibc-primitives/src/lib.rs
+++ b/ibc-primitives/src/lib.rs
@@ -25,8 +25,9 @@ pub use traits::*;
 mod types;
 pub use types::*;
 
-/// Re-export of common proto types from the `ibc-proto` crate.
+/// Re-exports google proto types and `Protobuf` trait from the `ibc-proto-rs`
+/// crate.
 pub mod proto {
-    pub use ibc_proto::google::protobuf::Any;
+    pub use ibc_proto::google::protobuf::*;
     pub use ibc_proto::Protobuf;
 }

--- a/ibc-primitives/src/lib.rs
+++ b/ibc-primitives/src/lib.rs
@@ -25,9 +25,9 @@ pub use traits::*;
 mod types;
 pub use types::*;
 
-/// Re-exports google proto types and `Protobuf` trait from the `ibc-proto-rs`
-/// crate.
+/// Re-exports necessary google proto types and `Protobuf` trait from the
+/// `ibc-proto-rs` crate.
 pub mod proto {
-    pub use ibc_proto::google::protobuf::*;
+    pub use ibc_proto::google::protobuf::{Any, Duration, Timestamp};
     pub use ibc_proto::Protobuf;
 }


### PR DESCRIPTION
## Description

This requirement emerged while implementing the `sov-celestia` light client, eliminating the need to import the same types from `tendermint_proto::google::protobuf`.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.