### PR TITLE
docs: fix spelling errors in documentation

### DIFF
--- a/ibc-clients/README.md
+++ b/ibc-clients/README.md
@@ -9,7 +9,7 @@ specs of external blockchains, which are required to properly verify proofs
 against the client's consensus state.
 
 The structure within the `ibc-clients` crate is designed to provide flexibility
-for external users. It allows you to utilize the own `ibc-clients` crate or
+for external users. It allows you to utilize the `ibc-clients` crate or
 selectively import specific libraries, whether you need a certain IBC client
 implementation (e.g. `ibc-client-tendermint` crate) or only its associated data
 structures (e.g. `ibc-core-tendermint-types`). This versatility empowers hosts,

--- a/ibc-core/README.md
+++ b/ibc-core/README.md
@@ -88,7 +88,7 @@ object-capability reference or source authentication for modules.
 > module in the host state machine, which cannot be altered by the module or
 > faked by another module.
 
-**This crate currently requires neither of the host system**. Since modules are
+**This crate currently requires neither of these from the host system**. Since modules are
 assumed to be trusted, there is no need for this object capability system that
 protects resources for potentially malicious modules.
 

--- a/ibc-data-types/README.md
+++ b/ibc-data-types/README.md
@@ -4,7 +4,7 @@ This crate serves as a central hub for re-exporting the implemented
 Inter-Blockchain Communication (IBC) data structures. It simplifies the
 integration of various IBC domain types into your project. IBC is a distributed
 protocol facilitating communication between independent sovereign blockchains
-and The IBC data structures within this crate abstract various IBC
+and the IBC data structures within this crate abstract various IBC
 specifications, offering a convenient means to encode and decode IBC messages to
 and from proto types exposed by
 [`ibc-proto`](https://github.com/cosmos/ibc-proto-rs) crate. Additionally, it

--- a/ibc-query/README.md
+++ b/ibc-query/README.md
@@ -10,9 +10,9 @@ connection, and channel layers of a chain enabled with `ibc-rs`.
 ## Features
 
 - Provides essential utility request/response domain types and their conversions
-to the proto types for efficient integration.
+  to the proto types for efficient integration.
 - Provides convenient query objects with pre-implemented gRPC query services.
-- Offers convenient objects on which query service has been implemented and
+- Offers convenient objects on which query service has been implemented.
 - Includes convenient `QueryContext` and `ProvableContext` traits that extend
   the capabilities of an implemented IBC module, enabling the retrieval of state
   from the chain.


### PR DESCRIPTION
# Spelling Corrections in Documentation

Fixed four spelling errors in documentation files:

## Files Modified

1. **ibc-data-types/README.md** (line 7)
   - Before: "and The IBC data structures"
   - After: "and the IBC data structures"
   - Reason: incorrect capital letter mid-sentence

2. **ibc-query/README.md** (line 15)
   - Before: "Offers convenient objects on which query service has been implemented and" (incomplete sentence)
   - After: "Offers convenient objects on which query service has been implemented."
   - Reason: sentence cut off

3. **ibc-clients/README.md** (line 12)
   - Before: "It allows you to utilize the own `ibc-clients` crate"
   - After: "It allows you to utilize the `ibc-clients` crate"
   - Reason: "the own" is incorrect

4. **ibc-core/README.md** (line 91)
   - Before: "This crate currently requires neither of the host system"
   - After: "This crate currently requires neither of these from the host system"
   - Reason: incomplete sentence and missing subject agreement