### PR TITLE
imp(testkit): integration test for packet timeout

### DIFF
--- a/.changelog/unreleased/bug-fixes/1217-fix-packet-timeout-on-closed-channel.md
+++ b/.changelog/unreleased/bug-fixes/1217-fix-packet-timeout-on-closed-channel.md
@@ -1,0 +1,2 @@
+- [ibc-core] Fix proof verification for `PacketTimeout` on a closed channel.
+  ([\#1217](https://github.com/cosmos/ibc-rs/issues/1217))

--- a/docs/architecture/adr-009-revamp-testkit.md
+++ b/docs/architecture/adr-009-revamp-testkit.md
@@ -335,7 +335,7 @@ defined `TestContext` to have a concrete store implementation -
 
 ```rs
 // A mock store type using basecoin-storage implementations.
-pub type MockStore = RevertibleStore<GrowingStore<InMemoryStore>>;
+pub type MockStore = InMemoryStore;
 
 pub type TestContext<H> = StoreGenericTestContext<MockStore, H>;
 ```

--- a/docs/architecture/adr-009-revamp-testkit.md
+++ b/docs/architecture/adr-009-revamp-testkit.md
@@ -304,16 +304,16 @@ The following provides the concrete implementations of the proposed changes:
 #### MockIbcStore
 
 The modified `MockIbcStore` with Merkle store lives at
-[`testapp/ibc/core/types.rs`](https://github.com/cosmos/ibc-rs/blob/feat/refactor-testkit/ibc-testkit/src/testapp/ibc/core/types.rs#L43-L96).
+[`testapp/ibc/core/types.rs`](https://github.com/cosmos/ibc-rs/blob/main/ibc-testkit/src/testapp/ibc/core/types.rs#L43-L96).
 
 #### TestHost
 
 The Rust trait lives at
-[`hosts/mod.rs`](https://github.com/cosmos/ibc-rs/blob/feat/refactor-testkit/ibc-testkit/src/hosts/mod.rs#L27).
+[`hosts/mod.rs`](https://github.com/cosmos/ibc-rs/blob/main/ibc-testkit/src/hosts/mod.rs#L27).
 The `Mock` and `Tendermint` host implementations live in
-[`hosts/mock.rs`](https://github.com/cosmos/ibc-rs/blob/feat/refactor-testkit/ibc-testkit/src/hosts/mock.rs#L30)
+[`hosts/mock.rs`](https://github.com/cosmos/ibc-rs/blob/main/ibc-testkit/src/hosts/mock.rs#L30)
 and
-[`hosts/tendermint.rs`](https://github.com/cosmos/ibc-rs/blob/feat/refactor-testkit/ibc-testkit/src/hosts/tendermint.rs#L42)
+[`hosts/tendermint.rs`](https://github.com/cosmos/ibc-rs/blob/main/ibc-testkit/src/hosts/tendermint.rs#L42)
 respectively.
 
 #### Renaming `MockContext` to `StoreGenericTestContext`
@@ -328,10 +328,10 @@ have `Mock` in their name.
 
 #### StoreGenericTestContext
 
-[`StoreGenericTestContext`](https://github.com/cosmos/ibc-rs/blob/feat/refactor-testkit/ibc-testkit/src/context.rs#L34-L52)
+[`StoreGenericTestContext`](https://github.com/cosmos/ibc-rs/blob/main/ibc-testkit/src/context.rs#L34-L52)
 is actually what is described as `MockContext` in the ADR. For convenience, we
 defined `TestContext` to have a concrete store implementation -
-[`MockStore`](https://github.com/cosmos/ibc-rs/blob/feat/refactor-testkit/ibc-testkit/src/context.rs#L55-L56).
+[`MockStore`](https://github.com/cosmos/ibc-rs/blob/main/ibc-testkit/src/context.rs#L55-L56).
 
 ```rs
 // A mock store type using basecoin-storage implementations.

--- a/ibc-core/ics04-channel/src/handler/timeout_on_close.rs
+++ b/ibc-core/ics04-channel/src/handler/timeout_on_close.rs
@@ -109,7 +109,7 @@ where
         client_state_of_b_on_a
             .verify_membership(
                 prefix_on_b,
-                &msg.proof_unreceived_on_b,
+                &msg.proof_close_on_b,
                 consensus_state_of_b_on_a.root(),
                 Path::ChannelEnd(chan_end_path_on_b),
                 expected_chan_end_on_b.encode_vec(),

--- a/ibc-testkit/Cargo.toml
+++ b/ibc-testkit/Cargo.toml
@@ -36,7 +36,7 @@ ibc-client-tendermint-cw = { workspace = true }
 ibc-query                = { workspace = true }
 
 # basecoin dependencies
-basecoin-store = { git = "https://github.com/informalsystems/basecoin-rs", rev = "8496b3f" }
+basecoin-store = { git = "https://github.com/informalsystems/basecoin-rs", rev = "cc15eb0" }
 
 # cosmos dependencies
 tendermint         = { workspace = true }

--- a/ibc-testkit/Cargo.toml
+++ b/ibc-testkit/Cargo.toml
@@ -36,7 +36,7 @@ ibc-client-tendermint-cw = { workspace = true }
 ibc-query                = { workspace = true }
 
 # basecoin dependencies
-basecoin-store = { git = "https://github.com/informalsystems/basecoin-rs", rev = "cc15eb0" }
+basecoin-store = { git = "https://github.com/informalsystems/basecoin-rs", rev = "2dd5b95" }
 
 # cosmos dependencies
 tendermint         = { workspace = true }

--- a/ibc-testkit/src/context.rs
+++ b/ibc-testkit/src/context.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use core::time::Duration;
 
 use basecoin_store::context::ProvableStore;
-use basecoin_store::impls::{GrowingStore, InMemoryStore, RevertibleStore};
+use basecoin_store::impls::InMemoryStore;
 use ibc::core::channel::types::channel::ChannelEnd;
 use ibc::core::channel::types::commitment::PacketCommitment;
 use ibc::core::client::context::client_state::ClientStateValidation;
@@ -53,7 +53,7 @@ where
 }
 
 /// A mock store type using basecoin-storage implementations.
-pub type MockStore = RevertibleStore<GrowingStore<InMemoryStore>>;
+pub type MockStore = InMemoryStore;
 /// A [`StoreGenericTestContext`] using [`MockStore`].
 pub type TestContext<H> = StoreGenericTestContext<MockStore, H>;
 /// A [`StoreGenericTestContext`] using [`MockStore`] and [`MockHost`].

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -306,9 +306,11 @@ where
         )
     }
 
-    /// Sends a packet from the first context to the second context.
+    /// Sends a packet from the first context to the second context by
+    /// submitting on receive packet on the second context.
+    ///
     /// The IBC packet is created by an IBC application on the first context.
-    pub fn send_packet_on_a(&mut self, packet: Packet, signer: Signer) {
+    pub fn submit_packet_on_b(&mut self, packet: Packet, signer: Signer) {
         let conn_id_on_a = self
             .ctx_a
             .ibc_store()
@@ -347,7 +349,7 @@ where
             .client_id()
             .clone();
 
-        TypedRelayerOps::<A, B>::send_packet_on_a(
+        TypedRelayerOps::<A, B>::submit_packet_on_b(
             &mut self.ctx_a,
             &mut self.ctx_b,
             packet,
@@ -357,9 +359,11 @@ where
         )
     }
 
-    /// Timeouts a packet from the first context to the second context.
+    /// Times out a packet from the first context to the second context by
+    /// waiting for timeout period and then sending timeout packet on first context.
+    ///
     /// The IBC packet is created by an IBC application on the first context.
-    pub fn timeout_packet_on_a(&mut self, packet: Packet, signer: Signer) {
+    pub fn timeout_packet_from_a(&mut self, packet: Packet, signer: Signer) {
         let conn_id_on_a = self
             .ctx_a
             .ibc_store()
@@ -398,7 +402,7 @@ where
             .client_id()
             .clone();
 
-        TypedRelayerOps::<A, B>::timeout_packet_on_a(
+        TypedRelayerOps::<A, B>::timeout_packet_from_a(
             &mut self.ctx_a,
             &mut self.ctx_b,
             packet,
@@ -408,9 +412,11 @@ where
         )
     }
 
-    /// Timeouts a packet from the second context to the first context,
-    /// because of the channel is closed.
-    pub fn timeout_packet_on_channel_close_on_a(&mut self, packet: Packet, signer: Signer) {
+    /// Timeouts a packet from the first context on the second context by closing the
+    /// corresponding channel is closed and then sending a timeout packet on the first context.
+    ///
+    /// The IBC packet is created by an IBC application on the first context.
+    pub fn timeout_packet_from_a_on_channel_close(&mut self, packet: Packet, signer: Signer) {
         let conn_id_on_a = self
             .ctx_a
             .ibc_store()
@@ -449,7 +455,7 @@ where
             .client_id()
             .clone();
 
-        TypedRelayerOps::<A, B>::timeout_packet_on_channel_close_on_a(
+        TypedRelayerOps::<A, B>::timeout_packet_from_a_on_channel_close(
             &mut self.ctx_a,
             &mut self.ctx_b,
             packet,
@@ -459,13 +465,13 @@ where
         )
     }
 
-    /// Submit a packet via
+    /// Submit a
     /// [`DummyTransferModule`](crate::testapp::ibc::applications::transfer::types::DummyTransferModule)
-    /// on the first context.
+    /// packet on the first context.
     ///
     /// Requires `serde` feature because of [`ibc::apps::transfer::handler::send_transfer`].
     #[cfg(feature = "serde")]
-    pub fn send_packet_via_dummy_transfer_module_on_a(
+    pub fn send_dummy_transfer_packet_on_a(
         &mut self,
         chan_id_on_a: ChannelId,
         signer: Signer,

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -459,7 +459,9 @@ where
         )
     }
 
-    /// Submit a packet via [`DummyTransferModule`] on the first context.
+    /// Submit a packet via
+    /// [`DummyTransferModule`](crate::testapp::ibc::applications::transfer::types::DummyTransferModule)
+    /// on the first context.
     ///
     /// Requires `serde` feature because of [`ibc::apps::transfer::handler::send_transfer`].
     #[cfg(feature = "serde")]

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -407,4 +407,55 @@ where
             signer,
         )
     }
+
+    /// Timeouts a packet from the second context to the first context,
+    /// because of the channel is closed.
+    pub fn timeout_packet_on_channel_close_on_a(&mut self, packet: Packet, signer: Signer) {
+        let conn_id_on_a = self
+            .ctx_a
+            .ibc_store()
+            .channel_end(&ChannelEndPath::new(
+                &packet.port_id_on_a,
+                &packet.chan_id_on_a,
+            ))
+            .expect("connection exists")
+            .connection_hops()[0]
+            .clone();
+
+        let conn_id_on_b = self
+            .ctx_b
+            .ibc_store()
+            .channel_end(&ChannelEndPath::new(
+                &packet.port_id_on_b,
+                &packet.chan_id_on_b,
+            ))
+            .expect("connection exists")
+            .connection_hops()[0]
+            .clone();
+
+        let client_id_on_a = self
+            .ctx_a
+            .ibc_store()
+            .connection_end(&conn_id_on_a)
+            .expect("connection exists")
+            .client_id()
+            .clone();
+
+        let client_id_on_b = self
+            .ctx_b
+            .ibc_store()
+            .connection_end(&conn_id_on_b)
+            .expect("connection exists")
+            .client_id()
+            .clone();
+
+        TypedRelayerOps::<A, B>::timeout_packet_on_channel_close_on_a(
+            &mut self.ctx_a,
+            &mut self.ctx_b,
+            packet,
+            client_id_on_a,
+            client_id_on_b,
+            signer,
+        )
+    }
 }

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -356,4 +356,55 @@ where
             signer,
         )
     }
+
+    /// Timeouts a packet from the first context to the second context.
+    /// The IBC packet is created by an IBC application on the first context.
+    pub fn timeout_packet_on_a(&mut self, packet: Packet, signer: Signer) {
+        let conn_id_on_a = self
+            .ctx_a
+            .ibc_store()
+            .channel_end(&ChannelEndPath::new(
+                &packet.port_id_on_a,
+                &packet.chan_id_on_a,
+            ))
+            .expect("connection exists")
+            .connection_hops()[0]
+            .clone();
+
+        let conn_id_on_b = self
+            .ctx_b
+            .ibc_store()
+            .channel_end(&ChannelEndPath::new(
+                &packet.port_id_on_b,
+                &packet.chan_id_on_b,
+            ))
+            .expect("connection exists")
+            .connection_hops()[0]
+            .clone();
+
+        let client_id_on_a = self
+            .ctx_a
+            .ibc_store()
+            .connection_end(&conn_id_on_a)
+            .expect("connection exists")
+            .client_id()
+            .clone();
+
+        let client_id_on_b = self
+            .ctx_b
+            .ibc_store()
+            .connection_end(&conn_id_on_b)
+            .expect("connection exists")
+            .client_id()
+            .clone();
+
+        TypedRelayerOps::<A, B>::timeout_packet_on_a(
+            &mut self.ctx_a,
+            &mut self.ctx_b,
+            packet,
+            client_id_on_a,
+            client_id_on_b,
+            signer,
+        )
+    }
 }

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -1,4 +1,3 @@
-use ibc::apps::transfer::handler::send_transfer;
 use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
 use ibc::apps::transfer::types::packet::PacketData;
 use ibc::core::channel::types::packet::Packet;
@@ -465,6 +464,9 @@ where
     }
 
     /// Submit a packet via [`DummyTransferModule`] on the first context.
+    ///
+    /// Requires `serde` feature because of [`ibc::apps::transfer::handler::send_transfer`].
+    #[cfg(feature = "serde")]
     pub fn send_packet_via_dummy_transfer_module_on_a(
         &mut self,
         chan_id_on_a: ChannelId,
@@ -491,7 +493,7 @@ where
         };
 
         // module creates the send_packet
-        send_transfer(
+        ibc::apps::transfer::handler::send_transfer(
             self.get_ctx_a_mut().ibc_store_mut(),
             &mut DummyTransferModule,
             msg,

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -468,13 +468,13 @@ where
         chan_id_on_a: ChannelId,
         signer: Signer,
     ) -> Packet {
-        use crate::testapp::ibc::applications::transfer::types::DummyTransferModule;
-
         use ibc::apps::transfer::handler::send_transfer;
         use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
         use ibc::apps::transfer::types::packet::PacketData;
         use ibc::core::handler::types::events::IbcEvent;
         use ibc::primitives::Timestamp;
+
+        use crate::testapp::ibc::applications::transfer::types::DummyTransferModule;
 
         // generate packet for DummyTransferModule
         let packet_data = PacketData {

--- a/ibc-testkit/src/relayer/context.rs
+++ b/ibc-testkit/src/relayer/context.rs
@@ -1,17 +1,13 @@
-use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
-use ibc::apps::transfer::types::packet::PacketData;
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::client::context::client_state::ClientStateValidation;
-use ibc::core::handler::types::events::IbcEvent;
 use ibc::core::host::types::identifiers::{ChannelId, ClientId, ConnectionId, PortId};
 use ibc::core::host::types::path::ChannelEndPath;
 use ibc::core::host::ValidationContext;
-use ibc::primitives::{Signer, Timestamp};
+use ibc::primitives::Signer;
 
 use crate::context::TestContext;
 use crate::hosts::{HostClientState, TestHost};
 use crate::relayer::utils::TypedRelayerOps;
-use crate::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use crate::testapp::ibc::core::types::DefaultIbcStore;
 
 /// A relayer context that allows interaction between two [`TestContext`] instances.
@@ -472,6 +468,14 @@ where
         chan_id_on_a: ChannelId,
         signer: Signer,
     ) -> Packet {
+        use crate::testapp::ibc::applications::transfer::types::DummyTransferModule;
+
+        use ibc::apps::transfer::handler::send_transfer;
+        use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
+        use ibc::apps::transfer::types::packet::PacketData;
+        use ibc::core::handler::types::events::IbcEvent;
+        use ibc::primitives::Timestamp;
+
         // generate packet for DummyTransferModule
         let packet_data = PacketData {
             token: "1000uibc".parse().expect("valid prefixed coin"),
@@ -493,7 +497,7 @@ where
         };
 
         // module creates the send_packet
-        ibc::apps::transfer::handler::send_transfer(
+        send_transfer(
             self.get_ctx_a_mut().ibc_store_mut(),
             &mut DummyTransferModule,
             msg,

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -8,9 +8,10 @@ use crate::hosts::{HostClientState, TestHost};
 use crate::relayer::context::RelayerContext;
 use crate::testapp::ibc::core::types::DefaultIbcStore;
 
-/// Integration test for IBC implementation.
-/// This test creates clients, connections, channels, and sends packets between two [`TestHost`]s.
-/// This uses [`DummyTransferModule`] to simulate the transfer of tokens between two contexts.
+/// Integration test for IBC implementation. This test creates clients,
+/// connections, channels, and sends packets between two [`TestHost`]s. This uses
+/// [`DummyTransferModule`](crate::testapp::ibc::applications::transfer::types::DummyTransferModule)
+/// to simulate the transfer of tokens between two contexts.
 pub fn ibc_integration_test<A, B>()
 where
     A: TestHost,

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -1,20 +1,11 @@
-use core::str::FromStr;
-
-use ibc::apps::transfer::handler::send_transfer;
-use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
-use ibc::apps::transfer::types::packet::PacketData;
-use ibc::apps::transfer::types::PrefixedCoin;
-use ibc::core::channel::types::packet::Packet;
 use ibc::core::client::context::client_state::ClientStateValidation;
 use ibc::core::handler::types::events::IbcEvent;
 use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
-use ibc::primitives::Timestamp;
 
 use crate::context::TestContext;
 use crate::fixtures::core::signer::dummy_account_id;
 use crate::hosts::{HostClientState, TestHost};
 use crate::relayer::context::RelayerContext;
-use crate::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use crate::testapp::ibc::core::types::DefaultIbcStore;
 
 /// Integration test for IBC implementation.
@@ -91,64 +82,12 @@ where
     assert_eq!(chan_id_on_a, ChannelId::new(1));
     assert_eq!(chan_id_on_b, ChannelId::new(1));
 
+    // ------------------------
     // send packet from A to B
+    // ------------------------
 
-    // generate packet for DummyTransferModule
-    let packet_data = PacketData {
-        token: PrefixedCoin::from_str("1000uibc").expect("valid prefixed coin"),
-        sender: signer.clone(),
-        receiver: signer.clone(),
-        memo: "sample memo".into(),
-    };
-
-    // packet with ibc metadata
-    // either height timeout or timestamp timeout must be set
-    let msg = MsgTransfer {
-        port_id_on_a: PortId::transfer(),
-        chan_id_on_a: chan_id_on_a.clone(),
-        packet_data,
-        // setting timeout height to 10 blocks from B's current height.
-        timeout_height_on_b: relayer.get_ctx_b().latest_height().add(10).into(),
-        // not setting timeout timestamp.
-        timeout_timestamp_on_b: Timestamp::none(),
-    };
-
-    // module creates the send_packet
-    send_transfer(
-        relayer.get_ctx_a_mut().ibc_store_mut(),
-        &mut DummyTransferModule,
-        msg,
-    )
-    .expect("successfully created send_packet");
-
-    // send_packet wasn't committed, hence produce a block
-    relayer.get_ctx_a_mut().advance_block_height();
-
-    // retrieve the send_packet event
-    let Some(IbcEvent::SendPacket(send_packet_event)) = relayer
-        .get_ctx_a()
-        .ibc_store()
-        .events
-        .lock()
-        .iter()
-        .rev()
-        .nth(2)
-        .cloned()
-    else {
-        panic!("unexpected event")
-    };
-
-    // create the IBC packet type
-    let packet = Packet {
-        port_id_on_a: send_packet_event.port_id_on_a().clone(),
-        chan_id_on_a: send_packet_event.chan_id_on_a().clone(),
-        seq_on_a: *send_packet_event.seq_on_a(),
-        data: send_packet_event.packet_data().to_vec(),
-        timeout_height_on_b: *send_packet_event.timeout_height_on_b(),
-        timeout_timestamp_on_b: *send_packet_event.timeout_timestamp_on_b(),
-        port_id_on_b: send_packet_event.port_id_on_b().clone(),
-        chan_id_on_b: send_packet_event.chan_id_on_b().clone(),
-    };
+    let packet =
+        relayer.send_packet_via_dummy_transfer_module_on_a(chan_id_on_a.clone(), signer.clone());
 
     // continue packet relay starting from recv_packet at B
     relayer.send_packet_on_a(packet, signer.clone());
@@ -165,64 +104,12 @@ where
         panic!("unexpected event")
     };
 
+    // --------------------------
     // timeout packet from A to B
+    // --------------------------
 
-    // generate packet for DummyTransferModule
-    let packet_data = PacketData {
-        token: PrefixedCoin::from_str("1000uibc").expect("valid prefixed coin"),
-        sender: signer.clone(),
-        receiver: signer.clone(),
-        memo: "sample memo".into(),
-    };
-
-    // packet with ibc metadata
-    // either height timeout or timestamp timeout must be set
-    let msg = MsgTransfer {
-        port_id_on_a: PortId::transfer(),
-        chan_id_on_a: chan_id_on_a.clone(),
-        packet_data,
-        // setting timeout height to 10 blocks from B's current height.
-        timeout_height_on_b: relayer.get_ctx_b().latest_height().add(10).into(),
-        // not setting timeout timestamp.
-        timeout_timestamp_on_b: Timestamp::none(),
-    };
-
-    // module creates the send_packet
-    send_transfer(
-        relayer.get_ctx_a_mut().ibc_store_mut(),
-        &mut DummyTransferModule,
-        msg,
-    )
-    .expect("successfully created send_packet");
-
-    // send_packet wasn't committed, hence produce a block
-    relayer.get_ctx_a_mut().advance_block_height();
-
-    // retrieve the send_packet event
-    let Some(IbcEvent::SendPacket(send_packet_event)) = relayer
-        .get_ctx_a()
-        .ibc_store()
-        .events
-        .lock()
-        .iter()
-        .rev()
-        .nth(2)
-        .cloned()
-    else {
-        panic!("unexpected event")
-    };
-
-    // create the IBC packet type
-    let packet = Packet {
-        port_id_on_a: send_packet_event.port_id_on_a().clone(),
-        chan_id_on_a: send_packet_event.chan_id_on_a().clone(),
-        seq_on_a: *send_packet_event.seq_on_a(),
-        data: send_packet_event.packet_data().to_vec(),
-        timeout_height_on_b: *send_packet_event.timeout_height_on_b(),
-        timeout_timestamp_on_b: *send_packet_event.timeout_timestamp_on_b(),
-        port_id_on_b: send_packet_event.port_id_on_b().clone(),
-        chan_id_on_b: send_packet_event.chan_id_on_b().clone(),
-    };
+    let packet =
+        relayer.send_packet_via_dummy_transfer_module_on_a(chan_id_on_a.clone(), signer.clone());
 
     // timeout the packet on A; never relay the packet to B
     relayer.timeout_packet_on_a(packet.clone(), signer.clone());
@@ -239,64 +126,12 @@ where
         panic!("unexpected event")
     };
 
-    // timeout packet from A to B; using close channel
+    // ------------------------------------------------
+    // timeout packet from A to B; using closed channel
+    // ------------------------------------------------
 
-    // generate packet for DummyTransferModule
-    let packet_data = PacketData {
-        token: PrefixedCoin::from_str("1000uibc").expect("valid prefixed coin"),
-        sender: signer.clone(),
-        receiver: signer.clone(),
-        memo: "sample memo".into(),
-    };
-
-    // packet with ibc metadata
-    // either height timeout or timestamp timeout must be set
-    let msg = MsgTransfer {
-        port_id_on_a: PortId::transfer(),
-        chan_id_on_a: chan_id_on_a.clone(),
-        packet_data,
-        // setting timeout height to 10 blocks from B's current height.
-        timeout_height_on_b: relayer.get_ctx_b().latest_height().add(10).into(),
-        // not setting timeout timestamp.
-        timeout_timestamp_on_b: Timestamp::none(),
-    };
-
-    // module creates the send_packet
-    send_transfer(
-        relayer.get_ctx_a_mut().ibc_store_mut(),
-        &mut DummyTransferModule,
-        msg,
-    )
-    .expect("successfully created send_packet");
-
-    // send_packet wasn't committed, hence produce a block
-    relayer.get_ctx_a_mut().advance_block_height();
-
-    // retrieve the send_packet event
-    let Some(IbcEvent::SendPacket(send_packet_event)) = relayer
-        .get_ctx_a()
-        .ibc_store()
-        .events
-        .lock()
-        .iter()
-        .rev()
-        .nth(2)
-        .cloned()
-    else {
-        panic!("unexpected event")
-    };
-
-    // create the IBC packet type
-    let packet = Packet {
-        port_id_on_a: send_packet_event.port_id_on_a().clone(),
-        chan_id_on_a: send_packet_event.chan_id_on_a().clone(),
-        seq_on_a: *send_packet_event.seq_on_a(),
-        data: send_packet_event.packet_data().to_vec(),
-        timeout_height_on_b: *send_packet_event.timeout_height_on_b(),
-        timeout_timestamp_on_b: *send_packet_event.timeout_timestamp_on_b(),
-        port_id_on_b: send_packet_event.port_id_on_b().clone(),
-        chan_id_on_b: send_packet_event.chan_id_on_b().clone(),
-    };
+    let packet =
+        relayer.send_packet_via_dummy_transfer_module_on_a(chan_id_on_a.clone(), signer.clone());
 
     // timeout the packet on A; never relay the packet to B
     relayer.timeout_packet_on_channel_close_on_a(packet.clone(), signer.clone());

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -93,11 +93,11 @@ where
             // send packet from A to B
             // ------------------------
 
-            let packet = relayer
-                .send_packet_via_dummy_transfer_module_on_a(chan_id_on_a.clone(), signer.clone());
+            let packet =
+                relayer.send_dummy_transfer_packet_on_a(chan_id_on_a.clone(), signer.clone());
 
-            // continue packet relay starting from recv_packet at B
-            relayer.send_packet_on_a(packet, signer.clone());
+            // continue packet relay; submitting recv_packet at B
+            relayer.submit_packet_on_b(packet, signer.clone());
 
             // retrieve the ack_packet event
             let Some(IbcEvent::AcknowledgePacket(_)) = relayer
@@ -117,11 +117,11 @@ where
             // timeout packet from A to B
             // --------------------------
 
-            let packet = relayer
-                .send_packet_via_dummy_transfer_module_on_a(chan_id_on_a.clone(), signer.clone());
+            let packet =
+                relayer.send_dummy_transfer_packet_on_a(chan_id_on_a.clone(), signer.clone());
 
-            // timeout the packet on A; never relay the packet to B
-            relayer.timeout_packet_on_a(packet.clone(), signer.clone());
+            // timeout the packet on B; by never submitting the packet to B
+            relayer.timeout_packet_from_a(packet.clone(), signer.clone());
 
             // retrieve the timeout_packet event
             let Some(IbcEvent::TimeoutPacket(_)) = relayer
@@ -141,11 +141,11 @@ where
             // timeout packet from A to B; using closed channel
             // ------------------------------------------------
 
-            let packet = relayer
-                .send_packet_via_dummy_transfer_module_on_a(chan_id_on_a.clone(), signer.clone());
+            let packet =
+                relayer.send_dummy_transfer_packet_on_a(chan_id_on_a.clone(), signer.clone());
 
-            // timeout the packet on A; never relay the packet to B
-            relayer.timeout_packet_on_channel_close_on_a(packet.clone(), signer.clone());
+            // timeout the packet on B; close the corresponding channel
+            relayer.timeout_packet_from_a_on_channel_close(packet.clone(), signer.clone());
 
             // retrieve the timeout_packet event
             let Some(IbcEvent::TimeoutPacket(_)) = relayer

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -151,7 +151,69 @@ where
     };
 
     // continue packet relay starting from recv_packet at B
-    relayer.send_packet_on_a(packet, signer);
+    relayer.send_packet_on_a(packet, signer.clone());
+
+    // timeout packet from A to B
+
+    // generate packet for DummyTransferModule
+    let packet_data = PacketData {
+        token: PrefixedCoin::from_str("1000uibc").expect("valid prefixed coin"),
+        sender: signer.clone(),
+        receiver: signer.clone(),
+        memo: "sample memo".into(),
+    };
+
+    // packet with ibc metadata
+    // either height timeout or timestamp timeout must be set
+    let msg = MsgTransfer {
+        port_id_on_a: PortId::transfer(),
+        chan_id_on_a: chan_id_on_a.clone(),
+        packet_data,
+        // setting timeout height to 10 blocks from B's current height.
+        timeout_height_on_b: relayer.get_ctx_b().latest_height().add(10).into(),
+        // not setting timeout timestamp.
+        timeout_timestamp_on_b: Timestamp::none(),
+    };
+
+    // module creates the send_packet
+    send_transfer(
+        relayer.get_ctx_a_mut().ibc_store_mut(),
+        &mut DummyTransferModule,
+        msg,
+    )
+    .expect("successfully created send_packet");
+
+    // send_packet wasn't committed, hence produce a block
+    relayer.get_ctx_a_mut().advance_block_height();
+
+    // retrieve the send_packet event
+    let Some(IbcEvent::SendPacket(send_packet_event)) = relayer
+        .get_ctx_a()
+        .ibc_store()
+        .events
+        .lock()
+        .iter()
+        .rev()
+        .nth(2)
+        .cloned()
+    else {
+        panic!("unexpected event")
+    };
+
+    // create the IBC packet type
+    let packet = Packet {
+        port_id_on_a: send_packet_event.port_id_on_a().clone(),
+        chan_id_on_a: send_packet_event.chan_id_on_a().clone(),
+        seq_on_a: *send_packet_event.seq_on_a(),
+        data: send_packet_event.packet_data().to_vec(),
+        timeout_height_on_b: *send_packet_event.timeout_height_on_b(),
+        timeout_timestamp_on_b: *send_packet_event.timeout_timestamp_on_b(),
+        port_id_on_b: send_packet_event.port_id_on_b().clone(),
+        chan_id_on_b: send_packet_event.chan_id_on_b().clone(),
+    };
+
+    // timeout the packet on A; never relay the packet to B
+    relayer.timeout_packet_on_a(packet.clone(), signer.clone());
 }
 
 #[cfg(test)]

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -1,5 +1,4 @@
 use ibc::core::client::context::client_state::ClientStateValidation;
-use ibc::core::handler::types::events::IbcEvent;
 use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
 
 use crate::context::TestContext;
@@ -87,6 +86,8 @@ where
 
     #[cfg(feature = "serde")]
     {
+        use ibc::core::handler::types::events::IbcEvent;
+
         {
             // ------------------------
             // send packet from A to B

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -214,6 +214,68 @@ where
 
     // timeout the packet on A; never relay the packet to B
     relayer.timeout_packet_on_a(packet.clone(), signer.clone());
+
+    // timeout packet from A to B; using close channel
+
+    // generate packet for DummyTransferModule
+    let packet_data = PacketData {
+        token: PrefixedCoin::from_str("1000uibc").expect("valid prefixed coin"),
+        sender: signer.clone(),
+        receiver: signer.clone(),
+        memo: "sample memo".into(),
+    };
+
+    // packet with ibc metadata
+    // either height timeout or timestamp timeout must be set
+    let msg = MsgTransfer {
+        port_id_on_a: PortId::transfer(),
+        chan_id_on_a: chan_id_on_a.clone(),
+        packet_data,
+        // setting timeout height to 10 blocks from B's current height.
+        timeout_height_on_b: relayer.get_ctx_b().latest_height().add(10).into(),
+        // not setting timeout timestamp.
+        timeout_timestamp_on_b: Timestamp::none(),
+    };
+
+    // module creates the send_packet
+    send_transfer(
+        relayer.get_ctx_a_mut().ibc_store_mut(),
+        &mut DummyTransferModule,
+        msg,
+    )
+    .expect("successfully created send_packet");
+
+    // send_packet wasn't committed, hence produce a block
+    relayer.get_ctx_a_mut().advance_block_height();
+
+    // retrieve the send_packet event
+    let Some(IbcEvent::SendPacket(send_packet_event)) = relayer
+        .get_ctx_a()
+        .ibc_store()
+        .events
+        .lock()
+        .iter()
+        .rev()
+        .nth(2)
+        .cloned()
+    else {
+        panic!("unexpected event")
+    };
+
+    // create the IBC packet type
+    let packet = Packet {
+        port_id_on_a: send_packet_event.port_id_on_a().clone(),
+        chan_id_on_a: send_packet_event.chan_id_on_a().clone(),
+        seq_on_a: *send_packet_event.seq_on_a(),
+        data: send_packet_event.packet_data().to_vec(),
+        timeout_height_on_b: *send_packet_event.timeout_height_on_b(),
+        timeout_timestamp_on_b: *send_packet_event.timeout_timestamp_on_b(),
+        port_id_on_b: send_packet_event.port_id_on_b().clone(),
+        chan_id_on_b: send_packet_event.chan_id_on_b().clone(),
+    };
+
+    // timeout the packet on A; never relay the packet to B
+    relayer.timeout_packet_on_channel_close_on_a(packet.clone(), signer.clone());
 }
 
 #[cfg(test)]

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -153,6 +153,18 @@ where
     // continue packet relay starting from recv_packet at B
     relayer.send_packet_on_a(packet, signer.clone());
 
+    // retrieve the ack_packet event
+    let Some(IbcEvent::AcknowledgePacket(_)) = relayer
+        .get_ctx_a()
+        .ibc_store()
+        .events
+        .lock()
+        .last()
+        .cloned()
+    else {
+        panic!("unexpected event")
+    };
+
     // timeout packet from A to B
 
     // generate packet for DummyTransferModule
@@ -215,6 +227,18 @@ where
     // timeout the packet on A; never relay the packet to B
     relayer.timeout_packet_on_a(packet.clone(), signer.clone());
 
+    // retrieve the timeout_packet event
+    let Some(IbcEvent::TimeoutPacket(_)) = relayer
+        .get_ctx_a()
+        .ibc_store()
+        .events
+        .lock()
+        .last()
+        .cloned()
+    else {
+        panic!("unexpected event")
+    };
+
     // timeout packet from A to B; using close channel
 
     // generate packet for DummyTransferModule
@@ -276,6 +300,18 @@ where
 
     // timeout the packet on A; never relay the packet to B
     relayer.timeout_packet_on_channel_close_on_a(packet.clone(), signer.clone());
+
+    // retrieve the timeout_packet event
+    let Some(IbcEvent::TimeoutPacket(_)) = relayer
+        .get_ctx_a()
+        .ibc_store()
+        .events
+        .lock()
+        .last()
+        .cloned()
+    else {
+        panic!("unexpected event")
+    };
 }
 
 #[cfg(test)]

--- a/ibc-testkit/src/relayer/mod.rs
+++ b/ibc-testkit/src/relayer/mod.rs
@@ -1,7 +1,4 @@
 pub mod context;
 pub mod error;
-pub mod utils;
-
-// `ibc::apps::transfer::handler::send_transfer` requires `serde`
-#[cfg(feature = "serde")]
 pub mod integration;
+pub mod utils;

--- a/ibc-testkit/src/relayer/utils.rs
+++ b/ibc-testkit/src/relayer/utils.rs
@@ -1,6 +1,7 @@
 use alloc::string::String;
 use core::marker::PhantomData;
 use core::time::Duration;
+use ibc::core::channel::types::timeout::TimeoutHeight;
 
 use ibc::core::channel::types::acknowledgement::Acknowledgement;
 use ibc::core::channel::types::channel::Order;
@@ -991,6 +992,47 @@ where
             signer.clone(),
         );
 
+        TypedRelayerOps::<B, A>::update_client_on_a_with_sync(
+            ctx_b,
+            ctx_a,
+            client_id_on_b,
+            signer.clone(),
+        );
+    }
+
+    /// Times out a packet from an IBC application on `A` to `B` using the IBC packet relay protocol.
+    pub fn timeout_packet_on_a(
+        ctx_a: &mut TestContext<A>,
+        ctx_b: &mut TestContext<B>,
+        packet: Packet,
+        client_id_on_a: ClientId,
+        client_id_on_b: ClientId,
+        signer: Signer,
+    ) {
+        // packet is passed from module
+
+        let TimeoutHeight::At(timeout_height) = packet.timeout_height_on_b else {
+            panic!("timeout height is set")
+        };
+
+        // progress `B`'s block height to the timeout height.
+        // packet is timed out at the timeout height + 1
+        while ctx_b.latest_height() <= timeout_height {
+            ctx_b.advance_block_height();
+        }
+
+        // update client on `A` with the latest header from `B`.
+        TypedRelayerOps::<A, B>::update_client_on_a_with_sync(
+            ctx_a,
+            ctx_b,
+            client_id_on_a.clone(),
+            signer.clone(),
+        );
+
+        // timeout the packet on `A`.
+        TypedRelayerOps::<A, B>::packet_timeout_on_a(ctx_a, ctx_b, packet.clone(), signer.clone());
+
+        // `A` has progressed; update client on `B` with the latest header from `A`.
         TypedRelayerOps::<B, A>::update_client_on_a_with_sync(
             ctx_b,
             ctx_a,

--- a/ibc-testkit/src/relayer/utils.rs
+++ b/ibc-testkit/src/relayer/utils.rs
@@ -957,7 +957,7 @@ where
     }
 
     /// Sends a packet from an IBC application on `A` to `B` using the IBC packet relay protocol.
-    pub fn send_packet_on_a(
+    pub fn submit_packet_on_b(
         ctx_a: &mut TestContext<A>,
         ctx_b: &mut TestContext<B>,
         packet: Packet,
@@ -1000,8 +1000,8 @@ where
         );
     }
 
-    /// Times out a packet from an IBC application on `A` to `B` using the IBC packet relay protocol.
-    pub fn timeout_packet_on_a(
+    /// Times out a packet from an IBC application on `A` to `B` after waiting timeout period.
+    pub fn timeout_packet_from_a(
         ctx_a: &mut TestContext<A>,
         ctx_b: &mut TestContext<B>,
         packet: Packet,
@@ -1042,7 +1042,7 @@ where
     }
 
     /// Times out a packet from an IBC application on `A` to `B` after closing the channel.
-    pub fn timeout_packet_on_channel_close_on_a(
+    pub fn timeout_packet_from_a_on_channel_close(
         ctx_a: &mut TestContext<A>,
         ctx_b: &mut TestContext<B>,
         packet: Packet,

--- a/ibc-testkit/src/relayer/utils.rs
+++ b/ibc-testkit/src/relayer/utils.rs
@@ -950,7 +950,7 @@ where
 
         ctx_a.deliver(msg_for_a).expect("success");
 
-        let Some(IbcEvent::ChannelClosed(_)) = ctx_a.ibc_store().events.lock().last().cloned()
+        let Some(IbcEvent::TimeoutPacket(_)) = ctx_a.ibc_store().events.lock().last().cloned()
         else {
             panic!("unexpected event")
         };

--- a/ibc-testkit/src/relayer/utils.rs
+++ b/ibc-testkit/src/relayer/utils.rs
@@ -1,7 +1,6 @@
 use alloc::string::String;
 use core::marker::PhantomData;
 use core::time::Duration;
-use ibc::core::channel::types::timeout::TimeoutHeight;
 
 use ibc::core::channel::types::acknowledgement::Acknowledgement;
 use ibc::core::channel::types::channel::Order;
@@ -11,6 +10,7 @@ use ibc::core::channel::types::msgs::{
     MsgTimeoutOnClose, PacketMsg,
 };
 use ibc::core::channel::types::packet::Packet;
+use ibc::core::channel::types::timeout::TimeoutHeight;
 use ibc::core::channel::types::Version as ChannelVersion;
 use ibc::core::client::context::client_state::ClientStateValidation;
 use ibc::core::client::context::ClientValidationContext;

--- a/ibc-testkit/src/relayer/utils.rs
+++ b/ibc-testkit/src/relayer/utils.rs
@@ -1040,4 +1040,47 @@ where
             signer.clone(),
         );
     }
+
+    /// Times out a packet from an IBC application on `A` to `B` after closing the channel.
+    pub fn timeout_packet_on_channel_close_on_a(
+        ctx_a: &mut TestContext<A>,
+        ctx_b: &mut TestContext<B>,
+        packet: Packet,
+        client_id_on_a: ClientId,
+        client_id_on_b: ClientId,
+        signer: Signer,
+    ) {
+        // packet is passed from module
+
+        // close the channel on `A`.
+        TypedRelayerOps::<A, B>::close_channel_on_a(
+            ctx_a,
+            ctx_b,
+            client_id_on_a.clone(),
+            packet.chan_id_on_a.clone(),
+            packet.port_id_on_a.clone(),
+            client_id_on_b.clone(),
+            packet.chan_id_on_b.clone(),
+            packet.port_id_on_b.clone(),
+            signer.clone(),
+        );
+
+        // timeout the packet on `A`.
+        TypedRelayerOps::<A, B>::packet_timeout_on_close_on_a(
+            ctx_a,
+            ctx_b,
+            packet.clone(),
+            packet.chan_id_on_b.clone(),
+            packet.port_id_on_b.clone(),
+            signer.clone(),
+        );
+
+        // `A` has progressed; update client on `B` with the latest header from `A`.
+        TypedRelayerOps::<B, A>::update_client_on_a_with_sync(
+            ctx_b,
+            ctx_a,
+            client_id_on_b,
+            signer.clone(),
+        );
+    }
 }

--- a/ibc-testkit/tests/core/ics02_client/recover_client.rs
+++ b/ibc-testkit/tests/core/ics02_client/recover_client.rs
@@ -284,6 +284,6 @@ fn test_recover_client_with_matching_heights() {
         signer,
     };
 
-    dbg!(recover_client::validate(ctx.ibc_store(), msg))
+    recover_client::validate(ctx.ibc_store(), msg)
         .expect_err("expected client recovery validation to fail");
 }

--- a/ibc-testkit/tests/core/ics03_connection/conn_open_ack.rs
+++ b/ibc-testkit/tests/core/ics03_connection/conn_open_ack.rs
@@ -1,6 +1,5 @@
 use core::str::FromStr;
 
-use basecoin_store::impls::{GrowingStore, InMemoryStore, RevertibleStore};
 use ibc::core::client::types::Height;
 use ibc::core::commitment_types::commitment::CommitmentPrefix;
 use ibc::core::connection::types::error::ConnectionError;
@@ -20,7 +19,7 @@ use ibc_testkit::fixtures::core::context::TestContextConfig;
 use ibc_testkit::fixtures::{Expect, Fixture};
 use ibc_testkit::hosts::MockHost;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
-use ibc_testkit::testapp::ibc::core::types::{LightClientState, MockIbcStore};
+use ibc_testkit::testapp::ibc::core::types::{DefaultIbcStore, LightClientState};
 use test_log::test;
 
 enum Ctx {
@@ -168,7 +167,7 @@ fn conn_open_ack_execute(fxt: &mut Fixture<MsgConnectionOpenAck>, expect: Expect
             let IbcEvent::OpenAckConnection(conn_open_try_event) = event else {
                 unreachable!()
             };
-            let conn_end = <MockIbcStore<RevertibleStore<GrowingStore<InMemoryStore>>> as ValidationContext>::connection_end(
+            let conn_end = <DefaultIbcStore as ValidationContext>::connection_end(
                 &fxt.ctx,
                 conn_open_try_event.conn_id_on_a(),
             )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #398
Closes: #1217

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Integration tests for:
- [x] Packet timeout.
- [x] Packet timeout on channel close.

Also, [reproduces the bug](https://github.com/cosmos/ibc-rs/actions/runs/8990023752/job/24694412763?pr=1215#step:5:1301) from #1217.

The latest branch from `basecoin-rs` now has non-membership proofs for its IAVL tree.

This PR adds a packet timeout scenario to our existing integration test. This exercises non-membership proof for the Tendermint light client.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
