### PR TITLE
Acknowledge packets asynchronously

### DIFF
--- a/.changelog/unreleased/features/1392-optional-ack.md
+++ b/.changelog/unreleased/features/1392-optional-ack.md
@@ -1,0 +1,2 @@
+- Support asynchronous packet acknowledgements.
+  ([\#1392](https://github.com/cosmos/ibc-rs/pull/1392))

--- a/ibc-core/README.md
+++ b/ibc-core/README.md
@@ -111,11 +111,11 @@ asynchronously](https://github.com/cosmos/ibc/tree/main/spec/core/ics-004-channe
 This allows modules to receive the packet, but only applying the changes at a
 later time (after which they would write the acknowledgement).
 
-We currently force applications to process the packets as part of
-`onRecvPacket()`. If you need asynchronous acknowledgements for your
-application, please open an issue.
+Our implementation supports the same semantics, as part of the `on_recv_packet_execute`
+method of [`Module`]. The documentation of this method explains how packets should be
+acknowledged out of sync.
 
-Note that this still makes us 100% compatible with `ibc-go`.
+[`Module`]: https://github.com/cosmos/ibc-rs/blob/main/ibc-core/ics26-routing/src/module.rs
 
 ## Contributing
 

--- a/ibc-core/ics04-channel/src/handler/acknowledgement.rs
+++ b/ibc-core/ics04-channel/src/handler/acknowledgement.rs
@@ -1,18 +1,94 @@
+use ibc_core_channel_types::acknowledgement::Acknowledgement;
 use ibc_core_channel_types::channel::{Counterparty, Order, State as ChannelState};
 use ibc_core_channel_types::commitment::{compute_ack_commitment, compute_packet_commitment};
 use ibc_core_channel_types::error::ChannelError;
-use ibc_core_channel_types::events::AcknowledgePacket;
+use ibc_core_channel_types::events::{AcknowledgePacket, WriteAcknowledgement};
 use ibc_core_channel_types::msgs::MsgAcknowledgement;
+use ibc_core_channel_types::packet::{Packet, Receipt};
 use ibc_core_client::context::prelude::*;
 use ibc_core_connection::delay::verify_conn_delay_passed;
 use ibc_core_connection::types::State as ConnectionState;
 use ibc_core_handler_types::events::{IbcEvent, MessageEvent};
 use ibc_core_host::types::path::{
-    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, Path, SeqAckPath,
+    AckPath, ChannelEndPath, ClientConsensusStatePath, CommitmentPath, Path, ReceiptPath,
+    SeqAckPath, SeqRecvPath,
 };
 use ibc_core_host::{ExecutionContext, ValidationContext};
 use ibc_core_router::module::Module;
 use ibc_primitives::prelude::*;
+
+pub fn commit_packet_sequence_number<ExecCtx>(
+    ctx_b: &mut ExecCtx,
+    packet: &Packet,
+) -> Result<(), ChannelError>
+where
+    ExecCtx: ExecutionContext,
+{
+    let chan_end_path_on_b = ChannelEndPath::new(&packet.port_id_on_b, &packet.chan_id_on_b);
+    let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
+
+    // `recvPacket` core handler state changes
+    match chan_end_on_b.ordering {
+        Order::Unordered => {
+            let receipt_path_on_b = ReceiptPath {
+                port_id: packet.port_id_on_b.clone(),
+                channel_id: packet.chan_id_on_b.clone(),
+                sequence: packet.seq_on_a,
+            };
+
+            ctx_b.store_packet_receipt(&receipt_path_on_b, Receipt::Ok)?;
+        }
+        Order::Ordered => {
+            let seq_recv_path_on_b = SeqRecvPath::new(&packet.port_id_on_b, &packet.chan_id_on_b);
+            let next_seq_recv = ctx_b.get_next_sequence_recv(&seq_recv_path_on_b)?;
+            ctx_b.store_next_sequence_recv(&seq_recv_path_on_b, next_seq_recv.increment())?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+pub fn commit_packet_acknowledgment<ExecCtx>(
+    ctx_b: &mut ExecCtx,
+    packet: &Packet,
+    acknowledgement: &Acknowledgement,
+) -> Result<(), ChannelError>
+where
+    ExecCtx: ExecutionContext,
+{
+    let ack_path_on_b = AckPath::new(&packet.port_id_on_b, &packet.chan_id_on_b, packet.seq_on_a);
+
+    // `writeAcknowledgement` handler state changes
+    ctx_b.store_packet_acknowledgement(&ack_path_on_b, compute_ack_commitment(acknowledgement))?;
+
+    Ok(())
+}
+
+pub fn emit_packet_acknowledgement_event<ExecCtx>(
+    ctx_b: &mut ExecCtx,
+    packet: Packet,
+    acknowledgement: Acknowledgement,
+) -> Result<(), ChannelError>
+where
+    ExecCtx: ExecutionContext,
+{
+    let chan_end_path_on_b = ChannelEndPath::new(&packet.port_id_on_b, &packet.chan_id_on_b);
+    let chan_end_on_b = ctx_b.channel_end(&chan_end_path_on_b)?;
+    let conn_id_on_b = &chan_end_on_b.connection_hops()[0];
+
+    ctx_b.log_message("success: packet write acknowledgement".to_string())?;
+
+    let event = IbcEvent::WriteAcknowledgement(WriteAcknowledgement::new(
+        packet,
+        acknowledgement,
+        conn_id_on_b.clone(),
+    ));
+    ctx_b.emit_ibc_event(IbcEvent::Message(MessageEvent::Channel))?;
+    ctx_b.emit_ibc_event(event)?;
+
+    Ok(())
+}
 
 pub fn acknowledgement_packet_validate<ValCtx>(
     ctx_a: &ValCtx,

--- a/ibc-core/ics26-routing/src/module.rs
+++ b/ibc-core/ics26-routing/src/module.rs
@@ -123,11 +123,33 @@ pub trait Module: Debug {
     // if any error occurs, than an "error acknowledgement"
     // must be returned
 
+    /// ICS-26 `onRecvPacket` callback implementation.
+    ///
+    /// # Note on optional acknowledgements
+    ///
+    /// Acknowledgements can be committed asynchronously, hence
+    /// the `Option` type. In general, acknowledgements should
+    /// be committed to storage, accompanied by an ack event,
+    /// as soon as a packet is received. This will be done
+    /// automatically as long as `Some(ack)` is returned from
+    /// this callback. However, in some cases, such as when
+    /// implementing a multiple hop packet delivery protocol,
+    /// a packet can only be acknowledged after it has reached
+    /// the last hop.
+    ///
+    /// ## Committing a packet asynchronously
+    ///
+    /// Event emission and state updates for packet acknowledgements
+    /// can be performed asynchronously using [`emit_packet_acknowledgement_event`]
+    /// and [`commit_packet_acknowledgment`], respectively.
+    ///
+    /// [`commit_packet_acknowledgment`]: ../../channel/handler/fn.commit_packet_acknowledgment.html
+    /// [`emit_packet_acknowledgement_event`]: ../../channel/handler/fn.emit_packet_acknowledgement_event.html
     fn on_recv_packet_execute(
         &mut self,
         packet: &Packet,
         relayer: &Signer,
-    ) -> (ModuleExtras, Acknowledgement);
+    ) -> (ModuleExtras, Option<Acknowledgement>);
 
     fn on_acknowledgement_packet_validate(
         &self,

--- a/ibc-testkit/src/testapp/ibc/applications/nft_transfer/module.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/nft_transfer/module.rs
@@ -64,10 +64,10 @@ impl Module for DummyNftTransferModule {
         &mut self,
         _packet: &Packet,
         _relayer: &Signer,
-    ) -> (ModuleExtras, Acknowledgement) {
+    ) -> (ModuleExtras, Option<Acknowledgement>) {
         (
             ModuleExtras::empty(),
-            Acknowledgement::try_from(vec![1u8]).expect("Never fails"),
+            Some(Acknowledgement::try_from(vec![1u8]).expect("Never fails")),
         )
     }
 

--- a/ibc-testkit/src/testapp/ibc/applications/transfer/module.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/transfer/module.rs
@@ -64,10 +64,10 @@ impl Module for DummyTransferModule {
         &mut self,
         _packet: &Packet,
         _relayer: &Signer,
-    ) -> (ModuleExtras, Acknowledgement) {
+    ) -> (ModuleExtras, Option<Acknowledgement>) {
         (
             ModuleExtras::empty(),
-            Acknowledgement::try_from(vec![1u8]).expect("Never fails"),
+            Some(Acknowledgement::try_from(vec![1u8]).expect("Never fails")),
         )
     }
 

--- a/ibc-testkit/src/testapp/ibc/core/types.rs
+++ b/ibc-testkit/src/testapp/ibc/core/types.rs
@@ -279,12 +279,12 @@ mod tests {
                 &mut self,
                 _packet: &Packet,
                 _relayer: &Signer,
-            ) -> (ModuleExtras, Acknowledgement) {
+            ) -> (ModuleExtras, Option<Acknowledgement>) {
                 self.counter += 1;
 
                 (
                     ModuleExtras::empty(),
-                    Acknowledgement::try_from(vec![1u8]).expect("Never fails"),
+                    Some(Acknowledgement::try_from(vec![1u8]).expect("Never fails")),
                 )
             }
 
@@ -379,10 +379,10 @@ mod tests {
                 &mut self,
                 _packet: &Packet,
                 _relayer: &Signer,
-            ) -> (ModuleExtras, Acknowledgement) {
+            ) -> (ModuleExtras, Option<Acknowledgement>) {
                 (
                     ModuleExtras::empty(),
-                    Acknowledgement::try_from(vec![1u8]).expect("Never fails"),
+                    Some(Acknowledgement::try_from(vec![1u8]).expect("Never fails")),
                 )
             }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Potentially related to #361

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR introduces the ability to acknowledge IBC packets asynchronously, [bringing `ibc-rs`'s API closer to `ibc-go`](https://pkg.go.dev/github.com/cosmos/ibc-go/v8/modules/core/05-port/types#IBCModule).

These changes were required in order to implement the [packet forward middleware](https://github.com/heliaxdev/ibc-middleware/tree/pfm/v0.9.0/crates/packet-forward) on top of `ibc-rs`.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests (tested through https://github.com/anoma/namada/pull/4082)
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
