### PR TITLE
fix: revert `frozen_height` to 0 for active clients in conversions

### DIFF
--- a/ibc-clients/ics07-tendermint/types/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state.rs
@@ -284,7 +284,11 @@ impl TryFrom<RawTmClientState> for ClientState {
             .try_into()
             .map_err(|_| Error::MissingLatestHeight)?;
 
-        let frozen_height = raw.frozen_height.and_then(|h| Height::try_from(h).ok());
+        // NOTE: In `RawClientState`, a `frozen_height` of `0` means "not
+        // frozen". See:
+        // https://github.com/cosmos/ibc-go/blob/8422d0c4c35ef970539466c5bdec1cd27369bab3/modules/light-clients/07-tendermint/types/client_state.go#L74
+        let frozen_height =
+            Height::try_from(raw.frozen_height.ok_or(Error::MissingFrozenHeight)?).ok();
 
         // We use set this deprecated field just so that we can properly convert
         // it back in its raw form

--- a/ibc-clients/ics07-tendermint/types/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state.rs
@@ -6,6 +6,7 @@ use core::str::FromStr;
 use core::time::Duration;
 
 use ibc_core_client_types::error::ClientError;
+use ibc_core_client_types::proto::v1::Height as RawHeight;
 use ibc_core_client_types::Height;
 use ibc_core_commitment_types::specs::ProofSpecs;
 use ibc_core_host_types::identifiers::ChainId;
@@ -283,9 +284,6 @@ impl TryFrom<RawTmClientState> for ClientState {
             .try_into()
             .map_err(|_| Error::MissingLatestHeight)?;
 
-        // In `RawClientState`, a `frozen_height` of `0` means "not frozen".
-        // See:
-        // https://github.com/cosmos/ibc-go/blob/8422d0c4c35ef970539466c5bdec1cd27369bab3/modules/light-clients/07-tendermint/types/client_state.go#L74
         let frozen_height = raw.frozen_height.and_then(|h| Height::try_from(h).ok());
 
         // We use set this deprecated field just so that we can properly convert
@@ -322,7 +320,17 @@ impl From<ClientState> for RawTmClientState {
             trusting_period: Some(value.trusting_period.into()),
             unbonding_period: Some(value.unbonding_period.into()),
             max_clock_drift: Some(value.max_clock_drift.into()),
-            frozen_height: value.frozen_height.map(|height| height.into()),
+            // NOTE: The protobuf encoded `frozen_height` of an active client
+            // must be set to `0` so that `ibc-go` driven chains can properly
+            // decode the `ClientState` value. In `RawClientState`, a
+            // `frozen_height` of `0` means "not frozen". See:
+            // https://github.com/cosmos/ibc-go/blob/8422d0c4c35ef970539466c5bdec1cd27369bab3/modules/light-clients/07-tendermint/types/client_state.go#L74
+            frozen_height: Some(value.frozen_height.map(|height| height.into()).unwrap_or(
+                RawHeight {
+                    revision_number: 0,
+                    revision_height: 0,
+                },
+            )),
             latest_height: Some(value.latest_height.into()),
             proof_specs: value.proof_specs.into(),
             upgrade_path: value.upgrade_path,

--- a/ibc-clients/ics07-tendermint/types/src/error.rs
+++ b/ibc-clients/ics07-tendermint/types/src/error.rs
@@ -61,8 +61,8 @@ pub enum Error {
     HeaderTimestampTooLow { actual: String, min: String },
     /// header revision height = `{height}` is invalid
     InvalidHeaderHeight { height: u64 },
-    /// Disallowed to create a new client with a frozen height
-    FrozenHeightNotAllowed,
+    /// frozen height not found
+    MissingFrozenHeight,
     /// the header's trusted revision number (`{trusted_revision}`) and the update's revision number (`{header_revision}`) should be the same
     MismatchHeightRevisions {
         trusted_revision: u64,

--- a/ibc-clients/ics07-tendermint/types/src/error.rs
+++ b/ibc-clients/ics07-tendermint/types/src/error.rs
@@ -61,7 +61,7 @@ pub enum Error {
     HeaderTimestampTooLow { actual: String, min: String },
     /// header revision height = `{height}` is invalid
     InvalidHeaderHeight { height: u64 },
-    /// frozen height not found
+    /// frozen height is missing
     MissingFrozenHeight,
     /// the header's trusted revision number (`{trusted_revision}`) and the update's revision number (`{header_revision}`) should be the same
     MismatchHeightRevisions {

--- a/ibc-testkit/tests/core/ics02_client/update_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/update_client.rs
@@ -10,6 +10,7 @@ use ibc::clients::tendermint::types::{
 use ibc::core::client::context::client_state::{ClientStateCommon, ClientStateValidation};
 use ibc::core::client::context::ClientValidationContext;
 use ibc::core::client::types::msgs::{ClientMsg, MsgSubmitMisbehaviour, MsgUpdateClient};
+use ibc::core::client::types::proto::v1::Height as RawHeight;
 use ibc::core::client::types::Height;
 use ibc::core::commitment_types::specs::ProofSpecs;
 use ibc::core::entrypoint::{execute, validate};
@@ -588,7 +589,10 @@ fn test_update_synthetic_tendermint_client_duplicate_ok() {
                 ),
                 proof_specs: ProofSpecs::default().into(),
                 upgrade_path: Default::default(),
-                frozen_height: None,
+                frozen_height: Some(RawHeight {
+                    revision_number: 0,
+                    revision_height: 0,
+                }),
                 allow_update_after_expiry: false,
                 allow_update_after_misbehaviour: false,
             };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In #1061, when converting an active Tendermint ClientState to its corresponding proto type, we set the `frozen_height` as `None`  to ensure consistency when switching between domain and proto types. However, [basecoin-rs revealed](https://github.com/informalsystems/basecoin-rs/actions/runs/7661621925/job/20881356539#step:14:941) that the ibc-go driven chain can only properly decode the Protobuf encoded of an active `ClientState` value when the `frozen_height` is explicitly set to zero!

Integration test: https://github.com/informalsystems/basecoin-rs/pull/151


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [X] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
