### PR TITLE
feat(ibc-core): port capability

### DIFF
--- a/ibc-apps/ics20-transfer/src/context.rs
+++ b/ibc-apps/ics20-transfer/src/context.rs
@@ -5,9 +5,10 @@ use ibc_app_transfer_types::{Memo, PrefixedCoin, PrefixedDenom};
 use ibc_core::host::types::identifiers::{ChannelId, PortId};
 use ibc_core::primitives::prelude::*;
 use ibc_core::primitives::Signer;
+use ibc_core::router::module::Module;
 
 /// Methods required in token transfer validation, to be implemented by the host
-pub trait TokenTransferValidationContext {
+pub trait TokenTransferValidationContext: Module {
     type AccountId: TryFrom<Signer>;
 
     /// get_port returns the portID for the transfer module.

--- a/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
+++ b/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
@@ -95,7 +95,7 @@ where
         }
     };
 
-    send_packet_validate(send_packet_ctx_a, &packet)?;
+    send_packet_validate(send_packet_ctx_a, token_ctx_a, &packet)?;
 
     Ok(())
 }
@@ -170,7 +170,7 @@ where
         }
     };
 
-    send_packet_execute(send_packet_ctx_a, packet)?;
+    send_packet_execute(send_packet_ctx_a, token_ctx_a, packet)?;
 
     {
         send_packet_ctx_a.log_message(format!(

--- a/ibc-apps/ics721-nft-transfer/src/context.rs
+++ b/ibc-apps/ics721-nft-transfer/src/context.rs
@@ -3,6 +3,7 @@
 use ibc_core::host::types::identifiers::{ChannelId, PortId};
 use ibc_core::primitives::prelude::*;
 use ibc_core::primitives::Signer;
+use ibc_core::router::module::Module;
 
 use crate::types::error::NftTransferError;
 use crate::types::{
@@ -35,7 +36,7 @@ pub trait NftClassContext {
 }
 
 /// Read-only methods required in NFT transfer validation context.
-pub trait NftTransferValidationContext {
+pub trait NftTransferValidationContext: Module {
     type AccountId: TryFrom<Signer> + PartialEq;
     type Nft: NftContext;
     type NftClass: NftClassContext;

--- a/ibc-apps/ics721-nft-transfer/src/handler/send_transfer.rs
+++ b/ibc-apps/ics721-nft-transfer/src/handler/send_transfer.rs
@@ -127,7 +127,7 @@ where
         }
     };
 
-    send_packet_validate(send_packet_ctx_a, &packet)?;
+    send_packet_validate(send_packet_ctx_a, transfer_ctx, &packet)?;
 
     Ok(())
 }
@@ -229,7 +229,7 @@ where
         }
     };
 
-    send_packet_execute(send_packet_ctx_a, packet)?;
+    send_packet_execute(send_packet_ctx_a, transfer_ctx, packet)?;
 
     {
         send_packet_ctx_a.log_message(format!(

--- a/ibc-core/ics03-connection/types/src/connection.rs
+++ b/ibc-core/ics03-connection/types/src/connection.rs
@@ -2,7 +2,6 @@
 
 use core::fmt::{Display, Error as FmtError, Formatter};
 use core::time::Duration;
-use core::u64;
 
 use ibc_core_client_types::error::ClientError;
 use ibc_core_commitment_types::commitment::CommitmentPrefix;

--- a/ibc-core/ics04-channel/src/context.rs
+++ b/ibc-core/ics04-channel/src/context.rs
@@ -6,8 +6,8 @@ use ibc_core_client::context::prelude::*;
 use ibc_core_connection::types::ConnectionEnd;
 use ibc_core_handler_types::error::ContextError;
 use ibc_core_handler_types::events::IbcEvent;
-use ibc_core_host::types::identifiers::{ChannelId, ConnectionId, PortId, Sequence};
-use ibc_core_host::types::path::{ChannelEndPath, CommitmentPath, SeqSendPath};
+use ibc_core_host::types::identifiers::{ConnectionId, Sequence};
+use ibc_core_host::types::path::{ChannelEndPath, CommitmentPath, PortPath, SeqSendPath};
 use ibc_core_host::{ExecutionContext, ValidationContext};
 use ibc_core_router::module::Module;
 use ibc_primitives::prelude::*;
@@ -30,9 +30,8 @@ pub trait SendPacketValidationContext {
 
     fn has_port_capability(
         &self,
+        port_path: &PortPath,
         module: &impl Module,
-        port_id: &PortId,
-        channel_id: &ChannelId,
     ) -> Result<(), ContextError>;
 }
 
@@ -63,11 +62,10 @@ where
 
     fn has_port_capability(
         &self,
+        port_path: &PortPath,
         module: &impl Module,
-        port_id: &PortId,
-        channel_id: &ChannelId,
     ) -> Result<(), ContextError> {
-        self.has_port_capability(module.identifier().to_string().into(), port_id, channel_id)
+        self.has_port_capability(port_path, module.identifier().to_string().into())
     }
 }
 

--- a/ibc-core/ics04-channel/src/context.rs
+++ b/ibc-core/ics04-channel/src/context.rs
@@ -6,9 +6,10 @@ use ibc_core_client::context::prelude::*;
 use ibc_core_connection::types::ConnectionEnd;
 use ibc_core_handler_types::error::ContextError;
 use ibc_core_handler_types::events::IbcEvent;
-use ibc_core_host::types::identifiers::{ConnectionId, Sequence};
+use ibc_core_host::types::identifiers::{ChannelId, ConnectionId, PortId, Sequence};
 use ibc_core_host::types::path::{ChannelEndPath, CommitmentPath, SeqSendPath};
 use ibc_core_host::{ExecutionContext, ValidationContext};
+use ibc_core_router::module::Module;
 use ibc_primitives::prelude::*;
 
 /// Methods required in send packet validation, to be implemented by the host
@@ -26,6 +27,13 @@ pub trait SendPacketValidationContext {
 
     fn get_next_sequence_send(&self, seq_send_path: &SeqSendPath)
         -> Result<Sequence, ContextError>;
+
+    fn has_port_capability(
+        &self,
+        module: &impl Module,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ContextError>;
 }
 
 impl<T> SendPacketValidationContext for T
@@ -51,6 +59,15 @@ where
         seq_send_path: &SeqSendPath,
     ) -> Result<Sequence, ContextError> {
         self.get_next_sequence_send(seq_send_path)
+    }
+
+    fn has_port_capability(
+        &self,
+        module: &impl Module,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ContextError> {
+        self.has_port_capability(module.identifier().to_string().into(), port_id, channel_id)
     }
 }
 

--- a/ibc-core/ics04-channel/src/handler/chan_open_init.rs
+++ b/ibc-core/ics04-channel/src/handler/chan_open_init.rs
@@ -32,6 +32,8 @@ where
         &msg.version_proposal,
     )?;
 
+    ctx_a.available_port_capability(&msg.port_id_on_a, &chan_id_on_a)?;
+
     Ok(())
 }
 
@@ -103,6 +105,12 @@ where
             ctx_a.log_message(log_message)?;
         }
     }
+
+    ctx_a.claim_port_capability(
+        module.identifier().to_string().into(),
+        &msg.port_id_on_a,
+        &chan_id_on_a,
+    )?;
 
     Ok(())
 }

--- a/ibc-core/ics04-channel/src/handler/chan_open_try.rs
+++ b/ibc-core/ics04-channel/src/handler/chan_open_try.rs
@@ -38,6 +38,8 @@ where
         &msg.version_supported_on_a,
     )?;
 
+    ctx_b.available_port_capability(&msg.port_id_on_b, &chan_id_on_b)?;
+
     Ok(())
 }
 
@@ -111,6 +113,12 @@ where
             ctx_b.log_message(log_message)?;
         }
     }
+
+    ctx_b.claim_port_capability(
+        module.identifier().to_string().into(),
+        &msg.port_id_on_b,
+        &chan_id_on_b,
+    )?;
 
     Ok(())
 }

--- a/ibc-core/ics04-channel/src/handler/chan_open_try.rs
+++ b/ibc-core/ics04-channel/src/handler/chan_open_try.rs
@@ -10,7 +10,7 @@ use ibc_core_handler_types::error::ContextError;
 use ibc_core_handler_types::events::{IbcEvent, MessageEvent};
 use ibc_core_host::types::identifiers::ChannelId;
 use ibc_core_host::types::path::{
-    ChannelEndPath, ClientConsensusStatePath, Path, SeqAckPath, SeqRecvPath, SeqSendPath,
+    ChannelEndPath, ClientConsensusStatePath, Path, PortPath, SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use ibc_core_host::{ExecutionContext, ValidationContext};
 use ibc_core_router::module::Module;
@@ -38,7 +38,12 @@ where
         &msg.version_supported_on_a,
     )?;
 
-    ctx_b.available_port_capability(&msg.port_id_on_b, &chan_id_on_b)?;
+    let port_path = PortPath(msg.port_id_on_b);
+
+    // either the capability is available or the module has the capability.
+    ctx_b.available_port_capability(&port_path).or_else(|_| {
+        ctx_b.has_port_capability(&port_path, module.identifier().to_string().into())
+    })?;
 
     Ok(())
 }
@@ -115,9 +120,8 @@ where
     }
 
     ctx_b.claim_port_capability(
+        &PortPath(msg.port_id_on_b),
         module.identifier().to_string().into(),
-        &msg.port_id_on_b,
-        &chan_id_on_b,
     )?;
 
     Ok(())

--- a/ibc-core/ics04-channel/src/handler/send_packet.rs
+++ b/ibc-core/ics04-channel/src/handler/send_packet.rs
@@ -7,7 +7,7 @@ use ibc_core_client::context::prelude::*;
 use ibc_core_handler_types::error::ContextError;
 use ibc_core_handler_types::events::{IbcEvent, MessageEvent};
 use ibc_core_host::types::path::{
-    ChannelEndPath, ClientConsensusStatePath, CommitmentPath, SeqSendPath,
+    ChannelEndPath, ClientConsensusStatePath, CommitmentPath, PortPath, SeqSendPath,
 };
 use ibc_core_router::module::Module;
 use ibc_primitives::prelude::*;
@@ -33,7 +33,7 @@ pub fn send_packet_validate(
     module: &impl Module,
     packet: &Packet,
 ) -> Result<(), ContextError> {
-    ctx_a.has_port_capability(module, &packet.port_id_on_a, &packet.chan_id_on_a)?;
+    ctx_a.has_port_capability(&PortPath(packet.port_id_on_a.clone()), module)?;
 
     if !packet.timeout_height_on_b.is_set() && !packet.timeout_timestamp_on_b.is_set() {
         return Err(ContextError::PacketError(PacketError::MissingTimeout));
@@ -112,7 +112,7 @@ pub fn send_packet_execute(
     module: &impl Module,
     packet: Packet,
 ) -> Result<(), ContextError> {
-    ctx_a.has_port_capability(module, &packet.port_id_on_a, &packet.chan_id_on_a)?;
+    ctx_a.has_port_capability(&PortPath(packet.port_id_on_a.clone()), module)?;
 
     {
         let seq_send_path_on_a = SeqSendPath::new(&packet.port_id_on_a, &packet.chan_id_on_a);

--- a/ibc-core/ics04-channel/types/src/error.rs
+++ b/ibc-core/ics04-channel/types/src/error.rs
@@ -71,6 +71,16 @@ pub enum ChannelError {
     InvalidIdentifier(IdentifierError),
     /// channel counter overflow error
     CounterOverflow,
+    /// Capability for `{port_id}/{channel_id}` does not exist
+    CapabilityNotFound {
+        port_id: PortId,
+        channel_id: ChannelId,
+    },
+    /// Capability for `{port_id}/{channel_id}` already exists
+    CapabilityAlreadyExists {
+        port_id: PortId,
+        channel_id: ChannelId,
+    },
     /// other error: `{description}`
     Other { description: String },
 }

--- a/ibc-core/ics04-channel/types/src/error.rs
+++ b/ibc-core/ics04-channel/types/src/error.rs
@@ -5,6 +5,7 @@ use ibc_core_client_types::{error as client_error, Height};
 use ibc_core_connection_types::error as connection_error;
 use ibc_core_host_types::error::IdentifierError;
 use ibc_core_host_types::identifiers::{ChannelId, ConnectionId, PortId, Sequence};
+use ibc_core_host_types::path::PortPath;
 use ibc_primitives::prelude::*;
 use ibc_primitives::{ParseTimestampError, Timestamp};
 
@@ -71,16 +72,10 @@ pub enum ChannelError {
     InvalidIdentifier(IdentifierError),
     /// channel counter overflow error
     CounterOverflow,
-    /// Capability for `{port_id}/{channel_id}` does not exist
-    CapabilityNotFound {
-        port_id: PortId,
-        channel_id: ChannelId,
-    },
-    /// Capability for `{port_id}/{channel_id}` already exists
-    CapabilityAlreadyExists {
-        port_id: PortId,
-        channel_id: ChannelId,
-    },
+    /// Capability for `{0}` does not exist
+    CapabilityNotFound(PortPath),
+    /// Capability for `{0}` already exists
+    CapabilityAlreadyExists(PortPath),
     /// other error: `{description}`
     Other { description: String },
 }

--- a/ibc-core/ics24-host/src/context.rs
+++ b/ibc-core/ics24-host/src/context.rs
@@ -10,7 +10,7 @@ use ibc_core_connection_types::version::{pick_version, Version as ConnectionVers
 use ibc_core_connection_types::ConnectionEnd;
 use ibc_core_handler_types::error::ContextError;
 use ibc_core_handler_types::events::IbcEvent;
-use ibc_core_host_types::identifiers::{ConnectionId, Sequence};
+use ibc_core_host_types::identifiers::{CapabilityKey, ChannelId, ConnectionId, PortId, Sequence};
 use ibc_core_host_types::path::{
     AckPath, ChannelEndPath, ClientConnectionPath, CommitmentPath, ConnectionPath, ReceiptPath,
     SeqAckPath, SeqRecvPath, SeqSendPath,
@@ -126,6 +126,19 @@ pub trait ValidationContext {
     /// `ExecutionContext::increase_channel_counter`.
     fn channel_counter(&self) -> Result<u64, ContextError>;
 
+    fn available_port_capability(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ContextError>;
+
+    fn has_port_capability(
+        &self,
+        capability: CapabilityKey,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ContextError>;
+
     /// Returns the maximum expected time per block
     fn max_expected_time_per_block(&self) -> Duration;
 
@@ -232,6 +245,13 @@ pub trait ExecutionContext: ValidationContext {
     /// Called upon channel identifier creation (Init or Try message processing).
     /// Increases the counter, that keeps track of how many channels have been created.
     fn increase_channel_counter(&mut self) -> Result<(), ContextError>;
+
+    fn claim_port_capability(
+        &mut self,
+        capability: CapabilityKey,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ContextError>;
 
     /// Emit the given IBC event
     fn emit_ibc_event(&mut self, event: IbcEvent) -> Result<(), ContextError>;

--- a/ibc-core/ics24-host/src/context.rs
+++ b/ibc-core/ics24-host/src/context.rs
@@ -10,10 +10,10 @@ use ibc_core_connection_types::version::{pick_version, Version as ConnectionVers
 use ibc_core_connection_types::ConnectionEnd;
 use ibc_core_handler_types::error::ContextError;
 use ibc_core_handler_types::events::IbcEvent;
-use ibc_core_host_types::identifiers::{CapabilityKey, ChannelId, ConnectionId, PortId, Sequence};
+use ibc_core_host_types::identifiers::{CapabilityKey, ConnectionId, Sequence};
 use ibc_core_host_types::path::{
-    AckPath, ChannelEndPath, ClientConnectionPath, CommitmentPath, ConnectionPath, ReceiptPath,
-    SeqAckPath, SeqRecvPath, SeqSendPath,
+    AckPath, ChannelEndPath, ClientConnectionPath, CommitmentPath, ConnectionPath, PortPath,
+    ReceiptPath, SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use ibc_primitives::prelude::*;
 use ibc_primitives::{Signer, Timestamp};
@@ -126,17 +126,12 @@ pub trait ValidationContext {
     /// `ExecutionContext::increase_channel_counter`.
     fn channel_counter(&self) -> Result<u64, ContextError>;
 
-    fn available_port_capability(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<(), ContextError>;
+    fn available_port_capability(&self, port_path: &PortPath) -> Result<(), ContextError>;
 
     fn has_port_capability(
         &self,
+        port_path: &PortPath,
         capability: CapabilityKey,
-        port_id: &PortId,
-        channel_id: &ChannelId,
     ) -> Result<(), ContextError>;
 
     /// Returns the maximum expected time per block
@@ -248,9 +243,8 @@ pub trait ExecutionContext: ValidationContext {
 
     fn claim_port_capability(
         &mut self,
+        port_path: &PortPath,
         capability: CapabilityKey,
-        port_id: &PortId,
-        channel_id: &ChannelId,
     ) -> Result<(), ContextError>;
 
     /// Emit the given IBC event

--- a/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
+++ b/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
@@ -1,4 +1,5 @@
 use core::any::TypeId;
+use core::fmt::Write;
 
 use ibc_primitives::prelude::String;
 
@@ -7,7 +8,9 @@ pub struct CapabilityKey(String);
 
 impl From<TypeId> for CapabilityKey {
     fn from(type_id: TypeId) -> Self {
-        Self(std::format!("{:?}", type_id))
+        let mut buf = String::new();
+        write!(buf, "{:?}", type_id).unwrap();
+        Self(buf)
     }
 }
 

--- a/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
+++ b/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
@@ -3,6 +3,7 @@ use core::fmt::Write;
 
 use ibc_primitives::prelude::String;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CapabilityKey(String);
 

--- a/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
+++ b/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
@@ -1,0 +1,24 @@
+use core::any::TypeId;
+
+use ibc_primitives::prelude::String;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CapabilityKey(String);
+
+impl From<TypeId> for CapabilityKey {
+    fn from(type_id: TypeId) -> Self {
+        Self(std::format!("{:?}", type_id))
+    }
+}
+
+impl From<String> for CapabilityKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for CapabilityKey {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}

--- a/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
+++ b/ibc-core/ics24-host/types/src/identifiers/capability_key.rs
@@ -1,28 +1,41 @@
 use core::any::TypeId;
 use core::fmt::Write;
 
-use ibc_primitives::prelude::String;
+use ibc_primitives::prelude::*;
 
+#[cfg_attr(
+    feature = "parity-scale-codec",
+    derive(
+        parity_scale_codec::Encode,
+        parity_scale_codec::Decode,
+        scale_info::TypeInfo
+    )
+)]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CapabilityKey(String);
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CapabilityKey(Vec<u8>);
 
 impl From<TypeId> for CapabilityKey {
     fn from(type_id: TypeId) -> Self {
         let mut buf = String::new();
         write!(buf, "{:?}", type_id).unwrap();
-        Self(buf)
+        buf.into()
     }
 }
 
 impl From<String> for CapabilityKey {
     fn from(value: String) -> Self {
-        Self(value)
+        Self(value.as_bytes().to_vec())
     }
 }
 
-impl AsRef<str> for CapabilityKey {
-    fn as_ref(&self) -> &str {
-        self.0.as_str()
+impl AsRef<[u8]> for CapabilityKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
     }
 }

--- a/ibc-core/ics24-host/types/src/identifiers/mod.rs
+++ b/ibc-core/ics24-host/types/src/identifiers/mod.rs
@@ -1,5 +1,6 @@
 //! Defines identifier types
 
+mod capability_key;
 mod chain_id;
 mod channel_id;
 mod client_id;
@@ -8,6 +9,7 @@ mod connection_id;
 mod port_id;
 mod sequence;
 
+pub use capability_key::CapabilityKey;
 pub use chain_id::ChainId;
 pub use channel_id::ChannelId;
 pub use client_id::ClientId;

--- a/ibc-core/ics26-routing/src/module.rs
+++ b/ibc-core/ics26-routing/src/module.rs
@@ -1,7 +1,5 @@
-use core::any::TypeId;
 /// The trait that defines an IBC application
 use core::fmt::Debug;
-use core::fmt::Write;
 
 use ibc_core_channel_types::acknowledgement::Acknowledgement;
 use ibc_core_channel_types::channel::{Counterparty, Order};
@@ -14,11 +12,7 @@ use ibc_primitives::prelude::*;
 use ibc_primitives::Signer;
 
 pub trait Module: 'static + Debug {
-    fn identifier(&self) -> ModuleId {
-        let mut buf = String::new();
-        write!(buf, "{:?}", TypeId::of::<Self>()).expect("Never fails");
-        ModuleId::new(buf)
-    }
+    fn identifier(&self) -> ModuleId;
 
     fn on_chan_open_init_validate(
         &self,

--- a/ibc-core/ics26-routing/src/module.rs
+++ b/ibc-core/ics26-routing/src/module.rs
@@ -1,5 +1,7 @@
+use core::any::TypeId;
 /// The trait that defines an IBC application
 use core::fmt::Debug;
+use core::fmt::Write;
 
 use ibc_core_channel_types::acknowledgement::Acknowledgement;
 use ibc_core_channel_types::channel::{Counterparty, Order};
@@ -7,11 +9,17 @@ use ibc_core_channel_types::error::{ChannelError, PacketError};
 use ibc_core_channel_types::packet::Packet;
 use ibc_core_channel_types::Version;
 use ibc_core_host_types::identifiers::{ChannelId, ConnectionId, PortId};
-use ibc_core_router_types::module::ModuleExtras;
+use ibc_core_router_types::module::{ModuleExtras, ModuleId};
 use ibc_primitives::prelude::*;
 use ibc_primitives::Signer;
 
-pub trait Module: Debug {
+pub trait Module: 'static + Debug {
+    fn identifier(&self) -> ModuleId {
+        let mut buf = String::new();
+        write!(buf, "{:?}", TypeId::of::<Self>()).expect("Never fails");
+        ModuleId::new(buf)
+    }
+
     fn on_chan_open_init_validate(
         &self,
         order: Order,

--- a/ibc-testkit/src/context.rs
+++ b/ibc-testkit/src/context.rs
@@ -19,6 +19,7 @@ use ibc::core::host::types::path::{
     SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use ibc::core::host::{ExecutionContext, ValidationContext};
+use ibc::core::router::module::Module;
 use ibc::primitives::prelude::*;
 use ibc::primitives::Timestamp;
 
@@ -386,6 +387,7 @@ where
     /// This does not bootstrap any corresponding IBC connection or light client.
     pub fn with_channel(
         mut self,
+        module: &impl Module,
         port_id: PortId,
         chan_id: ChannelId,
         channel_end: ChannelEnd,
@@ -394,6 +396,11 @@ where
         self.ibc_store
             .store_channel(&channel_end_path, channel_end)
             .expect("error writing to store");
+
+        self.ibc_store
+            .claim_port_capability(module.identifier().to_string().into(), &port_id, &chan_id)
+            .expect("error writing to store");
+
         self
     }
 

--- a/ibc-testkit/src/context.rs
+++ b/ibc-testkit/src/context.rs
@@ -16,7 +16,7 @@ use ibc::core::handler::types::msgs::MsgEnvelope;
 use ibc::core::host::types::identifiers::{ChannelId, ClientId, ConnectionId, PortId, Sequence};
 use ibc::core::host::types::path::{
     ChannelEndPath, ClientConsensusStatePath, ClientStatePath, CommitmentPath, ConnectionPath,
-    SeqAckPath, SeqRecvPath, SeqSendPath,
+    PortPath, SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use ibc::core::host::{ExecutionContext, ValidationContext};
 use ibc::core::router::module::Module;
@@ -398,7 +398,7 @@ where
             .expect("error writing to store");
 
         self.ibc_store
-            .claim_port_capability(module.identifier().to_string().into(), &port_id, &chan_id)
+            .claim_port_capability(&PortPath(port_id), module.identifier().to_string().into())
             .expect("error writing to store");
 
         self

--- a/ibc-testkit/src/testapp/ibc/applications/nft_transfer/module.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/nft_transfer/module.rs
@@ -7,11 +7,15 @@ use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
 use ibc::core::primitives::prelude::*;
 use ibc::core::primitives::Signer;
 use ibc::core::router::module::Module;
-use ibc::core::router::types::module::ModuleExtras;
+use ibc::core::router::types::module::{ModuleExtras, ModuleId};
 
 use super::types::DummyNftTransferModule;
 
 impl Module for DummyNftTransferModule {
+    fn identifier(&self) -> ModuleId {
+        ModuleId::new("nft-transfer".to_string())
+    }
+
     fn on_chan_open_init_validate(
         &self,
         _order: Order,

--- a/ibc-testkit/src/testapp/ibc/applications/transfer/module.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/transfer/module.rs
@@ -7,11 +7,15 @@ use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
 use ibc::core::primitives::prelude::*;
 use ibc::core::primitives::Signer;
 use ibc::core::router::module::Module;
-use ibc::core::router::types::module::ModuleExtras;
+use ibc::core::router::types::module::{ModuleExtras, ModuleId};
 
 use super::types::DummyTransferModule;
 
 impl Module for DummyTransferModule {
+    fn identifier(&self) -> ModuleId {
+        ModuleId::new("transfer".to_string())
+    }
+
     fn on_chan_open_init_validate(
         &self,
         _order: Order,

--- a/ibc-testkit/src/testapp/ibc/core/core_ctx.rs
+++ b/ibc-testkit/src/testapp/ibc/core/core_ctx.rs
@@ -18,13 +18,11 @@ use ibc::core::connection::types::error::ConnectionError;
 use ibc::core::connection::types::{ConnectionEnd, IdentifiedConnectionEnd};
 use ibc::core::handler::types::error::ContextError;
 use ibc::core::handler::types::events::IbcEvent;
-use ibc::core::host::types::identifiers::{
-    CapabilityKey, ChannelId, ClientId, ConnectionId, PortId, Sequence,
-};
+use ibc::core::host::types::identifiers::{CapabilityKey, ClientId, ConnectionId, Sequence};
 use ibc::core::host::types::path::{
     AckPath, ChannelEndPath, ClientConnectionPath, CommitmentPath, ConnectionPath,
-    NextChannelSequencePath, NextClientSequencePath, NextConnectionSequencePath, Path, ReceiptPath,
-    SeqAckPath, SeqRecvPath, SeqSendPath,
+    NextChannelSequencePath, NextClientSequencePath, NextConnectionSequencePath, Path, PortPath,
+    ReceiptPath, SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use ibc::core::host::{ClientStateRef, ConsensusStateRef, ExecutionContext, ValidationContext};
 use ibc::core::primitives::prelude::*;
@@ -235,10 +233,7 @@ where
     ) -> Result<AcknowledgementCommitment, ContextError> {
         Ok(self
             .packet_ack_store
-            .get(
-                StoreHeight::Pending,
-                &AckPath::new(&ack_path.port_id, &ack_path.channel_id, ack_path.sequence),
-            )
+            .get(StoreHeight::Pending, ack_path)
             .ok_or(PacketError::PacketAcknowledgementNotFound {
                 sequence: ack_path.sequence,
             })?)
@@ -269,39 +264,26 @@ where
         self
     }
 
-    fn available_port_capability(
-        &self,
-        port_id: &PortId,
-        channel_id: &ChannelId,
-    ) -> Result<(), ContextError> {
-        (!self
-            .port_capabilities
-            .lock()
-            .contains_key(&(port_id.clone(), channel_id.clone())))
-        .then_some(())
-        .ok_or_else(|| {
-            ContextError::ChannelError(ChannelError::CapabilityAlreadyExists {
-                port_id: port_id.clone(),
-                channel_id: channel_id.clone(),
+    fn available_port_capability(&self, port_path: &PortPath) -> Result<(), ContextError> {
+        self.port_capabilities
+            .get(StoreHeight::Pending, port_path)
+            .is_none()
+            .then_some(())
+            .ok_or_else(|| {
+                ContextError::ChannelError(ChannelError::CapabilityAlreadyExists(port_path.clone()))
             })
-        })
     }
 
     fn has_port_capability(
         &self,
+        port_path: &PortPath,
         capability: CapabilityKey,
-        port_id: &PortId,
-        channel_id: &ChannelId,
     ) -> Result<(), ContextError> {
         self.port_capabilities
-            .lock()
-            .get(&(port_id.clone(), channel_id.clone()))
-            .filter(|stored_capability| stored_capability == &&capability)
+            .get(StoreHeight::Pending, port_path)
+            .filter(|stored_capability| stored_capability == &capability)
             .ok_or_else(|| {
-                ContextError::ChannelError(ChannelError::CapabilityNotFound {
-                    port_id: port_id.clone(),
-                    channel_id: channel_id.clone(),
-                })
+                ContextError::ChannelError(ChannelError::CapabilityNotFound(port_path.clone()))
             })
             .map(|_| ())
     }
@@ -817,13 +799,14 @@ where
 
     fn claim_port_capability(
         &mut self,
+        port_path: &PortPath,
         capability: CapabilityKey,
-        port_id: &PortId,
-        channel_id: &ChannelId,
     ) -> Result<(), ContextError> {
         self.port_capabilities
-            .lock()
-            .insert((port_id.clone(), channel_id.clone()), capability);
+            .set(port_path.clone(), capability)
+            .map_err(|_| ChannelError::Other {
+                description: "Port capability claim store error".to_string(),
+            })?;
 
         Ok(())
     }

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -12,7 +12,9 @@ use ibc::core::client::context::client_state::ClientStateValidation;
 use ibc::core::client::types::Height;
 use ibc::core::connection::types::ConnectionEnd;
 use ibc::core::handler::types::events::IbcEvent;
-use ibc::core::host::types::identifiers::{ConnectionId, Sequence};
+use ibc::core::host::types::identifiers::{
+    CapabilityKey, ChannelId, ConnectionId, PortId, Sequence,
+};
 use ibc::core::host::types::path::{
     AckPath, ChannelEndPath, ClientConnectionPath, ClientConsensusStatePath, ClientStatePath,
     ClientUpdateHeightPath, ClientUpdateTimePath, CommitmentPath, ConnectionPath,
@@ -89,6 +91,8 @@ where
     pub host_consensus_states: Arc<Mutex<BTreeMap<u64, AnyConsensusState>>>,
     /// Map of older ibc commitment proofs
     pub ibc_commiment_proofs: Arc<Mutex<BTreeMap<u64, CommitmentProof>>>,
+    /// Map of port capabilities
+    pub port_capabilities: Arc<Mutex<BTreeMap<(PortId, ChannelId), CapabilityKey>>>,
     /// IBC Events
     pub events: Arc<Mutex<Vec<IbcEvent>>>,
     /// message logs
@@ -138,6 +142,7 @@ where
             packet_commitment_store: TypedStore::new(shared_store.clone()),
             packet_receipt_store: TypedStore::new(shared_store.clone()),
             packet_ack_store: TypedStore::new(shared_store.clone()),
+            port_capabilities: Arc::new(Mutex::new(Default::default())),
             events: Arc::new(Mutex::new(Vec::new())),
             logs: Arc::new(Mutex::new(Vec::new())),
             store: shared_store,

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -227,6 +227,10 @@ mod tests {
         }
 
         impl Module for FooModule {
+            fn identifier(&self) -> ModuleId {
+                ModuleId::new("foomodule".to_string())
+            }
+
             fn on_chan_open_init_validate(
                 &self,
                 _order: Order,
@@ -327,6 +331,10 @@ mod tests {
         struct BarModule;
 
         impl Module for BarModule {
+            fn identifier(&self) -> ModuleId {
+                ModuleId::new("barmodule".to_string())
+            }
+
             fn on_chan_open_init_validate(
                 &self,
                 _order: Order,

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -12,14 +12,12 @@ use ibc::core::client::context::client_state::ClientStateValidation;
 use ibc::core::client::types::Height;
 use ibc::core::connection::types::ConnectionEnd;
 use ibc::core::handler::types::events::IbcEvent;
-use ibc::core::host::types::identifiers::{
-    CapabilityKey, ChannelId, ConnectionId, PortId, Sequence,
-};
+use ibc::core::host::types::identifiers::{CapabilityKey, ConnectionId, Sequence};
 use ibc::core::host::types::path::{
     AckPath, ChannelEndPath, ClientConnectionPath, ClientConsensusStatePath, ClientStatePath,
     ClientUpdateHeightPath, ClientUpdateTimePath, CommitmentPath, ConnectionPath,
-    NextChannelSequencePath, NextClientSequencePath, NextConnectionSequencePath, ReceiptPath,
-    SeqAckPath, SeqRecvPath, SeqSendPath,
+    NextChannelSequencePath, NextClientSequencePath, NextConnectionSequencePath, PortPath,
+    ReceiptPath, SeqAckPath, SeqRecvPath, SeqSendPath,
 };
 use ibc::core::primitives::prelude::*;
 use ibc::core::primitives::Timestamp;
@@ -92,7 +90,7 @@ where
     /// Map of older ibc commitment proofs
     pub ibc_commiment_proofs: Arc<Mutex<BTreeMap<u64, CommitmentProof>>>,
     /// Map of port capabilities
-    pub port_capabilities: Arc<Mutex<BTreeMap<(PortId, ChannelId), CapabilityKey>>>,
+    pub port_capabilities: JsonStore<SharedStore<S>, PortPath, CapabilityKey>,
     /// IBC Events
     pub events: Arc<Mutex<Vec<IbcEvent>>>,
     /// message logs
@@ -142,7 +140,7 @@ where
             packet_commitment_store: TypedStore::new(shared_store.clone()),
             packet_receipt_store: TypedStore::new(shared_store.clone()),
             packet_ack_store: TypedStore::new(shared_store.clone()),
-            port_capabilities: Arc::new(Mutex::new(Default::default())),
+            port_capabilities: TypedStore::new(shared_store.clone()),
             events: Arc::new(Mutex::new(Vec::new())),
             logs: Arc::new(Mutex::new(Vec::new())),
             store: shared_store,

--- a/tests-integration/tests/core/ics04_channel/acknowledgement.rs
+++ b/tests-integration/tests/core/ics04_channel/acknowledgement.rs
@@ -16,6 +16,7 @@ use ibc::core::primitives::*;
 use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_acknowledgement;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
 use rstest::*;
@@ -128,6 +129,7 @@ fn ack_success_no_packet_commitment(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(client_height),
         )
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -162,6 +164,7 @@ fn ack_success_happy_path(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(client_height),
         )
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -197,6 +200,7 @@ fn ack_unordered_chan_execute(fixture: Fixture) {
     } = fixture;
     let mut ctx = ctx
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -237,7 +241,12 @@ fn ack_ordered_chan_execute(fixture: Fixture) {
         ..
     } = fixture;
     let mut ctx = ctx
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a_ordered)
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_a_ordered,
+        )
         .with_connection(ConnectionId::zero(), conn_end_on_a)
         .with_packet_commitment(
             msg.packet.port_id_on_a.clone(),

--- a/tests-integration/tests/core/ics04_channel/chan_close_confirm.rs
+++ b/tests-integration/tests/core/ics04_channel/chan_close_confirm.rs
@@ -15,6 +15,7 @@ use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_chan_close_confirm;
 use ibc_testkit::fixtures::core::connection::dummy_raw_counterparty_conn;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::clients::mock::client_state::client_type as mock_client_type;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
@@ -61,6 +62,7 @@ fn test_chan_close_confirm_validate() {
         )
         .with_connection(conn_id, conn_end)
         .with_channel(
+            &DummyTransferModule,
             msg_chan_close_confirm.port_id_on_b.clone(),
             msg_chan_close_confirm.chan_id_on_b,
             chan_end,
@@ -118,6 +120,7 @@ fn test_chan_close_confirm_execute() {
         )
         .with_connection(conn_id, conn_end)
         .with_channel(
+            &DummyTransferModule,
             msg_chan_close_confirm.port_id_on_b.clone(),
             msg_chan_close_confirm.chan_id_on_b,
             chan_end,

--- a/tests-integration/tests/core/ics04_channel/chan_close_init.rs
+++ b/tests-integration/tests/core/ics04_channel/chan_close_init.rs
@@ -15,6 +15,7 @@ use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_chan_close_init;
 use ibc_testkit::fixtures::core::connection::dummy_raw_counterparty_conn;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::clients::mock::client_state::client_type as mock_client_type;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
@@ -61,6 +62,7 @@ fn test_chan_close_init_validate() {
             )
             .with_connection(conn_id, conn_end)
             .with_channel(
+                &DummyTransferModule,
                 msg_chan_close_init.port_id_on_a.clone(),
                 msg_chan_close_init.chan_id_on_a,
                 chan_end,
@@ -119,6 +121,7 @@ fn test_chan_close_init_execute() {
             )
             .with_connection(conn_id, conn_end)
             .with_channel(
+                &DummyTransferModule,
                 msg_chan_close_init.port_id_on_a.clone(),
                 msg_chan_close_init.chan_id_on_a,
                 chan_end,

--- a/tests-integration/tests/core/ics04_channel/chan_open_ack.rs
+++ b/tests-integration/tests/core/ics04_channel/chan_open_ack.rs
@@ -16,6 +16,7 @@ use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_chan_open_ack;
 use ibc_testkit::fixtures::core::connection::dummy_raw_counterparty_conn;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::clients::mock::client_state::client_type as mock_client_type;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
@@ -98,6 +99,7 @@ fn chan_open_ack_happy_path(fixture: Fixture) {
         )
         .with_connection(conn_id_on_a, conn_end_on_a)
         .with_channel(
+            &DummyTransferModule,
             msg.port_id_on_a.clone(),
             msg.chan_id_on_a.clone(),
             chan_end_on_a,
@@ -131,6 +133,7 @@ fn chan_open_ack_execute_happy_path(fixture: Fixture) {
         )
         .with_connection(conn_id_on_a, conn_end_on_a)
         .with_channel(
+            &DummyTransferModule,
             msg.port_id_on_a.clone(),
             msg.chan_id_on_a.clone(),
             chan_end_on_a,
@@ -170,6 +173,7 @@ fn chan_open_ack_fail_no_connection(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(Height::new(0, proof_height).unwrap()),
         )
         .with_channel(
+            &DummyTransferModule,
             msg.port_id_on_a.clone(),
             msg.chan_id_on_a.clone(),
             chan_end_on_a,
@@ -242,6 +246,7 @@ fn chan_open_ack_fail_channel_wrong_state(fixture: Fixture) {
         )
         .with_connection(conn_id_on_a, conn_end_on_a)
         .with_channel(
+            &DummyTransferModule,
             msg.port_id_on_a.clone(),
             msg.chan_id_on_a.clone(),
             wrong_chan_end,

--- a/tests-integration/tests/core/ics04_channel/chan_open_confirm.rs
+++ b/tests-integration/tests/core/ics04_channel/chan_open_confirm.rs
@@ -15,6 +15,7 @@ use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_chan_open_confirm;
 use ibc_testkit::fixtures::core::connection::dummy_raw_counterparty_conn;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::clients::mock::client_state::client_type as mock_client_type;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
@@ -94,7 +95,12 @@ fn chan_open_confirm_validate_happy_path(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(Height::new(0, proof_height).unwrap()),
         )
         .with_connection(conn_id_on_b, conn_end_on_b)
-        .with_channel(msg.port_id_on_b.clone(), ChannelId::zero(), chan_end_on_b);
+        .with_channel(
+            &DummyTransferModule,
+            msg.port_id_on_b.clone(),
+            ChannelId::zero(),
+            chan_end_on_b,
+        );
 
     let msg_envelope = MsgEnvelope::from(ChannelMsg::from(msg));
 
@@ -123,7 +129,12 @@ fn chan_open_confirm_execute_happy_path(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(Height::new(0, proof_height).unwrap()),
         )
         .with_connection(conn_id_on_b, conn_end_on_b)
-        .with_channel(msg.port_id_on_b.clone(), ChannelId::zero(), chan_end_on_b);
+        .with_channel(
+            &DummyTransferModule,
+            msg.port_id_on_b.clone(),
+            ChannelId::zero(),
+            chan_end_on_b,
+        );
 
     let msg_envelope = MsgEnvelope::from(ChannelMsg::from(msg));
 
@@ -199,7 +210,12 @@ fn chan_open_confirm_fail_channel_wrong_state(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(Height::new(0, proof_height).unwrap()),
         )
         .with_connection(conn_id_on_b, conn_end_on_b)
-        .with_channel(msg.port_id_on_b.clone(), ChannelId::zero(), wrong_chan_end);
+        .with_channel(
+            &DummyTransferModule,
+            msg.port_id_on_b.clone(),
+            ChannelId::zero(),
+            wrong_chan_end,
+        );
 
     let msg_envelope = MsgEnvelope::from(ChannelMsg::from(msg));
 

--- a/tests-integration/tests/core/ics04_channel/recv_packet.rs
+++ b/tests-integration/tests/core/ics04_channel/recv_packet.rs
@@ -17,6 +17,7 @@ use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::{dummy_msg_recv_packet, dummy_raw_msg_recv_packet};
 use ibc_testkit::fixtures::core::signer::dummy_account_id;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
 use rstest::*;
@@ -124,6 +125,7 @@ fn recv_packet_validate_happy_path(fixture: Fixture) {
         )
         .with_connection(ConnectionId::zero(), conn_end_on_b)
         .with_channel(
+            &DummyTransferModule,
             packet.port_id_on_b.clone(),
             packet.chan_id_on_b.clone(),
             chan_end_on_b,
@@ -190,7 +192,12 @@ fn recv_packet_timeout_expired(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(client_height),
         )
         .with_connection(ConnectionId::zero(), conn_end_on_b)
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_b)
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_b,
+        )
         .with_send_sequence(PortId::transfer(), ChannelId::zero(), 1.into())
         .advance_block_up_to_height(host_height);
 
@@ -219,7 +226,12 @@ fn recv_packet_execute_happy_path(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(client_height),
         )
         .with_connection(ConnectionId::zero(), conn_end_on_b)
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_b);
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_b,
+        );
 
     let msg_env = MsgEnvelope::from(PacketMsg::from(msg));
 

--- a/tests-integration/tests/core/ics04_channel/send_packet.rs
+++ b/tests-integration/tests/core/ics04_channel/send_packet.rs
@@ -18,6 +18,7 @@ use ibc::core::primitives::*;
 use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_packet;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
 use test_log::test;
 
@@ -92,6 +93,8 @@ fn send_packet_processing() {
         packet
     };
 
+    let dummy_transfer_module = DummyTransferModule;
+
     let tests: Vec<Test> = vec![
         Test {
             name: "Processing fails because no channel exists in the context".to_string(),
@@ -107,7 +110,12 @@ fn send_packet_processing() {
                     LightClientState::<MockHost>::with_latest_height(client_height),
                 )
                 .with_connection(ConnectionId::zero(), conn_end_on_a.clone())
-                .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a.clone())
+                .with_channel(
+                    &dummy_transfer_module,
+                    PortId::transfer(),
+                    ChannelId::zero(),
+                    chan_end_on_a.clone(),
+                )
                 .with_send_sequence(PortId::transfer(), ChannelId::zero(), 1.into()),
             packet,
             want_pass: true,
@@ -120,7 +128,12 @@ fn send_packet_processing() {
                     LightClientState::<MockHost>::with_latest_height(client_height),
                 )
                 .with_connection(ConnectionId::zero(), conn_end_on_a.clone())
-                .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a.clone())
+                .with_channel(
+                    &dummy_transfer_module,
+                    PortId::transfer(),
+                    ChannelId::zero(),
+                    chan_end_on_a.clone(),
+                )
                 .with_send_sequence(PortId::transfer(), ChannelId::zero(), 1.into()),
             packet: packet_timeout_equal_client_height,
             want_pass: true,
@@ -133,7 +146,12 @@ fn send_packet_processing() {
                     LightClientState::<MockHost>::with_latest_height(client_height),
                 )
                 .with_connection(ConnectionId::zero(), conn_end_on_a.clone())
-                .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a.clone())
+                .with_channel(
+                    &dummy_transfer_module,
+                    PortId::transfer(),
+                    ChannelId::zero(),
+                    chan_end_on_a.clone(),
+                )
                 .with_send_sequence(PortId::transfer(), ChannelId::zero(), 1.into()),
             packet: packet_timeout_one_before_client_height,
             want_pass: false,
@@ -146,7 +164,12 @@ fn send_packet_processing() {
                     LightClientState::<MockHost>::with_latest_height(client_height),
                 )
                 .with_connection(ConnectionId::zero(), conn_end_on_a.clone())
-                .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a.clone())
+                .with_channel(
+                    &dummy_transfer_module,
+                    PortId::transfer(),
+                    ChannelId::zero(),
+                    chan_end_on_a.clone(),
+                )
                 .with_send_sequence(PortId::transfer(), ChannelId::zero(), 1.into()),
             packet: packet_with_no_timeout,
             want_pass: false,
@@ -159,7 +182,12 @@ fn send_packet_processing() {
                     LightClientState::<MockHost>::with_latest_height(client_height),
                 )
                 .with_connection(ConnectionId::zero(), conn_end_on_a)
-                .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a)
+                .with_channel(
+                    &dummy_transfer_module,
+                    PortId::transfer(),
+                    ChannelId::zero(),
+                    chan_end_on_a,
+                )
                 .with_send_sequence(PortId::transfer(), ChannelId::zero(), 1.into()),
             packet: packet_with_timestamp_old,
             want_pass: false,
@@ -169,7 +197,11 @@ fn send_packet_processing() {
     .collect();
 
     for mut test in tests {
-        let res = send_packet(&mut test.ctx.ibc_store, test.packet.clone());
+        let res = send_packet(
+            &mut test.ctx.ibc_store,
+            &DummyTransferModule,
+            test.packet.clone(),
+        );
         // Additionally check the events and the output objects in the result.
         match res {
             Ok(()) => {

--- a/tests-integration/tests/core/ics04_channel/timeout.rs
+++ b/tests-integration/tests/core/ics04_channel/timeout.rs
@@ -18,6 +18,7 @@ use ibc::core::primitives::*;
 use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_timeout;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
 use rstest::*;
@@ -145,6 +146,7 @@ fn timeout_fail_no_consensus_state_for_height(fixture: Fixture) {
 
     let mut ctx = ctx
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -208,6 +210,7 @@ fn timeout_fail_proof_timeout_not_reached(fixture: Fixture) {
         )
         .with_connection(ConnectionId::zero(), conn_end_on_a)
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -242,6 +245,7 @@ fn timeout_success_no_packet_commitment(fixture: Fixture) {
     } = fixture;
     let ctx = ctx
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -280,6 +284,7 @@ fn timeout_unordered_channel_validate(fixture: Fixture) {
         )
         .with_connection(ConnectionId::zero(), conn_end_on_a)
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -319,7 +324,12 @@ fn timeout_ordered_channel_validate(fixture: Fixture) {
             LightClientState::<MockHost>::with_latest_height(client_height),
         )
         .with_connection(ConnectionId::zero(), conn_end_on_a)
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a_ordered)
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_a_ordered,
+        )
         .with_packet_commitment(
             packet.port_id_on_a,
             packet.chan_id_on_a,
@@ -347,6 +357,7 @@ fn timeout_unordered_chan_execute(fixture: Fixture) {
     } = fixture;
     let mut ctx = ctx
         .with_channel(
+            &DummyTransferModule,
             PortId::transfer(),
             ChannelId::zero(),
             chan_end_on_a_unordered,
@@ -388,7 +399,12 @@ fn timeout_ordered_chan_execute(fixture: Fixture) {
         ..
     } = fixture;
     let mut ctx = ctx
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a_ordered)
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_a_ordered,
+        )
         .with_connection(ConnectionId::zero(), conn_end_on_a)
         .with_packet_commitment(
             msg.packet.port_id_on_a.clone(),

--- a/tests-integration/tests/core/ics04_channel/timeout_on_close.rs
+++ b/tests-integration/tests/core/ics04_channel/timeout_on_close.rs
@@ -15,6 +15,7 @@ use ibc::core::primitives::*;
 use ibc_testkit::context::MockContext;
 use ibc_testkit::fixtures::core::channel::dummy_raw_msg_timeout_on_close;
 use ibc_testkit::hosts::MockHost;
+use ibc_testkit::testapp::ibc::applications::transfer::types::DummyTransferModule;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
 use ibc_testkit::testapp::ibc::core::types::LightClientState;
 use rstest::*;
@@ -117,7 +118,12 @@ fn timeout_on_close_success_no_packet_commitment(fixture: Fixture) {
         ..
     } = fixture;
     let context = context
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a)
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_a,
+        )
         .with_connection(ConnectionId::zero(), conn_end_on_a);
 
     let msg_envelope = MsgEnvelope::from(PacketMsg::from(msg));
@@ -142,7 +148,12 @@ fn timeout_on_close_success_happy_path(fixture: Fixture) {
         ..
     } = fixture;
     let context = context
-        .with_channel(PortId::transfer(), ChannelId::zero(), chan_end_on_a)
+        .with_channel(
+            &DummyTransferModule,
+            PortId::transfer(),
+            ChannelId::zero(),
+            chan_end_on_a,
+        )
         .with_connection(ConnectionId::zero(), conn_end_on_a)
         .with_packet_commitment(
             msg.packet.port_id_on_a.clone(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #519

- [x] a port-channel is bound to a module at `ChanOpenInit` and `ChanOpenTry`.
- [x] a module can't _use_ a port-channel bound to another module. e.g. `transfer` module can't commit packets for `"nft-transfer"` port.
- [x] storing port capability at _PortPath_ e.g. `""ports/{id}"`.
- [ ] modules may release port at channel close. 
- [ ] custom port naming.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Ref: https://github.com/cosmos/ibc/blob/main/spec/core/ics-005-port-allocation/README.md


______

### PR author checklist:
- [ ] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
