### PR TITLE
Release v0.53.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,16 @@ test: ## Run tests with all features and without default features.
 	cargo test --all-targets --no-default-features
 
 check-release: ## Check that the release build compiles.
-	cargo release --workspace --no-push --no-tag --no-publish --exclude ibc-derive --exclude ibc-client-tendermint-cw
+	cargo release --workspace --no-push --no-tag --no-publish \
+		--exclude ibc-derive \
+		--exclude ibc-primitives \
+		--exclude ibc-client-tendermint-cw
 
 release: ## Perform an actual release and publishes to crates.io.
-	cargo release --workspace --no-push --no-tag --exclude ibc-derive --exclude ibc-client-tendermint-cw --allow-branch HEAD --execute
+	cargo release --workspace --no-push --no-tag --allow-branch HEAD --execute \
+		--exclude ibc-derive \
+		--exclude ibc-primitives \
+		--exclude ibc-client-tendermint-cw
 
 build-tendermint-cw: ## Build the WASM file for the ICS-07 Tendermint light client.
 	@echo "Building the WASM file for the ICS-07 Tendermint light client"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test: ## Run tests with all features and without default features.
 	cargo test --all-targets --no-default-features
 
 check-release: ## Check that the release build compiles.
-	cargo release --workspace --no-push --no-tag --no-publish \
+	cargo release --workspace --no-push --no-tag \
 		--exclude ibc-derive \
 		--exclude ibc-primitives \
 		--exclude ibc-client-tendermint-cw

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,7 +24,7 @@ Our release process is as follows:
 4. Bump the versions of all crates to the new version in their Cargo.toml and in
    the root `Cargo.toml` as well, and push these changes to the release PR.
    - If you released a new version of `ibc-derive` in step 3, make sure to
-        update that dependency.
+     update that dependency.
    - Verify that there is no dev-dependency among the workspace crates. This is
      important, as `cargo-release` ignores dev-dependency edges. You may use
      `cargo-depgraph`:
@@ -38,39 +38,43 @@ Our release process is as follows:
      because of release order complicacy (except maybe inside `ibc-testkit`, as
      it is the top crate that depends on `ibc` crate and no other crate depends
      on it).
-   - In order to resolve such a situation, the dev dependencies other than `ibc-testkit`
-     can be manually released to crates.io first so that the subsequent crates that
-     depend on them can then be released via the release process. For instructions
-     on how to release a crate on crates.io, refer [here](https://doc.rust-lang.org/cargo/reference/publishing.html).
+   - In order to resolve such a situation, the dev dependencies other than
+     `ibc-testkit` can be manually released to crates.io first so that the
+     subsequent crates that depend on them can then be released via the release
+     process. For instructions on how to release a crate on crates.io, refer
+     [here](https://doc.rust-lang.org/cargo/reference/publishing.html).
 5. Run `cargo doc -p ibc --all-features --open` locally to double-check that all
    the documentation compiles and seems up-to-date and coherent. Fix any
    potential issues here and push them to the release PR.
 6. Mark the PR as **Ready for Review** and incorporate feedback on the release.
    Once approved, merge the PR.
-7. Checkout the `main` and pull it with `git checkout main && git pull origin main`.
+7. Checkout the `main` and pull it with
+   `git checkout main && git pull origin main`.
 8. Create a signed tag `git tag -s -a vX.Y.Z`. In the tag message, write the
    version and the link to the corresponding section of the changelog. Then push
    the tag to GitHub with `git push origin vX.Y.Z`.
    - The [release workflow][release.yaml] will run the `cargo release --execute`
-   command in a CI worker.
-9. If some crates have not been released, check the cause of the failure and
-   act accordingly:
-    1. In case of intermittent problems with the registry, try `cargo release`
+     command in a CI worker.
+9. If some crates have not been released, check the cause of the failure and act
+   accordingly:
+   1. In case of intermittent problems with the registry, try `cargo release`
       locally to publish any missing crates from this release. This step
       requires the appropriate privileges to push crates to [crates.io].
-    2. If there is any new crate published locally, add
+   2. If there is any new crate published locally, add
       [ibcbot](https://crates.io/users/ibcbot) to its owners list.
-    3. In case problems arise from the source files, fix them, bump a new
-      patch version (e.g. `v0.48.1`) and repeat the process with its
-      corresponding new tag.
-10. Once the tag is pushed, wait for the CI bot to create a GitHub release,
-    then update the release description and append:
-   `[📖CHANGELOG](https://github.com/cosmos/ibc-rs/blob/main/CHANGELOG.md#vXYZ)`
+   3. In case problems arise from the source files, fix them, bump a new patch
+      version (e.g. `v0.48.1`) and repeat the process with its corresponding new
+      tag.
+10. Once the tag is pushed, wait for the CI bot to create a GitHub release, then
+    update the release description and append:
+    `[📖CHANGELOG](https://github.com/cosmos/ibc-rs/blob/main/CHANGELOG.md#vXYZ)`
 
 ### Communications (non-technical) release pipeline
 
-- Notify the communications team about the pending release and prepare an announcement.
-- Coordinate with other organizations that are active in IBC development (e.g., Interchain) and keep them in the loop.
+- Notify the communications team about the pending release and prepare an
+  announcement.
+- Coordinate with other organizations that are active in IBC development (e.g.,
+  Interchain) and keep them in the loop.
 
 All done! 🎉
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,14 +43,16 @@ Our release process is as follows:
      subsequent crates that depend on them can then be released via the release
      process. For instructions on how to release a crate on crates.io, refer
      [here](https://doc.rust-lang.org/cargo/reference/publishing.html).
-5. Beware of [crates-io rate limit][cargo-release-rate-limit]. For publishing
-   new crates it is 5 and for publishing existing crates it is 30. But the
-   number of our crates has reached 31. So we publish a leaf crate,
-   `ibc-primitives`, by hand and release the rest of the 30 crates via CI.
-   - Release `ibc-primitives` now by running:
+5. Beware of [crates-io rate limit][cargo-release-rate-limit]. It is 5 for
+   publishing new crates and 30 for publishing existing crates. But the number
+   of our crates has reached 31. So we publish a leaf crate, `ibc-primitives`
+   manually and release the rest of the 30 crates via CI.
+   - Release `ibc-primitives` by running:
    ```sh
    cargo release -p ibc-primitives --no-push --no-tag --allow-branch main --execute
    ```
+   - Validate the number of crates that need to be released via CI, it can not
+     be more than 30.
    - There should be a 10 minutes delay between the release of `ibc-primitives`
      and the release of the rest of the crates on CI.
    - If new crates are added, we need to recompute the set of crates that we

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,29 +43,41 @@ Our release process is as follows:
      subsequent crates that depend on them can then be released via the release
      process. For instructions on how to release a crate on crates.io, refer
      [here](https://doc.rust-lang.org/cargo/reference/publishing.html).
-5. Run `cargo doc -p ibc --all-features --open` locally to double-check that all
+5. Beware of [crates-io rate limit][cargo-release-rate-limit]. For publishing
+   new crates it is 5 and for publishing existing crates it is 30. But the
+   number of our crates has reached 31. So we publish a leaf crate,
+   `ibc-primitives`, by hand and release the rest of the 30 crates via CI.
+   - Release `ibc-primitives` now by running:
+   ```sh
+   cargo release -p ibc-primitives --no-push --no-tag --allow-branch main --execute
+   ```
+   - There should be a 10 minutes delay between the release of `ibc-primitives`
+     and the release of the rest of the crates on CI.
+   - If new crates are added, we need to recompute the set of crates that we
+     want to release via CI. The rest must be released manually.
+6. Run `cargo doc -p ibc --all-features --open` locally to double-check that all
    the documentation compiles and seems up-to-date and coherent. Fix any
    potential issues here and push them to the release PR.
-6. Mark the PR as **Ready for Review** and incorporate feedback on the release.
+7. Mark the PR as **Ready for Review** and incorporate feedback on the release.
    Once approved, merge the PR.
-7. Checkout the `main` and pull it with
+8. Checkout the `main` and pull it with
    `git checkout main && git pull origin main`.
-8. Create a signed tag `git tag -s -a vX.Y.Z`. In the tag message, write the
+9. Create a signed tag `git tag -s -a vX.Y.Z`. In the tag message, write the
    version and the link to the corresponding section of the changelog. Then push
    the tag to GitHub with `git push origin vX.Y.Z`.
    - The [release workflow][release.yaml] will run the `cargo release --execute`
      command in a CI worker.
-9. If some crates have not been released, check the cause of the failure and act
-   accordingly:
-   1. In case of intermittent problems with the registry, try `cargo release`
-      locally to publish any missing crates from this release. This step
-      requires the appropriate privileges to push crates to [crates.io].
-   2. If there is any new crate published locally, add
-      [ibcbot](https://crates.io/users/ibcbot) to its owners list.
-   3. In case problems arise from the source files, fix them, bump a new patch
-      version (e.g. `v0.48.1`) and repeat the process with its corresponding new
-      tag.
-10. Once the tag is pushed, wait for the CI bot to create a GitHub release, then
+10. If some crates have not been released, check the cause of the failure and
+    act accordingly:
+    1. In case of intermittent problems with the registry, try `cargo release`
+       locally to publish any missing crates from this release. This step
+       requires the appropriate privileges to push crates to [crates.io].
+    2. If there is any new crate published locally, add
+       [ibcbot](https://crates.io/users/ibcbot) to its owners list.
+    3. In case problems arise from the source files, fix them, bump a new patch
+       version (e.g. `v0.48.1`) and repeat the process with its corresponding
+       new tag.
+11. Once the tag is pushed, wait for the CI bot to create a GitHub release, then
     update the release description and append:
     `[📖CHANGELOG](https://github.com/cosmos/ibc-rs/blob/main/CHANGELOG.md#vXYZ)`
 
@@ -80,3 +92,4 @@ All done! 🎉
 
 [crates.io]: https://crates.io
 [release.yaml]: https://github.com/cosmos/ibc-rs/blob/main/.github/workflows/release.yaml
+[cargo-release-rate-limit]: https://github.com/crate-ci/cargo-release/blob/4b09269/src/steps/mod.rs#L214-L268


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This is the retry of the last failed release.

Looks like, the older `cargo release` dry-run test command was ignoring the publication errors because of `--no-publish` flag. This prevented catching the errors in the release PR. I removed this flag in this PR.

Note: I have already released [ibc-primitives](https://crates.io/crates/ibc-primitives) at v0.53.0.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
