### PR TITLE
tendermint: box headers in Misbehaviour message

### DIFF
--- a/.changelog/unreleased/improvements/1145-tendermint-boxed-header.md
+++ b/.changelog/unreleased/improvements/1145-tendermint-boxed-header.md
@@ -1,0 +1,4 @@
+- [ibc-client-tendermint-types] Box header fields inside of Misbehaviour type so
+  that the type is smaller (i.e. trade size of the type for heap memory).  This
+  prevents stack overflows on systems with small stack (e.g. Solana).
+  ([\#1145](https://github.com/cosmos/ibc-rs/pull/1145))

--- a/ibc-clients/ics07-tendermint/types/src/misbehaviour.rs
+++ b/ibc-clients/ics07-tendermint/types/src/misbehaviour.rs
@@ -17,16 +17,16 @@ pub const TENDERMINT_MISBEHAVIOUR_TYPE_URL: &str = "/ibc.lightclients.tendermint
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Misbehaviour {
     client_id: ClientId,
-    header1: Header,
-    header2: Header,
+    header1: Box<Header>,
+    header2: Box<Header>,
 }
 
 impl Misbehaviour {
     pub fn new(client_id: ClientId, header1: Header, header2: Header) -> Self {
         Self {
             client_id,
-            header1,
-            header2,
+            header1: Box::new(header1),
+            header2: Box::new(header2),
         }
     }
 
@@ -98,8 +98,8 @@ impl From<Misbehaviour> for RawMisbehaviour {
         #[allow(deprecated)]
         RawMisbehaviour {
             client_id: value.client_id.to_string(),
-            header_1: Some(value.header1.into()),
-            header_2: Some(value.header2.into()),
+            header_1: Some((*value.header1).into()),
+            header_2: Some((*value.header2).into()),
         }
     }
 }


### PR DESCRIPTION
Header type is quite large.  Misbehaviour holds two of those.  This becomes an issue on platforms with small stack—such as Solana—where keeping (even temporary) local variable may lead to stack overflow.

Fix that by Boxing each of the headers in the Misbehaviour message.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [x] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
