### PR TITLE
fix: serde support for `Height` without `revision_number`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1262-deserialize-height-without-revision-number.md
+++ b/.changelog/unreleased/bug-fixes/1262-deserialize-height-without-revision-number.md
@@ -1,0 +1,2 @@
+- Serde support for `Height` without `revision_number`
+  ([#1262](https://github.com/informalsystems/ibc-rs/issues/1262)).

--- a/.changelog/unreleased/bug-fixes/1262-deserialize-height-without-revision-number.md
+++ b/.changelog/unreleased/bug-fixes/1262-deserialize-height-without-revision-number.md
@@ -1,2 +1,2 @@
-- Serde support for `Height` without `revision_number`
-  ([#1262](https://github.com/informalsystems/ibc-rs/issues/1262)).
+- [ibc-core-client-types] Serde support for `Height` without `revision_number`
+  ([#1262](https://github.com/cosmos/ibc-rs/issues/1262)).

--- a/ibc-core/ics02-client/types/Cargo.toml
+++ b/ibc-core/ics02-client/types/Cargo.toml
@@ -42,7 +42,8 @@ parity-scale-codec = { workspace = true, optional = true }
 scale-info         = { workspace = true, optional = true }
 
 [dev-dependencies]
-rstest = { workspace = true }
+rstest     = { workspace = true }
+serde-json = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/ibc-core/ics02-client/types/src/height.rs
+++ b/ibc-core/ics02-client/types/src/height.rs
@@ -179,37 +179,42 @@ impl FromStr for Height {
     }
 }
 
-#[test]
-fn test_valid_height() {
-    assert_eq!(
-        "1-1".parse::<Height>().unwrap(),
-        Height {
-            revision_number: 1,
-            revision_height: 1
-        }
-    );
-    assert_eq!(
-        "1-10".parse::<Height>().unwrap(),
-        Height {
-            revision_number: 1,
-            revision_height: 10
-        }
-    );
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_invalid_height() {
-    assert!("0-0".parse::<Height>().is_err());
-    assert!("0-".parse::<Height>().is_err());
-    assert!("-0".parse::<Height>().is_err());
-    assert!("-".parse::<Height>().is_err());
-    assert!("1-1-1".parse::<Height>().is_err());
+    #[test]
+    fn test_valid_height() {
+        assert_eq!(
+            "1-1".parse::<Height>().unwrap(),
+            Height {
+                revision_number: 1,
+                revision_height: 1
+            }
+        );
+        assert_eq!(
+            "1-10".parse::<Height>().unwrap(),
+            Height {
+                revision_number: 1,
+                revision_height: 10
+            }
+        );
+    }
 
-    let decoding_err = "1".parse::<Height>().unwrap_err();
-    let decoding_err = decoding_err.to_string();
-    assert!(decoding_err.contains("height `1` not properly formatted"));
+    #[test]
+    fn test_invalid_height() {
+        assert!("0-0".parse::<Height>().is_err());
+        assert!("0-".parse::<Height>().is_err());
+        assert!("-0".parse::<Height>().is_err());
+        assert!("-".parse::<Height>().is_err());
+        assert!("1-1-1".parse::<Height>().is_err());
 
-    let decoding_err = "".parse::<Height>().unwrap_err();
-    let decoding_err = decoding_err.to_string();
-    assert!(decoding_err.contains("height `` not properly formatted"));
+        let decoding_err = "1".parse::<Height>().unwrap_err();
+        let decoding_err = decoding_err.to_string();
+        assert!(decoding_err.contains("height `1` not properly formatted"));
+
+        let decoding_err = "".parse::<Height>().unwrap_err();
+        let decoding_err = decoding_err.to_string();
+        assert!(decoding_err.contains("height `` not properly formatted"));
+    }
 }

--- a/ibc-core/ics02-client/types/src/height.rs
+++ b/ibc-core/ics02-client/types/src/height.rs
@@ -31,6 +31,7 @@ use crate::error::ClientError;
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Height {
     /// Previously known as "epoch"
+    #[serde(default)]
     revision_number: u64,
 
     /// The height of a block

--- a/ibc-core/ics02-client/types/src/height.rs
+++ b/ibc-core/ics02-client/types/src/height.rs
@@ -31,7 +31,7 @@ use crate::error::ClientError;
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Height {
     /// Previously known as "epoch"
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     revision_number: u64,
 
     /// The height of a block

--- a/ibc-core/ics02-client/types/src/height.rs
+++ b/ibc-core/ics02-client/types/src/height.rs
@@ -218,4 +218,14 @@ mod tests {
         let decoding_err = decoding_err.to_string();
         assert!(decoding_err.contains("height `` not properly formatted"));
     }
+
+    #[test]
+    fn test_empty_rev_number_deserialization() {
+        // #1262: ibc-go uses `omitempty` in JSON serialization
+        let json_str = r#"{"revision_height": 10}"#;
+        let actual: Height = serde_json::from_str(json_str).unwrap();
+        let expected = Height::new(0, 10).unwrap();
+
+        assert_eq!(actual, expected);
+    }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1262

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Makes `revision_number` field optional for `Height` struct when deserializing via serde -- specifically for JSON. 

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [x] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
