### PR TITLE
fix: add frozen client check for `create_client` handler

### DIFF
--- a/.changelog/unreleased/bug-fixes/1061-ease-frozen-height-check-ics07-try-from.md
+++ b/.changelog/unreleased/bug-fixes/1061-ease-frozen-height-check-ics07-try-from.md
@@ -1,3 +1,5 @@
 - [ibc-client-tendermint-types] Ease frozen Height check in the tendermint
-  `ClientState` protobuf deserialization
-  ([\#1061](https://github.com/cosmos/ibc-rs/issues/1061))
+  `ClientState` protobuf deserialization, and consequently include frozen client
+  check for client creation path.
+  ([\#1061](https://github.com/cosmos/ibc-rs/issues/1061)),
+  ([\#1063](https://github.com/cosmos/ibc-rs/pull/1063))

--- a/ibc-testkit/tests/core/ics02_client/create_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/create_client.rs
@@ -114,10 +114,8 @@ fn test_invalid_frozen_tm_client_creation() {
 
     let res = validate(&ctx, &router, msg_envelope.clone());
 
-    assert!(res.is_err());
-
-    match res.unwrap_err() {
-        ContextError::ClientError(ClientError::ClientFrozen { .. }) => {}
-        e => panic!("unexpected error: {}", e),
-    }
+    assert!(matches!(
+        res,
+        Err(ContextError::ClientError(ClientError::ClientFrozen { .. }))
+    ))
 }

--- a/ibc-testkit/tests/core/ics02_client/create_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/create_client.rs
@@ -2,9 +2,11 @@ use ibc::clients::tendermint::types::{
     client_type as tm_client_type, ConsensusState as TmConsensusState,
 };
 use ibc::core::client::context::client_state::ClientStateCommon;
+use ibc::core::client::types::error::ClientError;
 use ibc::core::client::types::msgs::{ClientMsg, MsgCreateClient};
 use ibc::core::client::types::Height;
 use ibc::core::entrypoint::{execute, validate};
+use ibc::core::handler::types::error::ContextError;
 use ibc::core::handler::types::msgs::MsgEnvelope;
 use ibc::core::host::ValidationContext;
 use ibc_testkit::fixtures::clients::tendermint::{
@@ -85,4 +87,37 @@ fn test_tm_create_client_ok() {
     let expected_client_state = ctx.decode_client_state(msg.client_state).unwrap();
     assert_eq!(expected_client_state.client_type(), client_type);
     assert_eq!(ctx.client_state(&client_id).unwrap(), expected_client_state);
+}
+
+#[test]
+fn test_invalid_frozen_tm_client_creation() {
+    let signer = dummy_account_id();
+
+    let ctx = MockContext::default();
+
+    let router = MockRouter::new_with_transfer();
+
+    let tm_header = dummy_tendermint_header();
+
+    let tm_client_state = dummy_tm_client_state_from_header(tm_header.clone())
+        .inner()
+        .clone()
+        .with_frozen_height(Height::min(0));
+
+    let msg = MsgCreateClient::new(
+        tm_client_state.into(),
+        TmConsensusState::from(tm_header).into(),
+        signer,
+    );
+
+    let msg_envelope = MsgEnvelope::from(ClientMsg::from(msg.clone()));
+
+    let res = validate(&ctx, &router, msg_envelope.clone());
+
+    assert!(res.is_err());
+
+    match res.unwrap_err() {
+        ContextError::ClientError(ClientError::ClientFrozen { .. }) => {}
+        e => panic!("unexpected error: {}", e),
+    }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1061

Fixes #1062 by adding the missing frozen client check in the client creation handler.
______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [X] Added tests.
- [X] Linked to GitHub issue.
- [X] Updated code comments and documentation (e.g., `docs/`).
- [X] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
