### PR TITLE
Add missing trait derivations

### DIFF
--- a/ibc-clients/ics07-tendermint/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state.rs
@@ -31,6 +31,18 @@ pub use validation::*;
 /// `ibc-client-tendermint-types` crate. This wrapper exists so that we can
 /// bypass Rust's orphan rules and implement traits from
 /// `ibc::core::client::context` on the `ClientState` type.
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, derive_more::From)]
 pub struct ClientState(ClientStateType);

--- a/ibc-clients/ics07-tendermint/src/consensus_state.rs
+++ b/ibc-clients/ics07-tendermint/src/consensus_state.rs
@@ -21,6 +21,18 @@ use tendermint::{Hash, Time};
 /// `ibc-client-tendermint-types` crate. This wrapper exists so that we can
 /// bypass Rust's orphan rules and implement traits from
 /// `ibc::core::client::context` on the `ConsensusState` type.
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, derive_more::From)]
 pub struct ConsensusState(ConsensusStateType);

--- a/ibc-clients/ics07-tendermint/types/src/client_state.rs
+++ b/ibc-clients/ics07-tendermint/types/src/client_state.rs
@@ -24,6 +24,18 @@ use crate::trust_threshold::TrustThreshold;
 
 pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
 
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AllowUpdate {
@@ -32,6 +44,18 @@ pub struct AllowUpdate {
 }
 
 /// Defines data structure for Tendermint client state.
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ClientState {

--- a/ibc-clients/ics07-tendermint/types/src/consensus_state.rs
+++ b/ibc-clients/ics07-tendermint/types/src/consensus_state.rs
@@ -18,6 +18,18 @@ pub const TENDERMINT_CONSENSUS_STATE_TYPE_URL: &str =
     "/ibc.lightclients.tendermint.v1.ConsensusState";
 
 /// Defines the Tendermint light client's consensus state
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConsensusState {

--- a/ibc-clients/ics07-tendermint/types/src/header.rs
+++ b/ibc-clients/ics07-tendermint/types/src/header.rs
@@ -24,6 +24,18 @@ use crate::error::Error;
 
 pub const TENDERMINT_HEADER_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.Header";
 
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Tendermint consensus header
 #[derive(Clone, PartialEq, Eq)]

--- a/ibc-clients/ics07-tendermint/types/src/misbehaviour.rs
+++ b/ibc-clients/ics07-tendermint/types/src/misbehaviour.rs
@@ -15,6 +15,18 @@ use crate::header::Header;
 pub const TENDERMINT_MISBEHAVIOUR_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.Misbehaviour";
 
 /// Tendermint light client's misbehaviour type
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Misbehaviour {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

The `ibc-client-tendermint` crate has two optional features: `borsh` and `parity-scale-codec`, which are supposed to derive relevant traits. However, these traits are not actually derived. This PR adds the missing derivations.

______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
