### PR TITLE
fix: add missing package fields for `ibc-client-wasm-types`

### DIFF
--- a/ibc-clients/ics08-wasm/types/Cargo.toml
+++ b/ibc-clients/ics08-wasm/types/Cargo.toml
@@ -2,9 +2,17 @@
 name = "ibc-client-wasm-types"
 version      = { workspace = true }
 authors      = { workspace = true }
-license      = { workspace = true }
-rust-version = { workspace = true }
 edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+keywords     = ["blockchain", "cosmos", "ibc", "wasm", "ics08"]
+readme       = "./../../README.md"
+description  = """
+    Maintained by `ibc-rs`, encapsulates essential ICS-08 Wasm Light Client data structures and domain types,
+    as specified in the Inter-Blockchain Communication (IBC) protocol. Designed for universal applicability 
+    to facilitate development and integration across diverse IBC-enabled projects.
+"""
 
 [dependencies]
 # external dependencies


### PR DESCRIPTION
Captured by the `cargo release` in the actual release pipeline.