### PR TITLE
Fix typo Update adr-001-handler-implementation.md

### DIFF
--- a/docs/architecture/adr-001-handler-implementation.md
+++ b/docs/architecture/adr-001-handler-implementation.md
@@ -311,7 +311,7 @@ pub fn keep(
 
 > This section is very much a work in progress, as further investigation into what
 > a production-ready implementation of the `ctx` parameter of the top-level dispatcher
-> is required. As such, implementors should feel free to disregard the recommendations
+> is required. As such, implementers should feel free to disregard the recommendations
 > below, and are encouraged to come up with amendments to this ADR to better capture
 > the actual requirements.
 


### PR DESCRIPTION
# Pull Request: [Title of Your Change]

## Summary
- **Fix**: Fixed a typo in `adr-001-handler-implementation.md` by changing `implementors` to `implementers`.

## Changes Made
- Replaced "implementors" with "implementers" in the section discussing the `ctx` parameter.

## Motivation
- The term "implementors" is not commonly used in the context of this documentation, and "implementers" is the correct term.

## Checklist
- [ ] I have tested my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have followed the contributing guidelines of the repository.

## Related Issues
- Issue #XXX (if applicable)

## Additional Information
- This is part of an ongoing effort to improve documentation clarity.
