### PR TITLE
fix(ics04): packet receive event type identifier

### DIFF
--- a/.changelog/unreleased/bug-fixes/1179-fix-packet-attribute-name.md
+++ b/.changelog/unreleased/bug-fixes/1179-fix-packet-attribute-name.md
@@ -1,1 +1,2 @@
-- [ibc-core-channel] Fix receive_packet to recv_packet to match go implementation
+- [ibc-core-channel] Fix receive_packet to recv_packet to match go
+  implementation ([\#1180](https://github.com/cosmos/ibc-rs/issues/1180))

--- a/.changelog/unreleased/bug-fixes/1179-fix-packet-attribute-name.md
+++ b/.changelog/unreleased/bug-fixes/1179-fix-packet-attribute-name.md
@@ -1,2 +1,2 @@
-- [ibc-core-channel] Fix receive_packet to recv_packet to match go
-  implementation ([\#1180](https://github.com/cosmos/ibc-rs/issues/1180))
+- [ibc-core-channel-types] Make receive packet event type identifier consistent
+  with `ibc-go`. ([\#1180](https://github.com/cosmos/ibc-rs/issues/1180))

--- a/.changelog/unreleased/bug-fixes/1179-fix-packet-attribute-name.md
+++ b/.changelog/unreleased/bug-fixes/1179-fix-packet-attribute-name.md
@@ -1,0 +1,1 @@
+- [ibc-core-channel] Fix receive_packet to recv_packet to match go implementation

--- a/ibc-core/ics04-channel/types/src/events/mod.rs
+++ b/ibc-core/ics04-channel/types/src/events/mod.rs
@@ -32,13 +32,14 @@ const CHANNEL_OPEN_ACK_EVENT: &str = "channel_open_ack";
 const CHANNEL_OPEN_CONFIRM_EVENT: &str = "channel_open_confirm";
 const CHANNEL_CLOSE_INIT_EVENT: &str = "channel_close_init";
 const CHANNEL_CLOSE_CONFIRM_EVENT: &str = "channel_close_confirm";
+const CHANNEL_CLOSED_EVENT: &str = "channel_close";
+
 /// Packet event types
 const SEND_PACKET_EVENT: &str = "send_packet";
 const RECEIVE_PACKET_EVENT: &str = "recv_packet";
 const WRITE_ACK_EVENT: &str = "write_acknowledgement";
 const ACK_PACKET_EVENT: &str = "acknowledge_packet";
 const TIMEOUT_EVENT: &str = "timeout_packet";
-const CHANNEL_CLOSED_EVENT: &str = "channel_close";
 
 #[cfg_attr(
     feature = "parity-scale-codec",

--- a/ibc-core/ics04-channel/types/src/events/mod.rs
+++ b/ibc-core/ics04-channel/types/src/events/mod.rs
@@ -25,7 +25,8 @@ use super::Version;
 use crate::error::ChannelError;
 use crate::packet::Packet;
 
-/// Channel event types
+/// Channel event types corresponding to ibc-go's channel events:
+/// https://github.com/cosmos/ibc-go/blob/c4413c5877f9ef883494da1721cb18caaba7f7f5/modules/core/04-channel/types/events.go#L52-L72
 const CHANNEL_OPEN_INIT_EVENT: &str = "channel_open_init";
 const CHANNEL_OPEN_TRY_EVENT: &str = "channel_open_try";
 const CHANNEL_OPEN_ACK_EVENT: &str = "channel_open_ack";

--- a/ibc-core/ics04-channel/types/src/events/mod.rs
+++ b/ibc-core/ics04-channel/types/src/events/mod.rs
@@ -34,7 +34,7 @@ const CHANNEL_CLOSE_INIT_EVENT: &str = "channel_close_init";
 const CHANNEL_CLOSE_CONFIRM_EVENT: &str = "channel_close_confirm";
 /// Packet event types
 const SEND_PACKET_EVENT: &str = "send_packet";
-const RECEIVE_PACKET_EVENT: &str = "receive_packet";
+const RECEIVE_PACKET_EVENT: &str = "recv_packet";
 const WRITE_ACK_EVENT: &str = "write_acknowledgement";
 const ACK_PACKET_EVENT: &str = "acknowledge_packet";
 const TIMEOUT_EVENT: &str = "timeout_packet";


### PR DESCRIPTION
Closes: #1180

# Description

Followup speaking with @rnbguy about a wrong event name I noticed while looking at optionally using ibc-rs for my Cosmos indexer, so it matches the [go implementation](https://github.com/cosmos/ibc-go/blob/main/modules/core/04-channel/types/events.go#L29)

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
