### PR TITLE
fix: use `upgrade_ctx` in `upgraded_client/consensus_state` for querying proof

### DIFF
--- a/ibc-query/src/core/client/query.rs
+++ b/ibc-query/src/core/client/query.rs
@@ -21,7 +21,7 @@ use super::{
     QueryUpgradedConsensusStateResponse,
 };
 use crate::core::client::QueryClientStateRequest;
-use crate::core::context::QueryContext;
+use crate::core::context::{ProvableContext, QueryContext};
 use crate::error::QueryError;
 
 /// Queries for the client state of a given client id.
@@ -202,8 +202,8 @@ pub fn query_upgraded_client_state<I, U>(
     request: &QueryUpgradedClientStateRequest,
 ) -> Result<QueryUpgradedClientStateResponse, QueryError>
 where
-    I: QueryContext,
-    U: UpgradeValidationContext,
+    I: ValidationContext,
+    U: UpgradeValidationContext + ProvableContext,
 {
     let upgrade_revision_height = match request.upgrade_height {
         Some(height) => height.revision_height(),
@@ -227,7 +227,7 @@ where
         None => ibc_ctx.host_height()?,
     };
 
-    let proof = ibc_ctx
+    let proof = upgrade_ctx
         .get_proof(
             proof_height,
             &Path::UpgradeClient(upgraded_client_state_path),
@@ -252,8 +252,8 @@ pub fn query_upgraded_consensus_state<I, U>(
     request: &QueryUpgradedConsensusStateRequest,
 ) -> Result<QueryUpgradedConsensusStateResponse, QueryError>
 where
-    I: QueryContext,
-    U: UpgradeValidationContext,
+    I: ValidationContext,
+    U: UpgradeValidationContext + ProvableContext,
     UpgradedConsensusStateRef<U>: Into<Any>,
 {
     let upgrade_revision_height = match request.upgrade_height {
@@ -278,7 +278,7 @@ where
         None => ibc_ctx.host_height()?,
     };
 
-    let proof = ibc_ctx
+    let proof = upgrade_ctx
         .get_proof(
             proof_height,
             &Path::UpgradeClient(upgraded_consensus_state_path),

--- a/ibc-query/src/core/client/service.rs
+++ b/ibc-query/src/core/client/service.rs
@@ -25,7 +25,7 @@ use super::{
     query_consensus_state_heights, query_consensus_states, query_upgraded_client_state,
     query_upgraded_consensus_state,
 };
-use crate::core::context::QueryContext;
+use crate::core::context::{ProvableContext, QueryContext};
 use crate::utils::{IntoDomain, IntoResponse, TryIntoDomain};
 
 // TODO(rano): currently the services don't support pagination, so we return all the results.
@@ -64,7 +64,7 @@ where
 impl<I, U> ClientQuery for ClientQueryService<I, U>
 where
     I: QueryContext + Send + Sync + 'static,
-    U: UpgradeValidationContext + Send + Sync + 'static,
+    U: UpgradeValidationContext + ProvableContext + Send + Sync + 'static,
     ConsensusStateRef<I>: Into<Any>,
     UpgradedConsensusStateRef<U>: Into<Any>,
 {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

In PR #1153, we've made it so that client upgrade query endpoints now give us proof of inclusion along with the response. But when we [ran integration tests in basecoin-rs](https://github.com/informalsystems/basecoin-rs/pull/174), I found out we have to call the `get_proof` on `upgrade_ctx` to get that proof. This PR fixes this issue.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
