### PR TITLE
Fix typos and update broken links in Documentation

### DIFF
--- a/.changelog/v0.51.0/bug-fixes/1083-bump-serde-json.md
+++ b/.changelog/v0.51.0/bug-fixes/1083-bump-serde-json.md
@@ -1,3 +1,3 @@
-- [ibc] Upgrade `serde_json` to "1.0.1" to address an stack overflow issue
+- [ibc] Upgrade `serde_json` to "1.0.1" to address a stack overflow issue
   within the `serde-json-wasm` crate
   ([\#1083](https://github.com/cosmos/ibc-rs/pull/1083))

--- a/.changelog/v0.54.0/improvements/1295-move-cosmwasm-impls-to-separate-workspace.md
+++ b/.changelog/v0.54.0/improvements/1295-move-cosmwasm-impls-to-separate-workspace.md
@@ -1,3 +1,3 @@
 - [cosmwasm] Move CosmWasm implementations to a separate workspace under
 `cosmwasm` directory to simplify dependency management and decouple `ibc-rs`
-MSRV from `cosmwasm`. ([\#1295](https://github.com/cosmos/ibc-rs/issue/1295))
+MSRV from `cosmwasm`. ([\#1295](https://github.com/cosmos/ibc-rs/issues/1295))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,7 @@ instead of defaulting to `UPGRADED_IBC_STATE`.
   ([\#1283](https://github.com/cosmos/ibc-rs/pull/1283))
 - [cosmwasm] Move CosmWasm implementations to a separate workspace under
 `cosmwasm` directory to simplify dependency management and decouple `ibc-rs`
-MSRV from `cosmwasm`. ([\#1295](https://github.com/cosmos/ibc-rs/issue/1295))
+MSRV from `cosmwasm`. ([\#1295](https://github.com/cosmos/ibc-rs/issues/1295))
 
 ## v0.53.0
 
@@ -379,7 +379,7 @@ There are no consensus-breaking changes.
   ([\#1063](https://github.com/cosmos/ibc-rs/pull/1063))
 - [ibc-client-tendermint] Use header height for Tendermint consensus state storage
   ([\#1080](https://github.com/cosmos/ibc-rs/issues/1080))
-- [ibc] Upgrade `serde_json` to "1.0.1" to address an stack overflow issue
+- [ibc] Upgrade `serde_json` to "1.0.1" to address a stack overflow issue
   within the `serde-json-wasm` crate
   ([\#1083](https://github.com/cosmos/ibc-rs/pull/1083))
 - [ibc] Resolve potential `base64` dependency resolution issue by bringing it to

--- a/ibc-clients/README.md
+++ b/ibc-clients/README.md
@@ -25,7 +25,7 @@ IBC light clients:
 
 - [ibc-client-tendermint-types](./ics07-tendermint/types): Data Structures
 - [ibc-client-tendermint](./ics07-tendermint): Implementation
-- [ibc-client-tendermint-cw](https://github.com/cosmos/sp1-ics07-tendermint): CosmWasm
+- [ibc-client-tendermint-cw](https://github.com/informalsystems/cosmwasm-ibc/tree/main/ibc-clients/ics07-tendermint): CosmWasm
   Contract that lives under the [cosmwasm-ibc](https://github.com/informalsystems/cosmwasm-ibc) repository.
 
 ### ICS-08: WASM Proxy Light Client

--- a/ibc-clients/README.md
+++ b/ibc-clients/README.md
@@ -25,7 +25,7 @@ IBC light clients:
 
 - [ibc-client-tendermint-types](./ics07-tendermint/types): Data Structures
 - [ibc-client-tendermint](./ics07-tendermint): Implementation
-- [ibc-client-tendermint-cw](https://github.com/informalsystems/cosmwasm-ibc/ibc-clients/ics07-tendermint): CosmWasm
+- [ibc-client-tendermint-cw](https://github.com/cosmos/sp1-ics07-tendermint): CosmWasm
   Contract that lives under the [cosmwasm-ibc](https://github.com/informalsystems/cosmwasm-ibc) repository.
 
 ### ICS-08: WASM Proxy Light Client


### PR DESCRIPTION
This pull request addresses minor issues in the project documentation by fixing typos and updating outdated links. 
The following changes were made:

#### Typographical Fixes:
1. **File:** `1083-bump-serde-json.md`
   - Corrected "an stack overflow" to "a stack overflow."

#### Link Updates:
2. **File:** `1295-move-cosmwasm-impls-to-separate-workspace.md`
   - Updated broken link to issue #1295:
     - **Old:** `https://github.com/cosmos/ibc-rs/issue/1295`
     - **New:** `https://github.com/cosmos/ibc-rs/issues/1295`

3. **File:** `ibc-clients/README.md`
   - Updated outdated link for CosmWasm implementations:
     - **Old:** `https://github.com/informalsystems/cosmwasm-ibc/ibc-clients/ics07-tendermint`
     - **New:** `https://github.com/cosmos/sp1-ics07-tendermint`

---

### PR author checklist:
- [x] Added changelog entry using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests (N/A for documentation changes).
- [x] Updated relevant documentation and links.
- [x] Tagged reviewer to shepherd this PR.

---

### Reviewer checklist:
- [ ] Reviewed `Files changed` for correctness and consistency.
- [ ] Verified updated links.
- [ ] Confirmed no additional changes are necessary.
