### PR TITLE
Signer parsing from context

### DIFF
--- a/.changelog/unreleased/breaking-changes/1393-signer-parsing-from-ctx.md
+++ b/.changelog/unreleased/breaking-changes/1393-signer-parsing-from-ctx.md
@@ -1,0 +1,3 @@
+- [ibc-apps] Replace the `TryFrom<Signer>` bound on `AccountId` with new
+  context methods, with the aim of contextually parsing `Signer` instances.
+  ([\#1393](https://github.com/cosmos/ibc-rs/pull/1393))

--- a/ibc-apps/ics20-transfer/src/context.rs
+++ b/ibc-apps/ics20-transfer/src/context.rs
@@ -8,7 +8,14 @@ use ibc_core::primitives::Signer;
 
 /// Methods required in token transfer validation, to be implemented by the host
 pub trait TokenTransferValidationContext {
-    type AccountId: TryFrom<Signer>;
+    /// Native chain account id.
+    type AccountId;
+
+    /// Attempt to convert a [`Signer`] to a native chain sender account.
+    fn sender_account(&self, sender: &Signer) -> Result<Self::AccountId, HostError>;
+
+    /// Attempt to convert a [`Signer`] to a native chain receiver account.
+    fn receiver_account(&self, receiver: &Signer) -> Result<Self::AccountId, HostError>;
 
     /// get_port returns the portID for the transfer module.
     fn get_port(&self) -> Result<PortId, HostError>;

--- a/ibc-apps/ics20-transfer/src/handler/mod.rs
+++ b/ibc-apps/ics20-transfer/src/handler/mod.rs
@@ -17,11 +17,7 @@ pub fn refund_packet_token_execute(
     packet: &Packet,
     data: &PacketData,
 ) -> Result<(), TokenTransferError> {
-    let sender = data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| TokenTransferError::FailedToParseAccount)?;
+    let sender = ctx_a.sender_account(&data.sender)?;
 
     if is_sender_chain_source(
         packet.port_id_on_a.clone(),
@@ -48,11 +44,7 @@ pub fn refund_packet_token_validate(
     packet: &Packet,
     data: &PacketData,
 ) -> Result<(), TokenTransferError> {
-    let sender = data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| TokenTransferError::FailedToParseAccount)?;
+    let sender = ctx_a.sender_account(&data.sender)?;
 
     if is_sender_chain_source(
         packet.port_id_on_a.clone(),

--- a/ibc-apps/ics20-transfer/src/handler/on_recv_packet.rs
+++ b/ibc-apps/ics20-transfer/src/handler/on_recv_packet.rs
@@ -23,12 +23,9 @@ pub fn process_recv_packet_execute<Ctx: TokenTransferExecutionContext>(
         .can_receive_coins()
         .map_err(|err| (ModuleExtras::empty(), err.into()))?;
 
-    let receiver_account = data.receiver.clone().try_into().map_err(|_| {
-        (
-            ModuleExtras::empty(),
-            TokenTransferError::FailedToParseAccount,
-        )
-    })?;
+    let receiver_account = ctx_b
+        .receiver_account(&data.receiver)
+        .map_err(|err| (ModuleExtras::empty(), err.into()))?;
 
     let extras = if is_receiver_chain_source(
         packet.port_id_on_a.clone(),

--- a/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
+++ b/ibc-apps/ics20-transfer/src/handler/send_transfer.rs
@@ -56,12 +56,7 @@ where
 
     let token = &msg.packet_data.token;
 
-    let sender: TokenCtx::AccountId = msg
-        .packet_data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| TokenTransferError::FailedToParseAccount)?;
+    let sender = token_ctx_a.sender_account(&msg.packet_data.sender)?;
 
     if is_sender_chain_source(
         msg.port_id_on_a.clone(),
@@ -129,12 +124,7 @@ where
 
     let token = &msg.packet_data.token;
 
-    let sender = msg
-        .packet_data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| TokenTransferError::FailedToParseAccount)?;
+    let sender = token_ctx_a.sender_account(&msg.packet_data.sender)?;
 
     if is_sender_chain_source(
         msg.port_id_on_a.clone(),

--- a/ibc-apps/ics20-transfer/types/src/error.rs
+++ b/ibc-apps/ics20-transfer/types/src/error.rs
@@ -30,8 +30,6 @@ pub enum TokenTransferError {
     FailedToDeserializePacketData,
     /// failed to deserialize acknowledgement
     FailedToDeserializeAck,
-    /// failed to parse account
-    FailedToParseAccount,
 }
 
 #[cfg(feature = "std")]

--- a/ibc-apps/ics721-nft-transfer/src/context.rs
+++ b/ibc-apps/ics721-nft-transfer/src/context.rs
@@ -36,9 +36,16 @@ pub trait NftClassContext {
 
 /// Read-only methods required in NFT transfer validation context.
 pub trait NftTransferValidationContext {
-    type AccountId: TryFrom<Signer> + PartialEq;
+    /// Native chain account id.
+    type AccountId: PartialEq;
     type Nft: NftContext;
     type NftClass: NftClassContext;
+
+    /// Attempt to convert a [`Signer`] to a native chain sender account.
+    fn sender_account(&self, sender: &Signer) -> Result<Self::AccountId, HostError>;
+
+    /// Attempt to convert a [`Signer`] to a native chain receiver account.
+    fn receiver_account(&self, receiver: &Signer) -> Result<Self::AccountId, HostError>;
 
     /// get_port returns the portID for the transfer module.
     fn get_port(&self) -> Result<PortId, HostError>;

--- a/ibc-apps/ics721-nft-transfer/src/handler/mod.rs
+++ b/ibc-apps/ics721-nft-transfer/src/handler/mod.rs
@@ -17,11 +17,7 @@ pub fn refund_packet_nft_execute(
     packet: &Packet,
     data: &PacketData,
 ) -> Result<(), NftTransferError> {
-    let sender = data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| NftTransferError::FailedToParseAccount)?;
+    let sender = ctx_a.sender_account(&data.sender)?;
 
     if is_sender_chain_source(
         packet.port_id_on_a.clone(),
@@ -58,11 +54,7 @@ pub fn refund_packet_nft_validate(
     packet: &Packet,
     data: &PacketData,
 ) -> Result<(), NftTransferError> {
-    let sender = data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| NftTransferError::FailedToParseAccount)?;
+    let sender = ctx_a.sender_account(&data.sender)?;
 
     if is_sender_chain_source(
         packet.port_id_on_a.clone(),

--- a/ibc-apps/ics721-nft-transfer/src/handler/on_recv_packet.rs
+++ b/ibc-apps/ics721-nft-transfer/src/handler/on_recv_packet.rs
@@ -25,12 +25,9 @@ where
         .can_receive_nft()
         .map_err(|err| (ModuleExtras::empty(), err.into()))?;
 
-    let receiver_account = data.receiver.clone().try_into().map_err(|_| {
-        (
-            ModuleExtras::empty(),
-            NftTransferError::FailedToParseAccount,
-        )
-    })?;
+    let receiver_account = ctx_b
+        .receiver_account(&data.receiver)
+        .map_err(|err| (ModuleExtras::empty(), err.into()))?;
 
     let extras = if is_receiver_chain_source(
         packet.port_id_on_a.clone(),

--- a/ibc-apps/ics721-nft-transfer/src/handler/send_transfer.rs
+++ b/ibc-apps/ics721-nft-transfer/src/handler/send_transfer.rs
@@ -56,12 +56,7 @@ where
     let seq_send_path_on_a = SeqSendPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let sequence = send_packet_ctx_a.get_next_sequence_send(&seq_send_path_on_a)?;
 
-    let sender: TransferCtx::AccountId = msg
-        .packet_data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| NftTransferError::FailedToParseAccount)?;
+    let sender: TransferCtx::AccountId = transfer_ctx.sender_account(&msg.packet_data.sender)?;
 
     let mut packet_data = msg.packet_data;
     let class_id = &packet_data.class_id;
@@ -159,12 +154,7 @@ where
     let seq_send_path_on_a = SeqSendPath::new(&msg.port_id_on_a, &msg.chan_id_on_a);
     let sequence = send_packet_ctx_a.get_next_sequence_send(&seq_send_path_on_a)?;
 
-    let sender = msg
-        .packet_data
-        .sender
-        .clone()
-        .try_into()
-        .map_err(|_| NftTransferError::FailedToParseAccount)?;
+    let sender = transfer_ctx.sender_account(&msg.packet_data.sender)?;
 
     let mut packet_data = msg.packet_data;
     let class_id = &packet_data.class_id;

--- a/ibc-apps/ics721-nft-transfer/types/src/error.rs
+++ b/ibc-apps/ics721-nft-transfer/types/src/error.rs
@@ -33,8 +33,6 @@ pub enum NftTransferError {
     FailedToDeserializePacketData,
     /// failed to deserialize acknowledgement
     FailedToDeserializeAck,
-    /// failed to parse account ID
-    FailedToParseAccount,
     /// invalid channel state: cannot be closed
     InvalidClosedChannel,
 }

--- a/ibc-testkit/src/testapp/ibc/applications/nft_transfer/context.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/nft_transfer/context.rs
@@ -48,6 +48,14 @@ impl NftTransferValidationContext for DummyNftTransferModule {
     type Nft = DummyNft;
     type NftClass = DummyNftClass;
 
+    fn sender_account(&self, sender: &Signer) -> Result<Self::AccountId, HostError> {
+        Ok(sender.clone())
+    }
+
+    fn receiver_account(&self, receiver: &Signer) -> Result<Self::AccountId, HostError> {
+        Ok(receiver.clone())
+    }
+
     fn get_port(&self) -> Result<PortId, HostError> {
         Ok(PortId::transfer())
     }

--- a/ibc-testkit/src/testapp/ibc/applications/transfer/context.rs
+++ b/ibc-testkit/src/testapp/ibc/applications/transfer/context.rs
@@ -9,6 +9,14 @@ use super::types::DummyTransferModule;
 impl TokenTransferValidationContext for DummyTransferModule {
     type AccountId = Signer;
 
+    fn sender_account(&self, sender: &Signer) -> Result<Self::AccountId, HostError> {
+        Ok(sender.clone())
+    }
+
+    fn receiver_account(&self, receiver: &Signer) -> Result<Self::AccountId, HostError> {
+        Ok(receiver.clone())
+    }
+
     fn get_port(&self) -> Result<PortId, HostError> {
         Ok(PortId::transfer())
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Based on #1392

Diff: https://github.com/heliaxdev/cosmos-ibc-rs/compare/heliaxdev:cosmos-ibc-rs:tiago/optional-ack-rebased..heliaxdev:cosmos-ibc-rs:tiago/signer-parsing-from-ctx

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR replaces the `TryFrom<Signer>` bound on `AccountId` with new context methods, with the aim of contextually parsing `Signer` instances.

(Some context: https://github.com/cosmos/ibc-rs/pull/1392#discussion_r1918386120)

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [ ] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [x] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
