### PR TITLE
 refactor: make rust-crypto optional in ibc-client-tendermint

### DIFF
--- a/.changelog/unreleased/improvements/1433-optional-rust-crypto-in-ibc-client-tendermint.md
+++ b/.changelog/unreleased/improvements/1433-optional-rust-crypto-in-ibc-client-tendermint.md
@@ -1,0 +1,2 @@
+- [ibc-client-tendermint] Make `rust-crypto` an optional default-enabled feature
+  ([#1433](https://github.com/cosmos/ibc-rs/pull/1433))

--- a/ibc-clients/Cargo.toml
+++ b/ibc-clients/Cargo.toml
@@ -22,7 +22,8 @@ ibc-client-tendermint = { workspace = true }
 ibc-client-wasm-types = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = [ "std", "rust-crypto" ]
+rust-crypto = [ "ibc-client-tendermint/rust-crypto" ]
 std = [
   "ibc-client-tendermint/std",
   "ibc-client-wasm-types/std",

--- a/ibc-clients/ics07-tendermint/Cargo.toml
+++ b/ibc-clients/ics07-tendermint/Cargo.toml
@@ -32,10 +32,11 @@ ibc-primitives              = { workspace = true }
 
 # cosmos dependencies
 tendermint                       = { workspace = true }
-tendermint-light-client-verifier = { workspace = true, features = [ "rust-crypto" ] }
+tendermint-light-client-verifier = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = [ "std", "rust-crypto" ]
+rust-crypto = [ "tendermint-light-client-verifier/rust-crypto" ]
 std = [
   "serde/std",
   "ibc-client-tendermint-types/std",

--- a/ibc-clients/ics07-tendermint/src/client_state/execution.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state/execution.rs
@@ -12,7 +12,6 @@ use ibc_primitives::{IntoHostTime, TimestampError};
 
 use super::ClientState;
 
-#[cfg(feature = "rust-crypto")]
 impl<E> ClientStateExecution<E> for ClientState
 where
     E: ExtClientExecutionContext,

--- a/ibc-clients/ics07-tendermint/src/client_state/execution.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state/execution.rs
@@ -12,6 +12,7 @@ use ibc_primitives::{IntoHostTime, TimestampError};
 
 use super::ClientState;
 
+#[cfg(feature = "rust-crypto")]
 impl<E> ClientStateExecution<E> for ClientState
 where
     E: ExtClientExecutionContext,

--- a/ibc-clients/ics07-tendermint/src/client_state/validation.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state/validation.rs
@@ -2,7 +2,6 @@ use ibc_client_tendermint_types::{
     ClientState as ClientStateType, ConsensusState as ConsensusStateType, Header as TmHeader,
     Misbehaviour as TmMisbehaviour, TENDERMINT_HEADER_TYPE_URL, TENDERMINT_MISBEHAVIOUR_TYPE_URL,
 };
-#[cfg(feature = "rust-crypto")]
 use ibc_core_client::context::client_state::ClientStateValidation;
 use ibc_core_client::context::{Convertible, ExtClientValidationContext};
 use ibc_core_client::types::error::ClientError;
@@ -15,14 +14,12 @@ use tendermint::crypto::Sha256 as Sha256Trait;
 use tendermint::merkle::MerkleHash;
 use tendermint_light_client_verifier::Verifier;
 
-#[cfg(feature = "rust-crypto")]
-use super::ClientState;
 use super::{
-    check_for_misbehaviour_on_misbehavior, check_for_misbehaviour_on_update, consensus_state_status,
+    check_for_misbehaviour_on_misbehavior, check_for_misbehaviour_on_update,
+    consensus_state_status, ClientState,
 };
 use crate::client_state::{verify_header, verify_misbehaviour};
 
-#[cfg(feature = "rust-crypto")]
 impl<V> ClientStateValidation<V> for ClientState
 where
     V: ExtClientValidationContext,
@@ -51,20 +48,30 @@ where
     /// parameter.
     fn verify_client_message(
         &self,
-        ctx: &V,
-        client_id: &ClientId,
-        client_message: Any,
+        _ctx: &V,
+        _client_id: &ClientId,
+        _client_message: Any,
     ) -> Result<(), ClientError> {
-        use tendermint::crypto::default::Sha256;
-        use tendermint_light_client_verifier::ProdVerifier;
+        #[cfg(feature = "rust-crypto")]
+        {
+            use tendermint::crypto::default::Sha256;
+            use tendermint_light_client_verifier::ProdVerifier;
 
-        verify_client_message::<V, Sha256>(
-            self.inner(),
-            ctx,
-            client_id,
-            client_message,
-            &ProdVerifier::default(),
-        )
+            verify_client_message::<V, Sha256>(
+                self.inner(),
+                _ctx,
+                _client_id,
+                _client_message,
+                &ProdVerifier::default(),
+            )
+        }
+        #[cfg(not(feature = "rust-crypto"))]
+        {
+            unimplemented!(
+                "verify_client_message requires the `rust-crypto` feature; \
+                 use a custom verifier via the standalone verify_client_message function instead"
+            )
+        }
     }
 
     fn check_for_misbehaviour(

--- a/ibc-clients/ics07-tendermint/src/client_state/validation.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state/validation.rs
@@ -2,6 +2,7 @@ use ibc_client_tendermint_types::{
     ClientState as ClientStateType, ConsensusState as ConsensusStateType, Header as TmHeader,
     Misbehaviour as TmMisbehaviour, TENDERMINT_HEADER_TYPE_URL, TENDERMINT_MISBEHAVIOUR_TYPE_URL,
 };
+#[cfg(feature = "rust-crypto")]
 use ibc_core_client::context::client_state::ClientStateValidation;
 use ibc_core_client::context::{Convertible, ExtClientValidationContext};
 use ibc_core_client::types::error::ClientError;
@@ -10,17 +11,18 @@ use ibc_core_host::types::identifiers::ClientId;
 use ibc_core_host::types::path::ClientConsensusStatePath;
 use ibc_primitives::prelude::*;
 use ibc_primitives::proto::Any;
-use tendermint::crypto::default::Sha256;
 use tendermint::crypto::Sha256 as Sha256Trait;
 use tendermint::merkle::MerkleHash;
-use tendermint_light_client_verifier::{ProdVerifier, Verifier};
+use tendermint_light_client_verifier::Verifier;
 
+#[cfg(feature = "rust-crypto")]
+use super::ClientState;
 use super::{
-    check_for_misbehaviour_on_misbehavior, check_for_misbehaviour_on_update,
-    consensus_state_status, ClientState,
+    check_for_misbehaviour_on_misbehavior, check_for_misbehaviour_on_update, consensus_state_status,
 };
 use crate::client_state::{verify_header, verify_misbehaviour};
 
+#[cfg(feature = "rust-crypto")]
 impl<V> ClientStateValidation<V> for ClientState
 where
     V: ExtClientValidationContext,
@@ -30,12 +32,13 @@ where
     /// The default verification logic exposed by ibc-rs simply delegates to a
     /// standalone `verify_client_message` function. This is to make it as
     /// simple as possible for those who merely need the default
-    /// [`ProdVerifier`] behaviour, as well as those who require custom
-    /// verification logic.
+    /// [`ProdVerifier`](tendermint_light_client_verifier::ProdVerifier)
+    /// behaviour, as well as those who require custom verification logic.
     ///
-    /// In a situation where the Tendermint [`ProdVerifier`] doesn't provide the
-    /// desired outcome, users should define a custom verifier struct and then
-    /// implement the [`Verifier`] trait for it.
+    /// In a situation where the Tendermint
+    /// [`ProdVerifier`](tendermint_light_client_verifier::ProdVerifier)
+    /// doesn't provide the desired outcome, users should define a custom
+    /// verifier struct and then implement the [`Verifier`] trait for it.
     ///
     /// In order to wire up the custom verifier, create a newtype `ClientState`
     /// wrapper similar to [`ClientState`] and implement all client state traits
@@ -52,6 +55,9 @@ where
         client_id: &ClientId,
         client_message: Any,
     ) -> Result<(), ClientError> {
+        use tendermint::crypto::default::Sha256;
+        use tendermint_light_client_verifier::ProdVerifier;
+
         verify_client_message::<V, Sha256>(
             self.inner(),
             ctx,

--- a/ibc-clients/ics07-tendermint/src/client_state/validation.rs
+++ b/ibc-clients/ics07-tendermint/src/client_state/validation.rs
@@ -29,13 +29,12 @@ where
     /// The default verification logic exposed by ibc-rs simply delegates to a
     /// standalone `verify_client_message` function. This is to make it as
     /// simple as possible for those who merely need the default
-    /// [`ProdVerifier`](tendermint_light_client_verifier::ProdVerifier)
-    /// behaviour, as well as those who require custom verification logic.
+    /// [`ProdVerifier`] behaviour, as well as those who require custom
+    /// verification logic.
     ///
-    /// In a situation where the Tendermint
-    /// [`ProdVerifier`](tendermint_light_client_verifier::ProdVerifier)
-    /// doesn't provide the desired outcome, users should define a custom
-    /// verifier struct and then implement the [`Verifier`] trait for it.
+    /// In a situation where the Tendermint [`ProdVerifier`] doesn't provide the
+    /// desired outcome, users should define a custom verifier struct and then
+    /// implement the [`Verifier`] trait for it.
     ///
     /// In order to wire up the custom verifier, create a newtype `ClientState`
     /// wrapper similar to [`ClientState`] and implement all client state traits

--- a/ibc-clients/ics07-tendermint/types/Cargo.toml
+++ b/ibc-clients/ics07-tendermint/types/Cargo.toml
@@ -33,7 +33,7 @@ ibc-proto                 = { workspace = true }
 
 # cosmos dependencies
 tendermint                       = { workspace = true }
-tendermint-light-client-verifier = { workspace = true, features = [ "rust-crypto" ] }
+tendermint-light-client-verifier = { workspace = true }
 tendermint-proto                 = { workspace = true }
 
 # parity dependencies

--- a/ibc-testkit/Cargo.toml
+++ b/ibc-testkit/Cargo.toml
@@ -44,7 +44,8 @@ hex    = { workspace = true }
 rstest = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = [ "std", "rust-crypto" ]
+rust-crypto = [ "ibc/rust-crypto" ]
 std = [
   "hex/std",
   "serde/std",

--- a/ibc-testkit/src/relayer/integration.rs
+++ b/ibc-testkit/src/relayer/integration.rs
@@ -163,6 +163,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(feature = "rust-crypto")]
 mod tests {
     use super::*;
     use crate::hosts::{MockHost, TendermintHost};

--- a/ibc/Cargo.toml
+++ b/ibc/Cargo.toml
@@ -29,7 +29,8 @@ ibc-derive           = { workspace = true }
 ibc-primitives       = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = [ "std", "rust-crypto" ]
+rust-crypto = [ "ibc-clients/rust-crypto" ]
 std = [
   "ibc-apps/std",
   "ibc-clients/std",

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -41,7 +41,8 @@ test-log       = { version = "0.2.16", features = [ "trace" ] }
 tendermint-rpc = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = [ "std", "rust-crypto" ]
+rust-crypto = [ "ibc/rust-crypto" ]
 std = [
   "serde/std",
   "serde-json/std",

--- a/tests-integration/tests/core/ics02_client/mod.rs
+++ b/tests-integration/tests/core/ics02_client/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "serde")]
 pub mod create_client;
 pub mod recover_client;
+#[cfg(feature = "rust-crypto")]
 pub mod update_client;
 #[cfg(feature = "serde")]
 pub mod upgrade_client;

--- a/tests-integration/tests/core/router.rs
+++ b/tests-integration/tests/core/router.rs
@@ -42,6 +42,7 @@ use ibc_testkit::testapp::ibc::clients::mock::client_state::MockClientState;
 use ibc_testkit::testapp::ibc::clients::mock::consensus_state::MockConsensusState;
 use ibc_testkit::testapp::ibc::clients::mock::header::MockHeader;
 use ibc_testkit::testapp::ibc::core::router::MockRouter;
+use std::panic;
 use test_log::test;
 
 #[test]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #1432 

## Description

Make rust-crypto a default-enabled feature instead of unconditionally enabling it on tendermint-light-client-verifier. This allows environments like Solana's SBF VM (4KB stack limit) to opt out of curve25519-dalek-ng (35KB stack frames) when providing their own signature verification.

Existing users are unaffected — rust-crypto remains in default.

______

### PR author checklist:
- [x] Added changelog entry, using [`unclog`](https://github.com/informalsystems/unclog).
- [ ] Added tests.
- [x] Linked to GitHub issue.
- [ ] Updated code comments and documentation (e.g., `docs/`).
- [ ] Tagged *one* reviewer who will be the one responsible for shepherding this PR.

### Reviewer checklist:

- [ ] Reviewed `Files changed` in the GitHub PR explorer.
- [ ] Manually tested (in case integration/unit/mock tests are absent).
