### PR TITLE
chore(ci): enable `merge_group` trigger from merge queue

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,8 @@
 name: Code Quality Checks
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   code-quality:

--- a/.github/workflows/cw-check.yaml
+++ b/.github/workflows/cw-check.yaml
@@ -25,6 +25,9 @@ on:
       - ibc-clients/**
       - ibc-primitives/**
       - ibc-derive/**
+  merge_group:
+    types: [checks_requested]
+
 jobs:
   cw-check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: main
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   md-link-check:

--- a/.github/workflows/no-std.yaml
+++ b/.github/workflows/no-std.yaml
@@ -29,6 +29,9 @@ on:
       - ibc-clients/**
       - ibc-primitives/**
       - ibc-derive/**
+  merge_group:
+    types: [checks_requested]
+
 jobs:
   check-no-std-panic-conflict:
     name: Check no_std panic conflict

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,8 @@ on:
       - ibc-query/**
       - ibc-testkit/**
       - ibc-derive/**
+  merge_group:
+    types: [checks_requested]
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' }}
 
   check-features:
+    if: ${{ github.event_name == 'merge_group' }}
     name: Check features
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
     if: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' }}
 
   check-features:
-    if: ${{ github.event_name == 'merge_group' }}
+    if: ${{ github.event_name != 'pull_request' }}
     name: Check features
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #408

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Added `merge_group` triggers to
- code quality
- no std check
- cw check
- markdown dead link check
- rust - with `check-features` being skipped on PRs

References:
- [Github merge queue](https://github.blog/2023-07-12-github-merge-queue-is-generally-available)
- [`merge_group` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group)

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
