### PR TITLE
Update adr-007-light-client-contexts.md

### DIFF
--- a/docs/architecture/adr-007-light-client-contexts.md
+++ b/docs/architecture/adr-007-light-client-contexts.md
@@ -49,7 +49,7 @@ The `ClientStateValidation` and `ClientStateExecution` traits are the most impor
 
 #### `ClientStateValidation`
 
-Say the implementation of a light client needs a `get_resource_Y()` method from the host in `ClientState::verify_client_message()`. The implementor would first define a trait for the host to implement.
+Say the implementation of a light client needs a `get_resource_Y()` method from the host in `ClientState::verify_client_message()`. The implementer would first define a trait for the host to implement.
 
 ```rust
 trait MyClientValidationContext {


### PR DESCRIPTION
## Pull Request Title
fix: typo correction in adr-007-light-client-contexts.md ("implementor" to "implementer")

### Description
This pull request fixes a typo in the `adr-007-light-client-contexts.md` document where "implementor" was used instead of "implementer."

### Changes Made
- Corrected the typo "implementor" to "implementer" in the documentation.

