### PR TITLE
imp(core): remove `State::Uninitialized` check while parsing `ConnectionEnd`

### DIFF
--- a/.changelog/unreleased/improvements/1123-remove-check-for-unitialized-connection-end-state.md
+++ b/.changelog/unreleased/improvements/1123-remove-check-for-unitialized-connection-end-state.md
@@ -1,0 +1,2 @@
+- [ibc-core] Remove `State::Uninitialized` check while parsing `ConnectionEnd`
+  from Protobuf ([\#1123](https://github.com/cosmos/ibc-rs/issues/1123))

--- a/.changelog/unreleased/improvements/1123-remove-check-for-unitialized-connection-end-state.md
+++ b/.changelog/unreleased/improvements/1123-remove-check-for-unitialized-connection-end-state.md
@@ -1,2 +1,2 @@
-- [ibc-core] Remove `State::Uninitialized` check while parsing `ConnectionEnd`
+- [ibc-core-connection] Remove `State::Uninitialized` check while parsing `ConnectionEnd`
   from Protobuf ([\#1123](https://github.com/cosmos/ibc-rs/issues/1123))

--- a/.changelog/unreleased/improvements/1123-remove-check-for-unitialized-connection-end-state.md
+++ b/.changelog/unreleased/improvements/1123-remove-check-for-unitialized-connection-end-state.md
@@ -1,2 +1,3 @@
-- [ibc-core-connection] Remove `State::Uninitialized` check while parsing `ConnectionEnd`
-  from Protobuf ([\#1123](https://github.com/cosmos/ibc-rs/issues/1123))
+- [ibc-core-connection] Remove `State::Uninitialized` check while parsing
+  `ConnectionEnd` from Protobuf
+  ([\#1123](https://github.com/cosmos/ibc-rs/issues/1123))

--- a/ibc-core/ics03-connection/types/src/connection.rs
+++ b/ibc-core/ics03-connection/types/src/connection.rs
@@ -1,7 +1,6 @@
 //! Defines the types that define a connection
 
 use core::fmt::{Display, Error as FmtError, Formatter};
-use core::str::FromStr;
 use core::time::Duration;
 use core::u64;
 
@@ -9,7 +8,6 @@ use ibc_core_client_types::error::ClientError;
 use ibc_core_commitment_types::commitment::CommitmentPrefix;
 use ibc_core_host_types::identifiers::{ClientId, ConnectionId};
 use ibc_primitives::prelude::*;
-use ibc_primitives::ZERO_DURATION;
 use ibc_proto::ibc::core::connection::v1::{
     ConnectionEnd as RawConnectionEnd, Counterparty as RawCounterparty,
     IdentifiedConnection as RawIdentifiedConnection,
@@ -207,20 +205,6 @@ impl TryFrom<RawConnectionEnd> for ConnectionEnd {
     type Error = ConnectionError;
     fn try_from(value: RawConnectionEnd) -> Result<Self, Self::Error> {
         let state = value.state.try_into()?;
-
-        if state == State::Uninitialized {
-            return ConnectionEnd::new(
-                State::Uninitialized,
-                ClientId::from_str("07-tendermint-0").expect("should not fail"),
-                Counterparty::new(
-                    ClientId::from_str("07-tendermint-0").expect("should not fail"),
-                    None,
-                    CommitmentPrefix::empty(),
-                ),
-                Vec::new(),
-                ZERO_DURATION,
-            );
-        }
 
         if value.client_id.is_empty() {
             return Err(ConnectionError::EmptyProtoConnectionEnd);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1123

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->


______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
