### PR TITLE
imp: include `query_height` and `proof` for client upgrade query request/response types

### DIFF
--- a/.changelog/unreleased/features/738-client-recovery.md
+++ b/.changelog/unreleased/features/738-client-recovery.md
@@ -1,4 +1,4 @@
-- [ibc-client] Implement [client recovery][client-recovery] feature.
+- [ibc-core-client] Implement [client recovery][client-recovery] feature.
 ([\#738](https://github.com/cosmos/ibc-rs/issues/738))
 
-client-recovery: https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-026-ibc-client-recovery-mechanisms.md
+[client-recovery]: https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-026-ibc-client-recovery-mechanisms.md

--- a/.changelog/unreleased/improvements/1152-add-query-height-and-proof-for-client-upgrade-queries.md
+++ b/.changelog/unreleased/improvements/1152-add-query-height-and-proof-for-client-upgrade-queries.md
@@ -1,0 +1,3 @@
+- [ibc-query] Add support for querying `upgraded_client/consensus_state` at a
+  given height along with returning their proof of existence in the response.
+ ([\#1152](https://github.com/cosmos/ibc-rs/issues/1152))

--- a/ibc-query/src/core/client/query.rs
+++ b/ibc-query/src/core/client/query.rs
@@ -190,39 +190,98 @@ where
 }
 
 /// Queries for the upgraded client state.
-pub fn query_upgraded_client_state<U>(
+pub fn query_upgraded_client_state<I, U>(
+    ibc_ctx: &I,
     upgrade_ctx: &U,
-    _request: &QueryUpgradedClientStateRequest,
+    request: &QueryUpgradedClientStateRequest,
 ) -> Result<QueryUpgradedClientStateResponse, QueryError>
 where
+    I: QueryContext,
     U: UpgradeValidationContext,
 {
-    let plan = upgrade_ctx.upgrade_plan().map_err(ClientError::from)?;
+    let upgrade_revision_height = match request.upgrade_height {
+        Some(height) => height.revision_height(),
+        None => {
+            upgrade_ctx
+                .upgrade_plan()
+                .map_err(ClientError::from)?
+                .height
+        }
+    };
 
-    let upgraded_client_state_path = UpgradeClientPath::UpgradedClientState(plan.height);
+    let upgraded_client_state_path =
+        UpgradeClientPath::UpgradedClientState(upgrade_revision_height);
 
     let upgraded_client_state = upgrade_ctx
         .upgraded_client_state(&upgraded_client_state_path)
         .map_err(ClientError::from)?;
 
+    let proof_height = match request.query_height {
+        Some(height) => height,
+        None => ibc_ctx.host_height()?,
+    };
+
+    let proof = ibc_ctx
+        .get_proof(
+            proof_height,
+            &Path::UpgradeClient(UpgradeClientPath::UpgradedClientState(
+                upgrade_revision_height,
+            )),
+        )
+        .ok_or_else(|| {
+            QueryError::proof_not_found(format!(
+                "Proof not found for upgraded client state at: {proof_height:?}"
+            ))
+        })?;
+
     Ok(QueryUpgradedClientStateResponse::new(
         upgraded_client_state.into(),
+        proof,
+        proof_height,
     ))
 }
 
 /// Queries for the upgraded consensus state.
-pub fn query_upgraded_consensus_state<U>(
+pub fn query_upgraded_consensus_state<I, U>(
+    ibc_ctx: &I,
     upgrade_ctx: &U,
-    _request: &QueryUpgradedConsensusStateRequest,
+    request: &QueryUpgradedConsensusStateRequest,
 ) -> Result<QueryUpgradedConsensusStateResponse, QueryError>
 where
+    I: QueryContext,
     U: UpgradeValidationContext,
     UpgradedConsensusStateRef<U>: Into<Any>,
 {
-    let plan = upgrade_ctx.upgrade_plan().map_err(ClientError::from)?;
+    let upgrade_revision_height = match request.upgrade_height {
+        Some(height) => height.revision_height(),
+        None => {
+            upgrade_ctx
+                .upgrade_plan()
+                .map_err(ClientError::from)?
+                .height
+        }
+    };
 
     let upgraded_consensus_state_path =
-        UpgradeClientPath::UpgradedClientConsensusState(plan.height);
+        UpgradeClientPath::UpgradedClientConsensusState(upgrade_revision_height);
+
+    let proof_height = match request.query_height {
+        Some(height) => height,
+        None => ibc_ctx.host_height()?,
+    };
+
+    let proof = ibc_ctx
+        .get_proof(
+            proof_height,
+            &Path::UpgradeClient(UpgradeClientPath::UpgradedClientConsensusState(
+                upgrade_revision_height,
+            )),
+        )
+        .ok_or_else(|| {
+            QueryError::proof_not_found(format!(
+                "Proof not found for upgraded consensus state at: {proof_height:?}"
+            ))
+        })?;
 
     let upgraded_consensus_state = upgrade_ctx
         .upgraded_consensus_state(&upgraded_consensus_state_path)
@@ -230,5 +289,7 @@ where
 
     Ok(QueryUpgradedConsensusStateResponse::new(
         upgraded_consensus_state.into(),
+        proof,
+        proof_height,
     ))
 }

--- a/ibc-query/src/core/client/service.rs
+++ b/ibc-query/src/core/client/service.rs
@@ -124,14 +124,23 @@ where
         &self,
         request: Request<QueryUpgradedClientStateRequest>,
     ) -> Result<Response<QueryUpgradedClientStateResponse>, Status> {
-        query_upgraded_client_state(&self.upgrade_context, &request.into_domain())?.into_response()
+        query_upgraded_client_state(
+            &self.ibc_context,
+            &self.upgrade_context,
+            &request.into_domain(),
+        )?
+        .into_response()
     }
 
     async fn upgraded_consensus_state(
         &self,
         request: Request<QueryUpgradedConsensusStateRequest>,
     ) -> Result<Response<QueryUpgradedConsensusStateResponse>, Status> {
-        query_upgraded_consensus_state(&self.upgrade_context, &request.into_domain())?
-            .into_response()
+        query_upgraded_consensus_state(
+            &self.ibc_context,
+            &self.upgrade_context,
+            &request.into_domain(),
+        )?
+        .into_response()
     }
 }

--- a/ibc-query/src/core/client/types/request.rs
+++ b/ibc-query/src/core/client/types/request.rs
@@ -200,12 +200,16 @@ impl From<RawQueryClientParamsRequest> for QueryClientParamsRequest {
 pub struct QueryUpgradedClientStateRequest {
     /// Height at which the chain is scheduled to halt for upgrade
     pub upgrade_height: Option<Height>,
+    /// The height at which to query the upgraded client state. If not provided,
+    /// the latest height should be used.
+    pub query_height: Option<Height>,
 }
 
 impl From<RawUpgradedClientStateRequest> for QueryUpgradedClientStateRequest {
     fn from(_request: RawUpgradedClientStateRequest) -> Self {
         Self {
             upgrade_height: None,
+            query_height: None,
         }
     }
 }
@@ -218,12 +222,16 @@ impl From<RawUpgradedClientStateRequest> for QueryUpgradedClientStateRequest {
 pub struct QueryUpgradedConsensusStateRequest {
     /// Height at which the chain is scheduled to halt for upgrade.
     pub upgrade_height: Option<Height>,
+    /// The height at which to query the upgraded consensus state. If not
+    /// provided, the latest height should be used.
+    pub query_height: Option<Height>,
 }
 
 impl From<RawUpgradedConsensusStateRequest> for QueryUpgradedConsensusStateRequest {
     fn from(_request: RawUpgradedConsensusStateRequest) -> Self {
         Self {
             upgrade_height: None,
+            query_height: None,
         }
     }
 }

--- a/ibc-query/src/core/client/types/response.rs
+++ b/ibc-query/src/core/client/types/response.rs
@@ -436,28 +436,21 @@ impl From<QueryClientParamsResponse> for RawQueryClientParamsResponse {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct QueryUpgradedClientStateResponse {
+    /// The upgraded client state.
     pub upgraded_client_state: Any,
+    /// The proof of the upgraded client state existence.
+    pub proof: Proof,
+    /// The height at which the proof was retrieved.
+    pub proof_height: Height,
 }
 
 impl QueryUpgradedClientStateResponse {
-    pub fn new(upgraded_client_state: Any) -> Self {
+    pub fn new(upgraded_client_state: Any, proof: Proof, proof_height: Height) -> Self {
         Self {
             upgraded_client_state,
+            proof,
+            proof_height,
         }
-    }
-}
-
-impl Protobuf<RawQueryUpgradedClientStateResponse> for QueryUpgradedClientStateResponse {}
-
-impl TryFrom<RawQueryUpgradedClientStateResponse> for QueryUpgradedClientStateResponse {
-    type Error = QueryError;
-
-    fn try_from(value: RawQueryUpgradedClientStateResponse) -> Result<Self, Self::Error> {
-        Ok(Self {
-            upgraded_client_state: value
-                .upgraded_client_state
-                .ok_or_else(|| QueryError::missing_field("upgraded_client_state"))?,
-        })
     }
 }
 
@@ -474,28 +467,21 @@ impl From<QueryUpgradedClientStateResponse> for RawQueryUpgradedClientStateRespo
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct QueryUpgradedConsensusStateResponse {
+    /// The upgraded consensus state.
     pub upgraded_consensus_state: Any,
+    /// The proof of the upgraded consensus state existence.
+    pub proof: Proof,
+    /// The height at which the proof was retrieved.
+    pub proof_height: Height,
 }
 
 impl QueryUpgradedConsensusStateResponse {
-    pub fn new(upgraded_consensus_state: Any) -> Self {
+    pub fn new(upgraded_consensus_state: Any, proof: Proof, proof_height: Height) -> Self {
         Self {
             upgraded_consensus_state,
+            proof,
+            proof_height,
         }
-    }
-}
-
-impl Protobuf<RawQueryUpgradedConsensusStateResponse> for QueryUpgradedConsensusStateResponse {}
-
-impl TryFrom<RawQueryUpgradedConsensusStateResponse> for QueryUpgradedConsensusStateResponse {
-    type Error = QueryError;
-
-    fn try_from(value: RawQueryUpgradedConsensusStateResponse) -> Result<Self, Self::Error> {
-        Ok(Self {
-            upgraded_consensus_state: value
-                .upgraded_consensus_state
-                .ok_or_else(|| QueryError::missing_field("upgraded_consensus_state"))?,
-        })
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1152

## Remark
Because of changes in this PR,  the domain definition of the `QueryUpgradedClient/ConsensusResponse` will no longer be identical to their proto definitions. Their `TryFrom<raw>` has been removed.
More context [here](https://github.com/cosmos/ibc-rs/tree/main/ibc-query#remarks).
______

### PR author checklist:
- [X] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [X] Linked to GitHub issue.
- [X] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
