### PR TITLE
ci(deps): upgrade `checkout` action to version with `node20`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,7 @@ updates:
       - dependency-name: "ibc*"
       - dependency-name: "cosmwasm*"
       - dependency-name: "cw*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache cargo bin
         uses: actions/cache@v1
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -41,7 +41,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -9,7 +9,7 @@ jobs:
   md-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
         with:

--- a/.github/workflows/no-std.yaml
+++ b/.github/workflows/no-std.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Check no_std panic conflict
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -42,7 +42,7 @@ jobs:
     name: Check no_std substrate support
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2024-02-24

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -51,7 +51,7 @@ jobs:
   nightly_fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly # Since fmt uses unstable features for organizing imports
@@ -64,7 +64,7 @@ jobs:
   clippy_all_features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -77,7 +77,7 @@ jobs:
   clippy_no_default_features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -90,7 +90,7 @@ jobs:
   doc_all_features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -102,7 +102,7 @@ jobs:
   doc_no_default_features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
@@ -146,7 +146,7 @@ jobs:
           ]
     runs-on: ${{ matrix.param.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Download cargo-msrv
         uses: dsaltares/fetch-gh-release-asset@master


### PR DESCRIPTION
Node16 is deprecated and Actions using it will stop working 3rd of June
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

See example warning in https://github.com/cosmos/ibc-rs/actions/runs/9069561778