### PR TITLE
imp: remove order_matches from ChannelEnd impl

### DIFF
--- a/.changelog/unreleased/improvements/394-remove-order-match.md
+++ b/.changelog/unreleased/improvements/394-remove-order-match.md
@@ -1,0 +1,2 @@
+- Remove order_matches method from ChannelEnd impl
+  ([\#394](https://github.com/cosmos/ibc-rs/issues/394))

--- a/ibc-core/ics04-channel/src/handler/recv_packet.rs
+++ b/ibc-core/ics04-channel/src/handler/recv_packet.rs
@@ -224,40 +224,46 @@ where
             .map_err(PacketError::Channel)?;
     }
 
-    if chan_end_on_b.order_matches(&Order::Ordered) {
-        let seq_recv_path_on_b =
-            SeqRecvPath::new(&msg.packet.port_id_on_b, &msg.packet.chan_id_on_b);
-        let next_seq_recv = ctx_b.get_next_sequence_recv(&seq_recv_path_on_b)?;
-        if msg.packet.seq_on_a > next_seq_recv {
-            return Err(PacketError::InvalidPacketSequence {
-                given_sequence: msg.packet.seq_on_a,
-                next_sequence: next_seq_recv,
+    match chan_end_on_b.ordering {
+        Order::Ordered => {
+            let seq_recv_path_on_b =
+                SeqRecvPath::new(&msg.packet.port_id_on_b, &msg.packet.chan_id_on_b);
+            let next_seq_recv = ctx_b.get_next_sequence_recv(&seq_recv_path_on_b)?;
+            if msg.packet.seq_on_a > next_seq_recv {
+                return Err(PacketError::InvalidPacketSequence {
+                    given_sequence: msg.packet.seq_on_a,
+                    next_sequence: next_seq_recv,
+                }
+                .into());
             }
-            .into());
-        }
 
-        if msg.packet.seq_on_a == next_seq_recv {
+            if msg.packet.seq_on_a == next_seq_recv {
+                // Case where the recvPacket is successful and an
+                // acknowledgement will be written (not a no-op)
+                validate_write_acknowledgement(ctx_b, msg)?;
+            }
+        }
+        Order::Unordered => {
+            let receipt_path_on_b = ReceiptPath::new(
+                &msg.packet.port_id_on_a,
+                &msg.packet.chan_id_on_a,
+                msg.packet.seq_on_a,
+            );
+            let packet_rec = ctx_b.get_packet_receipt(&receipt_path_on_b);
+            match packet_rec {
+                Ok(_receipt) => {}
+                Err(ContextError::PacketError(PacketError::PacketReceiptNotFound { sequence }))
+                    if sequence == msg.packet.seq_on_a => {}
+                Err(e) => return Err(e),
+            }
             // Case where the recvPacket is successful and an
             // acknowledgement will be written (not a no-op)
             validate_write_acknowledgement(ctx_b, msg)?;
         }
-    } else {
-        let receipt_path_on_b = ReceiptPath::new(
-            &msg.packet.port_id_on_a,
-            &msg.packet.chan_id_on_a,
-            msg.packet.seq_on_a,
-        );
-        let packet_rec = ctx_b.get_packet_receipt(&receipt_path_on_b);
-        match packet_rec {
-            Ok(_receipt) => {}
-            Err(ContextError::PacketError(PacketError::PacketReceiptNotFound { sequence }))
-                if sequence == msg.packet.seq_on_a => {}
-            Err(e) => return Err(e),
+        Order::None => {
+            // Do nothing
         }
-        // Case where the recvPacket is successful and an
-        // acknowledgement will be written (not a no-op)
-        validate_write_acknowledgement(ctx_b, msg)?;
-    };
+    }
 
     Ok(())
 }

--- a/ibc-core/ics04-channel/src/handler/timeout_on_close.rs
+++ b/ibc-core/ics04-channel/src/handler/timeout_on_close.rs
@@ -120,37 +120,43 @@ where
 
         verify_conn_delay_passed(ctx_a, msg.proof_height_on_b, &conn_end_on_a)?;
 
-        let next_seq_recv_verification_result = if chan_end_on_a.order_matches(&Order::Ordered) {
-            if packet.seq_on_a < msg.next_seq_recv_on_b {
-                return Err(PacketError::InvalidPacketSequence {
-                    given_sequence: packet.seq_on_a,
-                    next_sequence: msg.next_seq_recv_on_b,
+        let next_seq_recv_verification_result = match chan_end_on_a.ordering {
+            Order::Ordered => {
+                if packet.seq_on_a < msg.next_seq_recv_on_b {
+                    return Err(PacketError::InvalidPacketSequence {
+                        given_sequence: packet.seq_on_a,
+                        next_sequence: msg.next_seq_recv_on_b,
+                    }
+                    .into());
                 }
-                .into());
+                let seq_recv_path_on_b =
+                    SeqRecvPath::new(&packet.port_id_on_b, &packet.chan_id_on_b);
+
+                client_state_of_b_on_a.verify_membership(
+                    conn_end_on_a.counterparty().prefix(),
+                    &msg.proof_unreceived_on_b,
+                    consensus_state_of_b_on_a.root(),
+                    Path::SeqRecv(seq_recv_path_on_b),
+                    packet.seq_on_a.to_vec(),
+                )
             }
-            let seq_recv_path_on_b = SeqRecvPath::new(&packet.port_id_on_b, &packet.chan_id_on_b);
+            Order::Unordered => {
+                let receipt_path_on_b = ReceiptPath::new(
+                    &msg.packet.port_id_on_b,
+                    &msg.packet.chan_id_on_b,
+                    msg.packet.seq_on_a,
+                );
 
-            client_state_of_b_on_a.verify_membership(
-                conn_end_on_a.counterparty().prefix(),
-                &msg.proof_unreceived_on_b,
-                consensus_state_of_b_on_a.root(),
-                Path::SeqRecv(seq_recv_path_on_b),
-                packet.seq_on_a.to_vec(),
-            )
-        } else {
-            let receipt_path_on_b = ReceiptPath::new(
-                &msg.packet.port_id_on_b,
-                &msg.packet.chan_id_on_b,
-                msg.packet.seq_on_a,
-            );
-
-            client_state_of_b_on_a.verify_non_membership(
-                conn_end_on_a.counterparty().prefix(),
-                &msg.proof_unreceived_on_b,
-                consensus_state_of_b_on_a.root(),
-                Path::Receipt(receipt_path_on_b),
-            )
+                client_state_of_b_on_a.verify_non_membership(
+                    conn_end_on_a.counterparty().prefix(),
+                    &msg.proof_unreceived_on_b,
+                    consensus_state_of_b_on_a.root(),
+                    Path::Receipt(receipt_path_on_b),
+                )
+            }
+            Order::None => Ok(()),
         };
+
         next_seq_recv_verification_result
             .map_err(|e| ChannelError::PacketVerificationFailed {
                 sequence: msg.next_seq_recv_on_b,

--- a/ibc-core/ics04-channel/types/src/channel.rs
+++ b/ibc-core/ics04-channel/types/src/channel.rs
@@ -279,11 +279,6 @@ impl ChannelEnd {
         Ok(())
     }
 
-    /// Helper function to compare the order of this end with another order.
-    pub fn order_matches(&self, other: &Order) -> bool {
-        self.ordering.eq(other)
-    }
-
     pub fn connection_hops_matches(&self, other: &Vec<ConnectionId>) -> bool {
         self.connection_hops.eq(other)
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes:  #394

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Remove the `order_matches` method, refactor the current usage of `order_matches` to use match statements instead.


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
